### PR TITLE
Set an entrypoint compatible with containerd

### DIFF
--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -62,8 +62,6 @@ spec:
       - name: ngrok-cli
         image: ngrok/ngrok:3
         command:
-        - ''
-        args:
         - ./scripts/gen-agent-config.sh
         envFrom:
         - configMapRef:


### PR DESCRIPTION
The containerd runtime is the default way to run k8s these days.

Unfortunately, containerd interprets '' as different than docker.
See https://github.com/containerd/containerd/issues/7229 for info.

The use of `command: ['']` also feels strange to me, since it expresses
the intent less clearly than what I've changed it to IMO, and I waas
pretty surprised that docker does something sensible with that at all.