### PR TITLE
Alex/tunnel controller

### DIFF
--- a/helm/ingress-controller/templates/deployment.yaml
+++ b/helm/ingress-controller/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ngrok-ingress-controller-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas:
+  replicas: 2
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/internal/controllers/main.go
+++ b/internal/controllers/main.go
@@ -1,0 +1,42 @@
+package controllers
+
+import (
+	"context"
+	"strings"
+
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getEdgeName(namespacedName string) string {
+	return strings.Replace(namespacedName, "/", "-", -1)
+}
+
+// Checks to see if the ingress controller should do anything about
+// the ingress object it saw depending on how ingress classes are configured
+// Returns a boolean indicating if the ingress object should be processed
+func matchesIngressClass(ctx context.Context, t client.Client) (bool, error) {
+	ingressClasses := &netv1.IngressClassList{}
+	if err := t.List(ctx, ingressClasses); err != nil {
+		return false, err
+	}
+
+	// TODO: Finish filtering on ingress class (verify the behavior based on how other controllers do it)
+	// https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
+	return true, nil
+}
+
+// Lookup the ingress object and provide any filtering or error handling logic to filter things out
+func getIngress(ctx context.Context, t client.Client, namespacedName types.NamespacedName) (*netv1.Ingress, error) {
+	if matches, err := matchesIngressClass(ctx, t); !matches || err != nil {
+		return nil, err
+	}
+
+	ingress := &netv1.Ingress{}
+	if err := t.Get(ctx, namespacedName, ingress); err != nil {
+		return nil, err
+	}
+
+	return ingress, nil
+}

--- a/internal/controllers/tunnel_controller.go
+++ b/internal/controllers/tunnel_controller.go
@@ -1,0 +1,87 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// This implements the Reconciler for the controller-runtime
+// https://pkg.go.dev/sigs.k8s.io/controller-runtime#section-readme
+type TunnelReconciler struct {
+	client.Client
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
+
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="networking.k8s.io",resources=ingressclasses,verbs=get;list;watch
+
+// This reconcile function is called by the controller-runtime manager.
+// It is invoked whenever there is an event that occurs for a resource
+// being watched (in our case, ingress objects). If you tail the controller
+// logs and delete, update, edit ingress objects, you see the events come in.
+func (t *TunnelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := t.Log.WithValues("ingress", req.NamespacedName)
+	edgeName := strings.Replace(req.NamespacedName.String(), "/", "-", -1)
+	ingress, err := getIngress(ctx, t.Client, req.NamespacedName)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	log.Info(fmt.Sprintf("We did find the ingress %+v \n", ingress))
+	log.Info(fmt.Sprintf("TODO: Create the api resources needed for this %s", edgeName))
+	return ctrl.Result{}, nil
+}
+
+// Create a new Controller that watches Ingress objects.
+// Add it to our manager.
+func (t *TunnelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	c, err := NewTunnelControllerNew("tunnel-controller", mgr, t)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Watch(&source.Kind{Type: &netv1.Ingress{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+
+	mgr.Add(c)
+	return nil
+}
+
+// Small wrapper struct of the core controller.Controller so we get most of its functionality
+type TunnelController struct {
+	controller.Controller
+}
+
+// Creates an un-managed controller that can be embeded in our controller struct so we can override functions.
+func NewTunnelControllerNew(name string, mgr manager.Manager, tr *TunnelReconciler) (controller.Controller, error) {
+	c, err := controller.NewUnmanaged(name, mgr, controller.Options{
+		Reconciler: tr,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &TunnelController{
+		Controller: c,
+	}, nil
+}
+
+// This controller should not use leader election. It should run on all controllers by default to control the agents on each.
+func (t *TunnelController) NeedLeaderElection() bool {
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -92,6 +92,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := (&controllers.TunnelReconciler{
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("tunnel"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("tunnel-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "tunnel")
+		os.Exit(1)
+	}
+
 	// Can query for config maps like this.
 	// For controller level configs, this may be the recommended way though https://book.kubebuilder.io/reference/markers.html
 	// We can't use this though to write config maps, and the mgr.GetClient() doesn't work because the cache isn't initialized


### PR DESCRIPTION
sets up a new tunnel controller that runs in all pods, even if they aren't the leader, and will be used to manage the ngrok agent.

The main change was to ditch the `NewControllerManagedBy` builder helper and just construct a controller and `Add` it to the manager manually. It runs even if its not the leader due to implementing the [LeaderElectionRunnable](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.3/pkg/manager#LeaderElectionRunnable) interface

```
k get pods
NAME                                                           READY   STATUS    RESTARTS   AGE
nginx-7848d4b86f-559w4                                         1/1     Running   2          7d22h
nginx-2-dff9ff64-whzfc                                         1/1     Running   1          7d6h
nginx-2-dff9ff64-wzc7q                                         1/1     Running   1          7d6h
nginx-7848d4b86f-txc5p                                         1/1     Running   2          7d22h
ngrok-ingress-controller-controller-manager-789cbdf88c-274dk   4/4     Running   0          103s
ngrok-ingress-controller-controller-manager-789cbdf88c-8c6rq   4/4     Running   0          103s
❯ k logs ngrok-ingress-controller-controller-manager-789cbdf88c-274dk | grep 'controller.tunnel\|controller.ingress'
1.6595045098114667e+09	INFO	controller.tunnel-controller	Starting EventSource	{"source": "kind source: *v1.Ingress"}
1.6595045098115823e+09	INFO	controller.tunnel-controller	Starting Controller
1.659504509912167e+09	INFO	controller.tunnel-controller	Starting workers	{"worker count": 1}
1.659504525724781e+09	INFO	controller.ingress	Starting EventSource	{"reconciler group": "networking.k8s.io", "reconciler kind": "Ingress", "source": "kind source: *v1.Ingress"}
1.6595045257247968e+09	INFO	controller.ingress	Starting Controller	{"reconciler group": "networking.k8s.io", "reconciler kind": "Ingress"}
1.6595045257248383e+09	INFO	controller.ingress	Starting workers	{"reconciler group": "networking.k8s.io", "reconciler kind": "Ingress", "worker count": 1}
❯ k logs ngrok-ingress-controller-controller-manager-789cbdf88c-8c6rq | grep 'controller.tunnel\|controller.ingress'
1.659504509804182e+09	INFO	controller.tunnel-controller	Starting EventSource	{"source": "kind source: *v1.Ingress"}
1.659504509804217e+09	INFO	controller.tunnel-controller	Starting Controller
1.6595045099054017e+09	INFO	controller.tunnel-controller	Starting workers	{"worker count": 1}
```