### PR TITLE
Update to use ctx logger and event recorder instead of fmt.Print. Als…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ TOOD:
 * user can supply their own metadata
 * setup unit tests for go
 * make it work with a free account
-* pass logger around in context or something and clean up fmt.println's
 
 ## Setup
 


### PR DESCRIPTION
…o updated the status to reflect the ngrok cname host for the address

This intends to be a first pass at plumbing through best standards for accessing the logger and eventer, but does not deal with making the messages "good". I would like to push dealing with the wordsmithing of these errors until we have our _semi-final_ alpha version that handles the CRUD workflows we officially support and we audit the event/log of those successful/failed workflows. 