### PR TITLE
use raw yq output, split e2e runner from deployment

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -54,46 +54,4 @@ done
 echo "--- Waiting for deployment"
 sleep 120
 
-# Run tests
-echo "--- Running e2e tests"
-failed="false"
-for e2e_config in $(find ./e2e-fixtures -name 'e2e-expected.yaml')
-do
-  example_dir=$(dirname $e2e_config)
-  for config_file in $(cat $e2e_config | yq -r '(. | keys)[]')
-  do
-    if [ -f "$example_dir/$config_file" ]
-    then
-      example_config="$example_dir/$config_file"
-      edge_fqdn=$(yq '.[0].value' $example_config)
-
-      echo "--- Testing '$example_config' with Edge '$edge_fqdn'"
-      for test_path in $(yq -r "(.\"$config_file\".paths | keys)[]" $e2e_config)
-      do
-        expected=$(yq -r ".\"$config_file\".paths[\"$test_path\"]" $e2e_config)
-        test_uri="https://${edge_fqdn}${test_path}"
-        result=$(curl -Is $test_uri | xargs -0)
-        status=$(printf "${result}" | strings | awk 'NR==1{$1=$1;print}')
-
-        printf "\tTesting '${test_uri}' expecting '${expected}': "
-        if [[ "$status" == "$expected" ]]
-        then
-          echo "Passed."
-        else
-          echo "FAILED!"
-          echo -en "  Expected:\"${expected}\" received:\"${status}\" with:\n\n"
-          echo "${result}" | sed 's/^/\t/'
-          failed="true"
-        fi
-      done
-    fi
-  done
-done
-
-echo "--- Results"
-if [[ "$failed" != "false" ]]
-then
-  echo "!!! Tests Failed!"
-  exit 1
-fi
-echo "Tests Passed."
+exec scripts/postflight.sh

--- a/scripts/postflight.sh
+++ b/scripts/postflight.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+namespace='ngrok-ingress-controller'
+kubectl config set-context --current --namespace=$namespace
+
+# Run tests
+echo "--- Running e2e tests"
+failed="false"
+for e2e_config in $(find ./e2e-fixtures -name 'e2e-expected.yaml')
+do
+  example_dir=$(dirname $e2e_config)
+  for config_file in $(cat $e2e_config | yq -r '(. | keys)[]')
+  do
+    if [ -f "$example_dir/$config_file" ]
+    then
+      example_config="$example_dir/$config_file"
+      edge_fqdn=$(yq -r '.[0].value' $example_config)
+
+      echo "--- Testing '$example_config' with Edge '$edge_fqdn'"
+      for test_path in $(yq -r "(.\"$config_file\".paths | keys)[]" $e2e_config)
+      do
+        expected=$(yq -r ".\"$config_file\".paths[\"$test_path\"]" $e2e_config)
+        test_uri="https://${edge_fqdn}${test_path}"
+        result=$(curl -Is $test_uri | xargs -0)
+        status=$(printf "${result}" | strings | awk 'NR==1{$1=$1;print}')
+
+        printf "\tTesting '${test_uri}' expecting '${expected}': "
+        if [[ "$status" == "$expected" ]]
+        then
+          echo "Passed."
+        else
+          echo "FAILED!"
+          echo -en "  Expected:\"${expected}\" received:\"${status}\" with:\n\n"
+          echo "${result}" | sed 's/^/\t/'
+          failed="true"
+        fi
+      done
+    fi
+  done
+done
+
+echo "--- Results"
+if [[ "$failed" != "false" ]]
+then
+  echo "!!! Tests Failed!"
+  exit 1
+fi
+echo "Tests Passed."


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What

Make it so the e2e tests can be easily run without waiting for a full deployment.
This also adds a `-r` to `yq` so it gets raw output, even on the version 3 from nix (version 4 does the happy thing by default).

## How

Splits out the e2e running into `scripts/postflight.sh` which is then exec'd from `scripts/e2e.sh`.

## Breaking Changes

No
