### PR TITLE
Update RBAC helm templates

### DIFF
--- a/helm/ngrok-operator/templates/rbac/httpsedge_editor_role.yaml
+++ b/helm/ngrok-operator/templates/rbac/httpsedge_editor_role.yaml
@@ -3,13 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: httpsedge-editor-role
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: ngrok-operator
-    app.kubernetes.io/part-of: ngrok-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: httpsedge-editor-role
+  name: {{ include "ngrok-operator.fullname" . }}-httpsedge-editor-role
 rules:
 - apiGroups:
   - ingress.k8s.ngrok.com

--- a/helm/ngrok-operator/templates/rbac/httpsedge_viewer_role.yaml
+++ b/helm/ngrok-operator/templates/rbac/httpsedge_viewer_role.yaml
@@ -3,13 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: httpsedge-viewer-role
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: ngrok-operator
-    app.kubernetes.io/part-of: ngrok-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: httpsedge-viewer-role
+  name: {{ include "ngrok-operator.fullname" . }}-httpsedge-viewer-role
 rules:
 - apiGroups:
   - ingress.k8s.ngrok.com

--- a/helm/ngrok-operator/templates/rbac/ippolicy_editor_role.yaml
+++ b/helm/ngrok-operator/templates/rbac/ippolicy_editor_role.yaml
@@ -3,13 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: ippolicy-editor-role
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: ngrok-operator
-    app.kubernetes.io/part-of: ngrok-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: ippolicy-editor-role
+  name: {{ include "ngrok-operator.fullname" . }}-ippolicy-editor-role
 rules:
 - apiGroups:
   - ingress.k8s.ngrok.com

--- a/helm/ngrok-operator/templates/rbac/ippolicy_viewer_role.yaml
+++ b/helm/ngrok-operator/templates/rbac/ippolicy_viewer_role.yaml
@@ -3,13 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: ippolicy-viewer-role
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: ngrok-operator
-    app.kubernetes.io/part-of: ngrok-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: ippolicy-viewer-role
+  name: {{ include "ngrok-operator.fullname" . }}-ippolicy-viewer-role
 rules:
 - apiGroups:
   - ingress.k8s.ngrok.com

--- a/helm/ngrok-operator/templates/rbac/ngrokmoduleset_editor_role.yaml
+++ b/helm/ngrok-operator/templates/rbac/ngrokmoduleset_editor_role.yaml
@@ -3,13 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: ngrokmoduleset-editor-role
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: ngrok-operator
-    app.kubernetes.io/part-of: ngrok-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: ngrokmoduleset-editor-role
+  name: {{ include "ngrok-operator.fullname" . }}-ngrokmoduleset-editor-role
 rules:
 - apiGroups:
   - ingress.k8s.ngrok.com

--- a/helm/ngrok-operator/templates/rbac/ngrokmoduleset_viewer_role.yaml
+++ b/helm/ngrok-operator/templates/rbac/ngrokmoduleset_viewer_role.yaml
@@ -3,13 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: ngrokmoduleset-viewer-role
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: ngrok-operator
-    app.kubernetes.io/part-of: ngrok-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: ngrokmoduleset-viewer-role
+  name: {{ include "ngrok-operator.fullname" . }}-ngrokmoduleset-viewer-role
 rules:
 - apiGroups:
   - ingress.k8s.ngrok.com

--- a/helm/ngrok-operator/templates/rbac/tcpedge_editor_role.yaml
+++ b/helm/ngrok-operator/templates/rbac/tcpedge_editor_role.yaml
@@ -3,13 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: tcpedge-editor-role
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: ngrok-operator
-    app.kubernetes.io/part-of: ngrok-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: tcpedge-editor-role
+  name: {{ include "ngrok-operator.fullname" . }}-tcpedge-editor-role
 rules:
 - apiGroups:
   - ingress.k8s.ngrok.com

--- a/helm/ngrok-operator/templates/rbac/tcpedge_viewer_role.yaml
+++ b/helm/ngrok-operator/templates/rbac/tcpedge_viewer_role.yaml
@@ -3,13 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: tcpedge-viewer-role
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: ngrok-operator
-    app.kubernetes.io/part-of: ngrok-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: tcpedge-viewer-role
+  name: {{ include "ngrok-operator.fullname" . }}-tcpedge-viewer-role
 rules:
 - apiGroups:
   - ingress.k8s.ngrok.com

--- a/helm/ngrok-operator/templates/rbac/tlsedge_editor_role.yaml
+++ b/helm/ngrok-operator/templates/rbac/tlsedge_editor_role.yaml
@@ -3,13 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: tlsedge-editor-role
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: ngrok-operator
-    app.kubernetes.io/part-of: ngrok-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: tlsedge-editor-role
+  name: {{ include "ngrok-operator.fullname" . }}-tlsedge-editor-role
 rules:
 - apiGroups:
   - ingress.k8s.ngrok.com

--- a/helm/ngrok-operator/templates/rbac/tlsedge_viewer_role.yaml
+++ b/helm/ngrok-operator/templates/rbac/tlsedge_viewer_role.yaml
@@ -3,13 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: tlsedge-viewer-role
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: ngrok-operator
-    app.kubernetes.io/part-of: ngrok-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: tlsedge-viewer-role
+  name: {{ include "ngrok-operator.fullname" . }}-tlsedge-viewer-role
 rules:
 - apiGroups:
   - ingress.k8s.ngrok.com

--- a/scripts/helm-setup.sh
+++ b/scripts/helm-setup.sh
@@ -48,4 +48,4 @@ function helm_install_plugin() {
     fi
 }
 
-helm_install_plugin "unittest" "https://github.com/helm-unittest/helm-unittest" "0.4.4"
+helm_install_plugin "unittest" "https://github.com/helm-unittest/helm-unittest" "0.6.1"


### PR DESCRIPTION
Similar to #436 

## What
I noticed that a lot of our rbac policies were not templated out for helm and copied from the kubebuilder generation.

## How

* Update them to match for consistency
* Bump helm unittest plugin to 0.6.1 (Not necessary, but updating dependencies is good)
