### PR TITLE
Seed additional types when first starting

### DIFF
--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -154,10 +154,6 @@ func listObjectsForType(ctx context.Context, client client.Reader, v interface{}
 		services := &corev1.ServiceList{}
 		err := client.List(ctx, services)
 		return util.ToClientObjects(services.Items), err
-	case *corev1.Secret:
-		secrets := &corev1.SecretList{}
-		err := client.List(ctx, secrets)
-		return util.ToClientObjects(secrets.Items), err
 	case *netv1.Ingress:
 		ingresses := &netv1.IngressList{}
 		err := client.List(ctx, ingresses)
@@ -218,23 +214,29 @@ func listObjectsForType(ctx context.Context, client client.Reader, v interface{}
 // - Gateways
 // - HTTPRoutes
 // - Services
-// - Secrets
 // - Domains
 // - Edges
+// - Tunnels
+// - ModuleSets
+// - TrafficPolicies
 // When the sync method becomes a background process, this likely won't be needed anymore
 func (d *Driver) Seed(ctx context.Context, c client.Reader) error {
 	typesToSeed := []interface{}{
 		&netv1.Ingress{},
 		&netv1.IngressClass{},
 		&corev1.Service{},
+		// CRDs
 		&ingressv1alpha1.Domain{},
 		&ingressv1alpha1.HTTPSEdge{},
 		&ingressv1alpha1.Tunnel{},
+		&ingressv1alpha1.NgrokModuleSet{},
+		&ngrokv1alpha1.NgrokTrafficPolicy{},
 	}
 
 	if d.gatewayEnabled {
 		typesToSeed = append(typesToSeed,
 			&gatewayv1.Gateway{},
+			&gatewayv1.GatewayClass{},
 			&gatewayv1.HTTPRoute{},
 		)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Storer is the interface that wraps the required methods to gather information
-// about ingresses, services, secrets and ingress annotations.
+// about ingresses, services, and other CRDs.
 // It exposes methods to list both all and filtered resources
 type Storer interface {
 	Get(obj runtime.Object) (item interface{}, exists bool, err error)


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
*Describe what the change is solving*

When restarting the operator in a cluster that has lots of ingress + modulesets + traffic policies, I see lots of errors at the start of the logs

```
{"level":"error","ts":"2024-09-11T18:50:41Z","logger":"cache-store-driver","msg":"error getting ngrok moduleset for ingress","ingress":{"namespace":"controlplane","name":"webhooks-2"},"error":"NgrokModuleSet webhooks-stripe not found","stacktrace":"github.com/ngrok/kubernetes-ingress-controller/internal/store.(*Driver).calculateHTTPSEdgesFromIngress\n\tgithub.com/ngrok/kubernetes-ingress-controller/internal/store/driver.go:874\ngithub.com/ngrok/kubernetes-ingress-controller/internal/store.(*Driver).calculateHTTPSEdges\n\tgithub.com/ngrok/kubernetes-ingress-controller/internal/store/driver.go:791\ngithub.com/ngrok/kubernetes-ingress-controller/internal/store.(*Driver).SyncEdges\n\tgithub.com/ngrok/kubernetes-ingress-controller/internal/store/driver.go:494\ngithub.com/ngrok/kubernetes-ingress-controller/internal/controller/ingress.(*ModuleSetReconciler).Reconcile\n\tgithub.com/ngrok/kubernetes-ingress-controller/internal/controller/ingress/moduleset_controller.go:42\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\tsigs.k8s.io/controller-runtime@v0.17.4/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.17.4/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.17.4/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.17.4/pkg/internal/controller/controller.go:227"}
```


## How
*Describe the solution*

We already have a mechanism to seed the driver and store with data on first launch so it doesn't calculate partial edges by only having some of the ingress objects available. 

This just updates that seed functionality to include other CRDs we use in the driver

## Breaking Changes
*Are there any breaking changes in this PR?*
