### PR TITLE
Allow for controller to fully create and delete tunnels when ingress …

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      # TODO: Should be scoped to tag pushes eventually
 
 jobs:
   release:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= ngrok-ingress-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ TOOD:
 * Generate a unique name for the controller installation.
 * ci to run make commands and then diff at end to make sure anything generated and checked in is all good
 * perhaps use https://book.kubebuilder.io/component-config-tutorial/tutorial.html instead of a normal config map for agent configs
-* use finalizers to handle deleting resources https://book.kubebuilder.io/reference/using-finalizers.html
 * add ingress class
 * helm lint
 * setup filters https://stuartleeks.com/posts/kubebuilder-event-filters-part-1-delete/
@@ -15,6 +14,11 @@ TOOD:
   * connecting to services in other namespaces
   * flexing what namespace the controller is installed in
 * handle ingress with multiple rules and hosts
+* make the health/ready checks run the `ngrok diagnose` command or ping the container tunnels endpoint to make sure its healthy
+* user can supply their own metadata
+* setup unit tests for go
+* make it work with a free account
+* pass logger around in context or somethign and clean up fmt.println's
 
 ## Setup
 

--- a/examples/hello-world-ingress-2.yaml
+++ b/examples/hello-world-ingress-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minimal-ingress-2
 spec:
   rules:
-  - host: minimal-ingress-2.example.com
+  - host: minimal-ingress-2.ngrok.io
     http:
       paths:
       - path: /

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/ngrok/ngrok-api-go/v4 v4.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -542,6 +542,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
+github.com/ngrok/ngrok-api-go/v4 v4.0.1 h1:VUf6FtDvfT4N7gqyCyilcnI0PMdFNSiCCtxyDSiFOtY=
+github.com/ngrok/ngrok-api-go/v4 v4.0.1/go.mod h1:WobrY7FusLhKZRShryNqFLhX1X33A0BS7I/bPTy8wUM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           name: scripts
           defaultMode: 0755
       containers:
-      - name: manager
+      - name: ngrok-ingress-controller
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -3,7 +3,7 @@
 replicaCount: 2
 
 image:
-  repository: controller
+  repository: ngrok-ingress-controller
   tag: latest
   pullPolicy: Never
 

