### PR TITLE
Convert ngrok.io to k8s.ngrok.com everywhere

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,4 +1,4 @@
-domain: ngrok.io
+domain: k8s.ngrok.com
 layout:
 - go.kubebuilder.io/v3
 projectName: ngrok-ingress-controller

--- a/helm/ingress-controller/templates/controller-cm.yaml
+++ b/helm/ingress-controller/templates/controller-cm.yaml
@@ -13,5 +13,5 @@ data:
       bindAddress: 127.0.0.1:8080
     leaderElection:
       leaderElect: true
-      resourceName: 3792108b.ngrok.io
+      resourceName: 3792108b.k8s.ngrok.com
 

--- a/internal/controllers/ingress_controller.go
+++ b/internal/controllers/ingress_controller.go
@@ -74,8 +74,8 @@ func (irec *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	// Else its being created or updated
 	// Check for a saved edge-id to do a lookup instead of a create
-	if ingress.ObjectMeta.Annotations["ngrok.io/edge-id"] != "" {
-		_, err := irec.NgrokAPIDriver.FindEdge(ctx, ingress.ObjectMeta.Annotations["ngrok.io/edge-id"])
+	if ingress.ObjectMeta.Annotations["k8s.ngrok.com/edge-id"] != "" {
+		_, err := irec.NgrokAPIDriver.FindEdge(ctx, ingress.ObjectMeta.Annotations["k8s.ngrok.com/edge-id"])
 		if err == nil {
 			log.Info("Edge already exists")
 			// TODO: Provide update functionality. Right now, its create/delete
@@ -113,7 +113,7 @@ func (irec *IngressReconciler) CreateIngress(ctx context.Context, edge ngrokapid
 		return ctrl.Result{}, err
 	}
 
-	ingress.ObjectMeta.Annotations["ngrok.io/edge-id"] = ngrokEdge.ID
+	ingress.ObjectMeta.Annotations["k8s.ngrok.com/edge-id"] = ngrokEdge.ID
 	return ctrl.Result{}, irec.Update(ctx, ingress)
 }
 

--- a/internal/controllers/main.go
+++ b/internal/controllers/main.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const finalizerName = "ngrok.io/finalizer"
+const finalizerName = "k8s.ngrok.com/finalizer"
 const controllerName = "k8s.ngrok.com/ingress-controller" // TODO: Let the user configure this
 
 // Checks to see if the ingress controller should do anything about
@@ -156,15 +156,15 @@ func validateIngress(ctx context.Context, ingress *netv1.Ingress) error {
 // Converts a k8s ingress object into an edge with all its configurations and sub-resources
 func IngressToEdge(ctx context.Context, ingress *netv1.Ingress) (*ngrokapidriver.Edge, error) {
 	return &ngrokapidriver.Edge{
-		Id: ingress.Annotations["ngrok.io/edge-id"],
+		Id: ingress.Annotations["k8s.ngrok.com/edge-id"],
 		// TODO: Support multiple rules
 		Hostport: ingress.Spec.Rules[0].Host + ":443",
 		Labels: map[string]string{
-			"ngrok.io/ingress-name":      ingress.Name,
-			"ngrok.io/ingress-namespace": ingress.Namespace,
+			"k8s.ngrok.com/ingress-name":      ingress.Name,
+			"k8s.ngrok.com/ingress-namespace": ingress.Namespace,
 			// TODO: Maybe I don't need this backend name. Need to figure out if edge labels have to all match or if we can match
 			// a subset. In theory the edge can support multiple different backends
-			"ngrok.io/k8s-backend-name": ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name,
+			"k8s.ngrok.com/k8s-backend-name": ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name,
 		},
 		Routes: []ngrokapidriver.Route{
 			{

--- a/internal/controllers/tunnel_controller.go
+++ b/internal/controllers/tunnel_controller.go
@@ -59,9 +59,9 @@ func (trec *TunnelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// TODO: This will need to handle cross namespace connections
 		Addr: fmt.Sprintf("%s:%d", backendService.Name, backendService.Port.Number),
 		Labels: []string{
-			"ngrok.io/ingress-name=" + ingress.Name,
-			"ngrok.io/ingress-namespace=" + ingress.Namespace,
-			"ngrok.io/k8s-backend-name=" + backendService.Name,
+			"k8s.ngrok.com/ingress-name=" + ingress.Name,
+			"k8s.ngrok.com/ingress-namespace=" + ingress.Namespace,
+			"k8s.ngrok.com/k8s-backend-name=" + backendService.Name,
 		},
 	})
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -5,6 +5,8 @@ set -eu -o pipefail
 namespace='ngrok-ingress-controller'
 kubectl config set-context --current --namespace=$namespace
 
+# TODO: Use ngrok cli api to delete all edges owned by the ingress controller
+
 kubectl delete -f examples --ignore-not-found --wait=false
 # Remove finalizers form ingress in namespace
 for i in $(kubectl get ing -o name); do


### PR DESCRIPTION
This was brought up in one of our reviews. I for some reason thought there was a convention of using `.io` but its juts because k8s uses it everywhere. Based on kong and aws ingress controllers, these urls don't have to be real or anything. But i think at some point we'd like to make `k8s.ngrok.com` redirect somewhere real. 

The main things updated here are:
* the annotations prefixes
* the tunnel/backend labels
  * There was a discussion of removing this prefix, but I think i'd like to keep them. It helps ensure we don't conflict with something else generic like `ingress-name`
* finalizer
* the kubeBuilder PROJECT `domain` attribute but they don't really explain what its used for https://book.kubebuilder.io/reference/project-config.html
* the kubebuilder leader election resource name, which i'm also not sure about.

But things work in a full tear down/up of e2e
![image](https://user-images.githubusercontent.com/8029578/190522252-a485d12c-f1c5-40fc-9a8f-1ae3dd5f9b53.png)
