### PR TITLE
Correct ngrok to ngrok

### DIFF
--- a/helm/ingress-controller/scripts/gen-agent-config.sh
+++ b/helm/ingress-controller/scripts/gen-agent-config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NGORK_LOG="${NGROK_LOG:-stdout}"
+NGROK_LOG="${NGROK_LOG:-stdout}"
 NGROK_METADATA="${NGROK_METADATA:-{}}"
 NGROK_REGION="${NGROK_REGION:-us}"
 NGROK_REMOTE_MANAGEMENT="${NGROK_REMOTE_MANAGEMENT:-true}"
@@ -9,7 +9,7 @@ cat > /var/lib/ngrok/agent-template.yaml <<EOF
 version: 2
 authtoken: $NGROK_AUTHTOKEN
 console_ui: false
-log: $NGORK_LOG
+log: $NGROK_LOG
 metadata: $NGROK_METADATA
 region: $NGROK_REGION
 remote_management: $NGROK_REMOTE_MANAGEMENT


### PR DESCRIPTION
Euan spotted a misspelling during the demo