--- a/internal/controllers/main.go
+++ b/internal/controllers/main.go
@@ -2,24 +2,23 @@ package controllers
 
 import (
 	"context"
-	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"ngrok.io/ngrok-ingress-controller/pkg/ngrokapidriver"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func getEdgeName(namespacedName string) string {
-	return strings.Replace(namespacedName, "/", "-", -1)
-}
+const finalizerName = "ngrok.io/finalizer"
 
 // Checks to see if the ingress controller should do anything about
 // the ingress object it saw depending on how ingress classes are configured
 // Returns a boolean indicating if the ingress object should be processed
-func matchesIngressClass(ctx context.Context, t client.Client) (bool, error) {
+func matchesIngressClass(ctx context.Context, c client.Client) (bool, error) {
 	ingressClasses := &netv1.IngressClassList{}
-	if err := t.List(ctx, ingressClasses); err != nil {
+	if err := c.List(ctx, ingressClasses); err != nil {
 		return false, err
 	}
 
@@ -43,13 +42,17 @@ func matchesIngressClass(ctx context.Context, t client.Client) (bool, error) {
 }
 
 // Lookup the ingress object and provide any filtering or error handling logic to filter things out
-func getIngress(ctx context.Context, t client.Client, namespacedName types.NamespacedName) (*netv1.Ingress, error) {
-	if matches, err := matchesIngressClass(ctx, t); !matches || err != nil {
+func getIngress(ctx context.Context, c client.Client, namespacedName types.NamespacedName) (*netv1.Ingress, error) {
+	if matches, err := matchesIngressClass(ctx, c); !matches || err != nil {
 		return nil, err
 	}
 
 	ingress := &netv1.Ingress{}
-	if err := t.Get(ctx, namespacedName, ingress); err != nil {
+	if err := c.Get(ctx, namespacedName, ingress); err != nil {
+		return nil, err
+	}
+
+	if err := validateIngress(ctx, ingress); err != nil {
 		return nil, err
 	}
 
@@ -57,9 +60,9 @@ func getIngress(ctx context.Context, t client.Client, namespacedName types.Names
 }
 
 // Sets the hostname that the tunnel is accessible on to the ingress object status
-func setStatus(ctx context.Context, ir *IngressReconciler, ingress *netv1.Ingress, hostname string) error {
+func setStatus(ctx context.Context, irec *IngressReconciler, ingress *netv1.Ingress) error {
 	// TODO: Handle multiple rules
-	if ingress.Spec.Rules[0].Host == "" {
+	if ingress.Spec.Rules[0].Host == "" || len(ingress.Status.LoadBalancer.Ingress) != 0 && ingress.Status.LoadBalancer.Ingress[0].Hostname == ingress.Spec.Rules[0].Host {
 		return nil
 	}
 
@@ -69,9 +72,64 @@ func setStatus(ctx context.Context, ir *IngressReconciler, ingress *netv1.Ingres
 		},
 	}
 
-	if err := ir.Status().Update(ctx, ingress); err != nil {
+	if err := irec.Status().Update(ctx, ingress); err != nil {
 		return err
 	}
 
-	return ir.Client.Update(ctx, ingress)
+	// TODO: This update and the update in setFinalizer both trigger new reconcile loops. We should
+	// make these functions just mutate the objects and then we save them once, and/or use
+	// updateFunc predicates to filter out updates to status and finalizers
+	return irec.Client.Update(ctx, ingress)
+}
+
+func setFinalizer(ctx context.Context, irec *IngressReconciler, ingress *netv1.Ingress) error {
+	// if the deletion timestamp is set, its being deleted and we don't need to add the finalizer
+	if !ingress.ObjectMeta.DeletionTimestamp.IsZero() {
+		return nil
+	}
+	// The object is not being deleted, so if it does not have our finalizer,
+	// then lets add the finalizer and update the object. This is equivalent
+	// registering our finalizer.
+	if !controllerutil.ContainsFinalizer(ingress, finalizerName) {
+		controllerutil.AddFinalizer(ingress, finalizerName)
+		if err := irec.Update(ctx, ingress); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Checks the ingress object to make sure its using a the limited set of configuration options
+// that we support. Returns an error if the ingress object is not valid
+func validateIngress(ctx context.Context, ingress *netv1.Ingress) error {
+	// TODO: restrict the spec to a limited set of usecases for now until we support others
+	// Only 1 unique hostname is allowed per object
+	// For now, only 1 rule is even allowed
+	// same namespace as the controller for now
+	// Atleast 1 route must be declared
+	return nil
+}
+
+// Converts a k8s ingress object into an edge with all its configurations and sub-resources
+func IngressToEdge(ctx context.Context, ingress *netv1.Ingress) (*ngrokapidriver.Edge, error) {
+	return &ngrokapidriver.Edge{
+		Id: ingress.Annotations["ngrok.io/edge-id"],
+		// TODO: Support multiple rules
+		Hostport: ingress.Spec.Rules[0].Host + ":443",
+		Labels: map[string]string{
+			"ngrok.io/ingress-name":      ingress.Name,
+			"ngrok.io/ingress-namespace": ingress.Namespace,
+			// TODO: Maybe I don't need this backend name. Need to figure out if edge labels have to all match or if we can match
+			// a subset. In theory the edge can support multiple different backends
+			"ngrok.io/k8s-backend-name": ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name,
+		},
+		Routes: []ngrokapidriver.Route{
+			{
+				Match:     ingress.Spec.Rules[0].HTTP.Paths[0].Path,
+				MatchType: "exact_path", // TODO: support other match types
+				// MatchType: string(*ingress.Spec.Rules[0].HTTP.Paths[0].PathType),
+				// Modules:   []ngrokapidriver.Module{},
+			}},
+	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"ngrok.io/ngrok-ingress-controller/internal/controllers"
+	"ngrok.io/ngrok-ingress-controller/pkg/ngrokapidriver"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -84,11 +85,12 @@ func main() {
 	}
 
 	if err := (&controllers.IngressReconciler{
-		Client:    mgr.GetClient(),
-		Log:       ctrl.Log.WithName("controllers").WithName("ingress"),
-		Scheme:    mgr.GetScheme(),
-		Recorder:  mgr.GetEventRecorderFor("ingress-controller"),
-		Namespace: namespace,
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("ingress"),
+		Scheme:         mgr.GetScheme(),
+		Recorder:       mgr.GetEventRecorderFor("ingress-controller"),
+		Namespace:      namespace,
+		NgrokAPIDriver: ngrokapidriver.NewNgrokApiClient(os.Getenv("NGROK_API_KEY")),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ingress")
 		os.Exit(1)

--- a/pkg/ngrokapidriver/driver.go
+++ b/pkg/ngrokapidriver/driver.go
@@ -1,0 +1,139 @@
+package ngrokapidriver
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ngrok/ngrok-api-go/v4"
+	tgb "github.com/ngrok/ngrok-api-go/v4/backends/tunnel_group"
+	edge "github.com/ngrok/ngrok-api-go/v4/edges/https"
+	edge_route "github.com/ngrok/ngrok-api-go/v4/edges/https_routes"
+	"github.com/ngrok/ngrok-api-go/v4/reserved_domains"
+)
+
+type NgrokAPIDriver interface {
+	FindEdge(ctx context.Context, id string) (*ngrok.HTTPSEdge, error)
+	CreateEdge(ctx context.Context, n Edge) (*ngrok.HTTPSEdge, error)
+	UpdateEdge(ctx context.Context, n Edge) (*ngrok.HTTPSEdge, error)
+	DeleteEdge(ctx context.Context, e Edge) error
+}
+
+type ngrokAPIDriver struct {
+	edges           edge.Client
+	tgbs            tgb.Client
+	routes          edge_route.Client
+	reservedDomains reserved_domains.Client
+	metadata        string
+}
+
+func NewNgrokApiClient(apiKey string) NgrokAPIDriver {
+	config := ngrok.NewClientConfig(apiKey)
+	return &ngrokAPIDriver{
+		edges:           *edge.NewClient(config),
+		tgbs:            *tgb.NewClient(config),
+		routes:          *edge_route.NewClient(config),
+		reservedDomains: *reserved_domains.NewClient(config),
+		metadata:        "\"{\"owned-by\":\"ngrok-ingress-controller\"}\"",
+	}
+}
+
+func (nc ngrokAPIDriver) FindEdge(ctx context.Context, id string) (*ngrok.HTTPSEdge, error) {
+	return nc.edges.Get(ctx, id)
+}
+
+// Goes through the whole edge object and creates resources for
+// * reserved domains
+// * tunnel group backends
+// * edge routes
+// * the edge itself
+func (napi ngrokAPIDriver) CreateEdge(ctx context.Context, edgeSummary Edge) (*ngrok.HTTPSEdge, error) {
+	// TODO: Support multiple rules and multiple hostports
+	domain := strings.Split(edgeSummary.Hostport, ":")[0]
+	_, err := napi.reservedDomains.Create(ctx, &ngrok.ReservedDomainCreate{
+		Name:        domain,
+		Region:      "us", // TODO: Set this from user config
+		Description: "Created by ngrok-ingress-controller",
+		Metadata:    napi.metadata,
+	})
+	// Swallow conflicts, just always try to create it
+	// TODO: Depending on if we choose to clean up reserved domains or not, we may want to surface this conflict to the user
+	if err != nil && !strings.Contains(err.Error(), "ERR_NGROK_413") && !strings.Contains(err.Error(), "ERR_NGROK_7122") {
+		return nil, err
+	}
+
+	var newEdge *ngrok.HTTPSEdge
+
+	// If the edge ID is already set, try to look it up
+	if edgeSummary.Id != "" {
+		newEdge, err = napi.edges.Get(ctx, edgeSummary.Id)
+		if ngrok.IsNotFound(err) {
+			edgeSummary.Id = ""
+		} else if err != nil {
+			return nil, err
+		}
+	} else { // Otherwise Make it
+		newEdge, err = napi.edges.Create(ctx, &ngrok.HTTPSEdgeCreate{
+			Hostports:   &[]string{edgeSummary.Hostport},
+			Description: "Created by ngrok-ingress-controller",
+			Metadata:    napi.metadata,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	backend, err := napi.tgbs.Create(ctx, &ngrok.TunnelGroupBackendCreate{
+		Labels:      edgeSummary.Labels,
+		Description: "Created by ngrok-ingress-controller",
+		Metadata:    napi.metadata,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, route := range edgeSummary.Routes {
+		_, err := napi.routes.Create(ctx, &ngrok.HTTPSEdgeRouteCreate{
+			EdgeID:      newEdge.ID,
+			MatchType:   route.MatchType,
+			Match:       route.Match,
+			Description: "Created by ngrok-ingress-controller",
+			Metadata:    napi.metadata,
+			Backend: &ngrok.EndpointBackendMutate{
+				BackendID: backend.ID,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return newEdge, nil
+}
+
+// TODO: Implement this
+func (nc ngrokAPIDriver) UpdateEdge(ctx context.Context, edgeSummary Edge) (*ngrok.HTTPSEdge, error) {
+	return nil, nil
+}
+
+func (nc ngrokAPIDriver) DeleteEdge(ctx context.Context, e Edge) error {
+	edge, err := nc.edges.Get(ctx, e.Id)
+	if err != nil {
+		return err
+	}
+	for _, route := range edge.Routes {
+		err := nc.routes.Delete(ctx, &ngrok.EdgeRouteItem{EdgeID: e.Id, ID: route.ID})
+		if err != nil {
+			return err
+		}
+	}
+
+	// TODO: I could delete the reserved endpoint, but it might make sense to just leave it reserved. Keeping this for now
+	err = nc.edges.Delete(ctx, e.Id)
+	if err != nil {
+		if !ngrok.IsNotFound(err) {
+			return err
+		} else {
+		}
+	}
+	return nil
+}

--- a/pkg/ngrokapidriver/types.go
+++ b/pkg/ngrokapidriver/types.go
@@ -1,0 +1,20 @@
+package ngrokapidriver
+
+type Edge struct {
+	Id       string
+	Hostport string // TODO: Support an array of hostports when we support multiple rules
+	Labels   map[string]string
+	Routes   []Route
+}
+
+type Route struct {
+	Id string
+	// route to match on, i.e. /example/foo
+	Match string
+	// "exact_path" or "path_prefix"
+	MatchType string
+	Modules   []any
+}
+
+type Module interface {
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,16 +4,16 @@ build:
   local:
     push: false
   artifacts:
-  - image: controller
+  - image: ngrok-ingress-controller
 deploy:
   kubectl:
     manifests:
       - examples/*
   helm:
     releases:
-    - name: controller
+    - name: ngrok-ingress-controller
       artifactOverrides:
-        image: controller
+        image: ngrok-ingress-controller
       chartPath: helm/ingress-controller/
       namespace: ngrok-ingress-controller
       createNamespace: true


### PR DESCRIPTION
…objects are created

There's lots of little clean up and refactoring going on in here, but it gets us to a pretty stable spot to start polishing some of the edge cases. Heres what this does:
* renamed some components to be `ngrok-ingress` instead of just controller or manager
* Setup the ngrok go client
* Ingress controller sets finalizers on ingress objects in order to handle deletions
* Ingress controller also sets the edge id as an annotation on the ingress object so it can just look it up in subsequent requests
* Handles both creating and deleting objects, but not updates for now
* Handles a very basic conversion of k8s resources into ngrok edges. Its severely limited to only 1 rule/path for now
* Tunnel controller handles deletes now


```
./scripts/e2e.sh
I0809 15:29:59.076047 1874718 request.go:665] Waited for 1.191031315s due to client-side throttling, not priority and fairness, request: GET:https://127.0.0.1:6443/apis/discovery.k8s.io/v1?timeout=32s
Warning: Detected changes to resource minimal-ingress-2 which is currently being deleted.
ingress.networking.k8s.io/minimal-ingress-2 configured
I0809 15:30:04.831077 1874810 request.go:665] Waited for 1.003684016s due to client-side throttling, not priority and fairness, request: GET:https://127.0.0.1:6443/apis/policy/v1?timeout=32s
Warning: Detected changes to resource minimal-ingress which is currently being deleted.
ingress.networking.k8s.io/minimal-ingress configured
namespace "ngrok-ingress-controller" deleted
namespace/ngrok-ingress-controller created
secret/ngrok-ingress-controller-credentials created
go run sigs.k8s.io/controller-tools/cmd/controller-gen rbac:roleName=ngrok-ingress-controller-manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=helm/ingress-controller/templates
go run sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
KUBEBUILDER_ASSETS="/home/alexbezek/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64" go test ./... -coverprofile cover.out
?   	ngrok.io/ngrok-ingress-controller	[no test files]
?   	ngrok.io/ngrok-ingress-controller/internal/controllers	[no test files]
?   	ngrok.io/ngrok-ingress-controller/pkg/agentapiclient	[no test files]
?   	ngrok.io/ngrok-ingress-controller/pkg/ngrokapidriver	[no test files]
docker build -t ngrok-ingress-controller:latest .
Sending build context to Docker daemon  174.1kB
Step 1/14 : FROM golang:1.18 as builder
 ---> e3c0472b1b62
Step 2/14 : WORKDIR /workspace
 ---> Using cache
 ---> f83311e09e1a
Step 3/14 : COPY go.mod go.mod
 ---> Using cache
 ---> 61225deaced1
Step 4/14 : COPY go.sum go.sum
 ---> Using cache
 ---> b75f012f0009
Step 5/14 : RUN go mod download
 ---> Using cache
 ---> a0f3cb51bb08
Step 6/14 : COPY main.go main.go
 ---> 376194fef747
Step 7/14 : COPY internal/ internal/
 ---> a80d466fe882
Step 8/14 : COPY pkg/ pkg/
 ---> 39f8fd4670ef
Step 9/14 : RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 ---> Running in 8b4b3e44ef59
Removing intermediate container 8b4b3e44ef59
 ---> 919f4357b68a
Step 10/14 : FROM gcr.io/distroless/static:nonroot
 ---> 22f885d10e05
Step 11/14 : WORKDIR /
 ---> Using cache
 ---> c1b18f458124
Step 12/14 : COPY --from=builder /workspace/manager .
 ---> a38fced571cc
Step 13/14 : USER 65532:65532
 ---> Running in d726c6a76769
Removing intermediate container d726c6a76769
 ---> 24e735d3a180
Step 14/14 : ENTRYPOINT ["/manager"]
 ---> Running in 0b3338c7047e
Removing intermediate container 0b3338c7047e
 ---> 8309e45dc482
Successfully built 8309e45dc482
Successfully tagged ngrok-ingress-controller:latest
helm upgrade ngrok-ingress-controller helm/ingress-controller --install
Release "ngrok-ingress-controller" does not exist. Installing it now.
NAME: ngrok-ingress-controller
LAST DEPLOYED: Tue Aug  9 15:31:05 2022
NAMESPACE: ngrok-ingress-controller
STATUS: deployed
REVISION: 1
TEST SUITE: None
ingress.networking.k8s.io/minimal-ingress-2 created
deployment.apps/nginx-2 created
service/nginx-2 created
ingress.networking.k8s.io/minimal-ingress created
deployment.apps/nginx created
service/nginx created
HTTP/2 200 
accept-ranges: bytes
content-type: text/html
date: Tue, 09 Aug 2022 22:31:36 GMT
etag: "62d6ba27-267"
last-modified: Tue, 19 Jul 2022 14:05:27 GMT
ngrok-trace-id: f5bf48855983f9d1478eaff636777a86
server: nginx/1.23.1
content-length: 615

HTTP/2 200 
accept-ranges: bytes
content-type: text/html
date: Tue, 09 Aug 2022 22:31:36 GMT
etag: "62d6ba27-267"
last-modified: Tue, 19 Jul 2022 14:05:27 GMT
ngrok-trace-id: 03dcacd450d4449e7f83014c34919490
server: nginx/1.23.1
content-length: 615
```