### PR TITLE
Add helm support for pod annotations for things like consul integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,8 @@ uninstall: manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube
 
 .PHONY: deploy
 deploy: docker-build manifests ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	helm upgrade ngrok-ingress-controller helm/ingress-controller --install
+	helm upgrade ngrok-ingress-controller helm/ingress-controller --install \
+		--set podAnnotations."k8s\.ngrok\.com/test"="\{\"env\": \"local\"\}"
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     checksum/agent-config: {{ include (print $.Template.BasePath "/agent-config-cm.yaml") . | sha256sum }}
     checksum/controller-role: {{ include (print $.Template.BasePath "/role.yaml") . | sha256sum }}
     checksum/rbac: {{ include (print $.Template.BasePath "/controller-rbac.yaml") . | sha256sum }}
+{{ toYaml .Values.podAnnotations | indent 4 }}
 spec:
   replicas: {{.Values.replicaCount}}
   selector:

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -31,3 +31,6 @@ resources:
   requests:
     cpu: 10m
     memory: 64Mi
+
+# Used to inject custom annotations directly into the ingress pods for things like service mesh integrations.
+podAnnotations: {}


### PR DESCRIPTION
This is a common pattern so other tools can be integrated, such as consul https://www.consul.io/docs/k8s/connect/ingress-controllers