### PR TITLE
Alex/ci init workflow

### DIFF
--- a/.github/workflow/ci.yaml
+++ b/.github/workflow/ci.yaml
@@ -4,18 +4,14 @@ on:
     branches: [ "main"]
   pull_request:
     branches: [ "main" ]
-
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
         go-version: 1.18
-
     - name: Build
       run: make build


### PR DESCRIPTION
I want to setup a github action for CI but nothing is triggering. Some CI systems initially only parse files out of the main/master branch. I want to try checking in this basic _hello world_ action to get triggers to work so I can iterate on a real build