### PR TITLE
Namespace Helm Values by Feature Set

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,18 +90,18 @@ func main() {
 
 type managerOpts struct {
 	// flags
-	metricsAddr    string
-	electionID     string
-	probeAddr      string
-	serverAddr     string
-	apiURL         string
-	controllerName string
-	watchNamespace string
-	ngrokMetadata  string
-	description    string
-	managerName    string
-	zapOpts        *zap.Options
-	clusterDomain  string
+	metricsAddr           string
+	electionID            string
+	probeAddr             string
+	serverAddr            string
+	apiURL                string
+	controllerName        string
+	ingressWatchNamespace string
+	ngrokMetadata         string
+	description           string
+	managerName           string
+	zapOpts               *zap.Options
+	clusterDomain         string
 
 	// feature flags
 	enableFeatureIngress  bool
@@ -136,7 +136,7 @@ func cmd() *cobra.Command {
 	c.Flags().StringVar(&opts.apiURL, "api-url", "", "The base URL to use for the ngrok api")
 	// TODO(operator-rename): This probably needs to be on a per controller basis. Each of the controllers will have their own value or we migrate this to k8s.ngrok.com/ngrok-operator.
 	c.Flags().StringVar(&opts.controllerName, "controller-name", "k8s.ngrok.com/ingress-controller", "The name of the controller to use for matching ingresses classes")
-	c.Flags().StringVar(&opts.watchNamespace, "watch-namespace", "", "Namespace to watch for Kubernetes resources. Defaults to all namespaces.")
+	c.Flags().StringVar(&opts.ingressWatchNamespace, "ingress-watch-namespace", "", "Namespace to watch for Kubernetes Ingress resources. Defaults to all namespaces.")
 	// TODO(operator-rename): Same as above, but for the manager name.
 	c.Flags().StringVar(&opts.managerName, "manager-name", "ngrok-ingress-controller-manager", "Manager name to identify unique ngrok ingress controller instances")
 	c.Flags().StringVar(&opts.clusterDomain, "cluster-domain", "svc.cluster.local", "Cluster domain used in the cluster")
@@ -198,10 +198,10 @@ func runController(ctx context.Context, opts managerOpts) error {
 		LeaderElectionID:       opts.electionID,
 	}
 
-	if opts.watchNamespace != "" {
+	if opts.ingressWatchNamespace != "" {
 		options.Cache = cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
-				opts.watchNamespace: {},
+				opts.ingressWatchNamespace: {},
 			},
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,7 +95,7 @@ type managerOpts struct {
 	probeAddr             string
 	serverAddr            string
 	apiURL                string
-	controllerName        string
+	ingressControllerName string
 	ingressWatchNamespace string
 	ngrokMetadata         string
 	description           string
@@ -135,7 +135,7 @@ func cmd() *cobra.Command {
 	c.Flags().StringVar(&opts.serverAddr, "server-addr", "", "The address of the ngrok server to use for tunnels")
 	c.Flags().StringVar(&opts.apiURL, "api-url", "", "The base URL to use for the ngrok api")
 	// TODO(operator-rename): This probably needs to be on a per controller basis. Each of the controllers will have their own value or we migrate this to k8s.ngrok.com/ngrok-operator.
-	c.Flags().StringVar(&opts.controllerName, "controller-name", "k8s.ngrok.com/ingress-controller", "The name of the controller to use for matching ingresses classes")
+	c.Flags().StringVar(&opts.ingressControllerName, "ingress-controller-name", "k8s.ngrok.com/ingress-controller", "The name of the controller to use for matching ingresses classes")
 	c.Flags().StringVar(&opts.ingressWatchNamespace, "ingress-watch-namespace", "", "Namespace to watch for Kubernetes Ingress resources. Defaults to all namespaces.")
 	// TODO(operator-rename): Same as above, but for the manager name.
 	c.Flags().StringVar(&opts.managerName, "manager-name", "ngrok-ingress-controller-manager", "Manager name to identify unique ngrok ingress controller instances")
@@ -338,7 +338,7 @@ func getK8sResourceDriver(ctx context.Context, mgr manager.Manager, options mana
 	d := store.NewDriver(
 		logger,
 		mgr.GetScheme(),
-		options.controllerName,
+		options.ingressControllerName,
 		types.NamespacedName{
 			Namespace: options.namespace,
 			Name:      options.managerName,

--- a/helm/ngrok-operator/CHANGELOG.md
+++ b/helm/ngrok-operator/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate `.Values.ingressClass` in favor of `.Values.ingress.ingressClass` for feature set namespacing
 - Deprecate `.Values.useExperimentalGatewayApi` in favor of `.Values.gateway.enabled` for feature set namespacing
 - Deprecate `.Values.watchNamespace` in favor of `.Values.ingress.watchNamespace` for feature set namespacing
+- Deprecate `.Values.controllerName` in favor of `.Values.ingress.controllerName` for feature set namespacing
 
 ## 0.15.0
 

--- a/helm/ngrok-operator/CHANGELOG.md
+++ b/helm/ngrok-operator/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate `.Values.metaData` in favor of `.Values.ngrokMetadata` for clarity
 - Deprecate `.Values.ingressClass` in favor of `.Values.ingress.ingressClass` for feature set namespacing
 - Deprecate `.Values.useExperimentalGatewayApi` in favor of `.Values.gateway.enabled` for feature set namespacing
+- Deprecate `.Values.watchNamespace` in favor of `.Values.ingress.watchNamespace` for feature set namespacing
 
 ## 0.15.0
 

--- a/helm/ngrok-operator/CHANGELOG.md
+++ b/helm/ngrok-operator/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Deprecate `.Values.metaData` in favor of `.Values.ngrokMetadata` for clarity
+- Deprecate `.Values.ingressClass` in favor of `.Values.ingress.ingressClass` for feature set namespacing
+- Deprecate `.Values.useExperimentalGatewayApi` in favor of `.Values.gateway.enabled` for feature set namespacing
 
 ## 0.15.0
 

--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -44,60 +44,109 @@ To uninstall the chart:
 | `commonAnnotations` | Annotations to add to all deployed objects                         | `{}`                                      |
 
 
-### Controller parameters
+### Image configuration
 
-| Name                                 | Description                                                                                                           | Value                              |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `podAnnotations`                     | Used to apply custom annotations to the ingress pods.                                                                 | `{}`                               |
-| `podLabels`                          | Used to apply custom labels to the ingress pods.                                                                      | `{}`                               |
-| `replicaCount`                       | The number of controllers to run.                                                                                     | `1`                                |
-| `image.registry`                     | The ngrok operator image registry.                                                                                    | `docker.io`                        |
-| `image.repository`                   | The ngrok operator image repository.                                                                                  | `ngrok/ngrok-operator`             |
-| `image.tag`                          | The ngrok operator image tag. Defaults to the chart's appVersion if not specified                                     | `""`                               |
-| `image.pullPolicy`                   | The ngrok operator image pull policy.                                                                                 | `IfNotPresent`                     |
-| `image.pullSecrets`                  | An array of imagePullSecrets to be used when pulling the image.                                                       | `[]`                               |
-| `ingressClass.name`                  | The name of the ingress class to use.                                                                                 | `ngrok`                            |
-| `ingressClass.create`                | Whether to create the ingress class.                                                                                  | `true`                             |
-| `ingressClass.default`               | Whether to set the ingress class as default.                                                                          | `false`                            |
-| `controllerName`                     | The name of the controller to look for matching ingress classes                                                       | `k8s.ngrok.com/ingress-controller` |
-| `useExperimentalGatewayApi`          | When true, enbale the Gateway controller                                                                              | `false`                            |
-| `watchNamespace`                     | The namespace to watch for ingress resources. Defaults to all                                                         | `""`                               |
-| `credentials.secret.name`            | The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.    | `""`                               |
-| `credentials.apiKey`                 | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well. | `""`                               |
-| `credentials.authtoken`              | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.  | `""`                               |
-| `region`                             | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                            | `""`                               |
-| `rootCAs`                            | Set to "trusted" for the ngrok agent CA or "host" to trust the host's CA. Defaults to "trusted".                      | `""`                               |
-| `serverAddr`                         | This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address. | `""`                               |
-| `clusterDomain`                      | Injects the cluster domain name for service discovery.                                                                | `svc.cluster.local`                |
-| `apiURL`                             | This is the URL of the ngrok API. You should set this if you are using a custom API URL.                              | `""`                               |
-| `metaData`                           | DEPRECATED: Use ngrokMetadata instead                                                                                 |                                    |
-| `ngrokMetadata`                      | This is a map of key=value,key=value pairs that will be added as metadata to all ngrok api resources created          | `{}`                               |
-| `affinity`                           | Affinity for the controller pod assignment                                                                            | `{}`                               |
-| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                   | `""`                               |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `soft`                             |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                               |
-| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                                                | `""`                               |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                                             | `[]`                               |
-| `priorityClassName`                  | Priority class for pod scheduling                                                                                     | `""`                               |
-| `podDisruptionBudget.create`         | Enable a Pod Disruption Budget creation                                                                               | `false`                            |
-| `podDisruptionBudget.minAvailable`   | Minimum number/percentage of pods that should remain scheduled                                                        | `""`                               |
-| `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable                                                        | `1`                                |
-| `resources.limits`                   | The resources limits for the container                                                                                | `{}`                               |
-| `resources.requests`                 | The requested resources for the container                                                                             | `{}`                               |
-| `extraVolumes`                       | An array of extra volumes to add to the controller.                                                                   | `[]`                               |
-| `extraVolumeMounts`                  | An array of extra volume mounts to add to the controller.                                                             | `[]`                               |
-| `extraEnv`                           | an object of extra environment variables to add to the controller.                                                    | `{}`                               |
-| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                                                  | `true`                             |
-| `serviceAccount.name`                | The name of the ServiceAccount to use.                                                                                | `""`                               |
-| `serviceAccount.annotations`         | Additional annotations to add to the ServiceAccount                                                                   | `{}`                               |
-| `log.level`                          | The level to log at. One of 'debug', 'info', or 'error'.                                                              | `info`                             |
-| `log.stacktraceLevel`                | The level to report stacktrace logs one of 'info' or 'error'.                                                         | `error`                            |
-| `log.format`                         | The log format to use. One of console, json.                                                                          | `json`                             |
-| `lifecycle`                          | an object containing lifecycle configuration                                                                          | `{}`                               |
-| `bindings.enabled`                   | Whether to enable the Endpoint Bindings feature                                                                       | `false`                            |
-| `bindings.name`                      | Unique name of this kubernetes binding in your ngrok account                                                          | `""`                               |
-| `bindings.description`               | Description of this kubernetes binding in your ngrok account                                                          | `Created by ngrok-operator`        |
-| `bindings.allowedURLs`               | List of allowed endpoint URL formats that this binding will project into the cluster                                  | `["*"]`                            |
-| `bindings.serviceAnnotations`        | Annotations to add to projected services bound to an endpoint                                                         | `{}`                               |
-| `bindings.serviceLabels`             | Labels to add to projected services bound to an endpoint                                                              | `{}`                               |
+| Name                | Description                                                                       | Value                  |
+| ------------------- | --------------------------------------------------------------------------------- | ---------------------- |
+| `image.registry`    | The ngrok operator image registry.                                                | `docker.io`            |
+| `image.repository`  | The ngrok operator image repository.                                              | `ngrok/ngrok-operator` |
+| `image.tag`         | The ngrok operator image tag. Defaults to the chart's appVersion if not specified | `""`                   |
+| `image.pullPolicy`  | The ngrok operator image pull policy.                                             | `IfNotPresent`         |
+| `image.pullSecrets` | An array of imagePullSecrets to be used when pulling the image.                   | `[]`                   |
+
+
+### ngrok configuration
+
+| Name            | Description                                                                                                           | Value               |
+| --------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `region`        | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                            | `""`                |
+| `rootCAs`       | Set to "trusted" for the ngrok agent CA or "host" to trust the host's CA. Defaults to "trusted".                      | `""`                |
+| `serverAddr`    | This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address. | `""`                |
+| `apiURL`        | This is the URL of the ngrok API. You should set this if you are using a custom API URL.                              | `""`                |
+| `metaData`      | DEPRECATED: Use ngrokMetadata instead                                                                                 |                     |
+| `ngrokMetadata` | This is a map of key=value,key=value pairs that will be added as metadata to all ngrok api resources created          | `{}`                |
+| `clusterDomain` | Configure the default cluster base domain for your kubernetes cluster DNS resolution                                  | `svc.cluster.local` |
+
+
+### Operator Manager parameters
+
+| Name                                 | Description                                                                               | Value   |
+| ------------------------------------ | ----------------------------------------------------------------------------------------- | ------- |
+| `podAnnotations`                     | Used to apply custom annotations to the ingress pods.                                     | `{}`    |
+| `podLabels`                          | Used to apply custom labels to the ingress pods.                                          | `{}`    |
+| `replicaCount`                       | The number of controllers to run.                                                         | `1`     |
+| `affinity`                           | Affinity for the controller pod assignment                                                | `{}`    |
+| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`    |
+| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`  |
+| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`    |
+| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                    | `""`    |
+| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                 | `[]`    |
+| `priorityClassName`                  | Priority class for pod scheduling                                                         | `""`    |
+| `lifecycle`                          | an object containing lifecycle configuration                                              | `{}`    |
+| `podDisruptionBudget.create`         | Enable a Pod Disruption Budget creation                                                   | `false` |
+| `podDisruptionBudget.minAvailable`   | Minimum number/percentage of pods that should remain scheduled                            | `""`    |
+| `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable                            | `1`     |
+| `resources.limits`                   | The resources limits for the container                                                    | `{}`    |
+| `resources.requests`                 | The requested resources for the container                                                 | `{}`    |
+| `extraVolumes`                       | An array of extra volumes to add to the controller.                                       | `[]`    |
+| `extraVolumeMounts`                  | An array of extra volume mounts to add to the controller.                                 | `[]`    |
+| `extraEnv`                           | an object of extra environment variables to add to the controller.                        | `{}`    |
+| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                      | `true`  |
+| `serviceAccount.name`                | The name of the ServiceAccount to use.                                                    | `""`    |
+| `serviceAccount.annotations`         | Additional annotations to add to the ServiceAccount                                       | `{}`    |
+
+
+### Logging configuration
+
+| Name                  | Description                                                   | Value   |
+| --------------------- | ------------------------------------------------------------- | ------- |
+| `log.level`           | The level to log at. One of 'debug', 'info', or 'error'.      | `info`  |
+| `log.stacktraceLevel` | The level to report stacktrace logs one of 'info' or 'error'. | `error` |
+| `log.format`          | The log format to use. One of console, json.                  | `json`  |
+
+
+### Credentials configuration
+
+| Name                      | Description                                                                                                           | Value |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----- |
+| `credentials.secret.name` | The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.    | `""`  |
+| `credentials.apiKey`      | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well. | `""`  |
+| `credentials.authtoken`   | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.  | `""`  |
+
+
+### Kubernetes Ingress feature configuration
+
+| Name                           | Description                                                     | Value                              |
+| ------------------------------ | --------------------------------------------------------------- | ---------------------------------- |
+| `ingressClass.name`            | DEPRECATED: Use ingress.ingressClass.name instead               |                                    |
+| `ingressClass.create`          | DEPRECATED: Use ingress.ingressClass.create instead             |                                    |
+| `ingressClass.default`         | DEPRECATED: Use ingress.ingressClass.default instead            |                                    |
+| `watchNamespace`               | DEPRECATED: Use ingress.watchNamespace instead                  |                                    |
+| `controllerName`               | DEPRECATED: Use ingress.controllerName instead                  |                                    |
+| `ingress.enabled`              | When true, enable the Ingress controller features               | `true`                             |
+| `ingress.ingressClass.name`    | The name of the ingress class to use.                           | `ngrok`                            |
+| `ingress.ingressClass.create`  | Whether to create the ingress class.                            | `true`                             |
+| `ingress.ingressClass.default` | Whether to set the ingress class as default.                    | `false`                            |
+| `ingress.watchNamespace`       | The namespace to watch for ingress resources (default all)      | `""`                               |
+| `ingress.controllerName`       | The name of the controller to look for matching ingress classes | `k8s.ngrok.com/ingress-controller` |
+
+
+### Kubernetes Gateway feature configuration
+
+| Name                        | Description                              | Value   |
+| --------------------------- | ---------------------------------------- | ------- |
+| `useExperimentalGatewayApi` | DEPRECATED: Use gateway.enabled instead  |         |
+| `gateway.enabled`           | When true, enable the Gateway controller | `false` |
+
+
+### Kubernetes Bindings feature configuration
+
+| Name                          | Description                                                                          | Value                       |
+| ----------------------------- | ------------------------------------------------------------------------------------ | --------------------------- |
+| `bindings.enabled`            | Whether to enable the Endpoint Bindings feature                                      | `false`                     |
+| `bindings.name`               | Unique name of this kubernetes binding in your ngrok account                         | `""`                        |
+| `bindings.description`        | Description of this kubernetes binding in your ngrok account                         | `Created by ngrok-operator` |
+| `bindings.allowedURLs`        | List of allowed endpoint URL formats that this binding will project into the cluster | `["*"]`                     |
+| `bindings.serviceAnnotations` | Annotations to add to projected services bound to an endpoint                        | `{}`                        |
+| `bindings.serviceLabels`      | Labels to add to projected services bound to an endpoint                             | `{}`                        |
 

--- a/helm/ngrok-operator/templates/controller-deployment.yaml
+++ b/helm/ngrok-operator/templates/controller-deployment.yaml
@@ -89,11 +89,14 @@ spec:
         {{- if .Values.watchNamespace }}
         - --watch-namespace={{ .Values.watchNamespace}}
         {{- end }}
-        {{- if .Values.bindings.enabled }}
-        - --enable-feature-bindings={{ .Values.bindings.enabled }}
+        {{- if .Values.ingress.enabled }}
+        - --enable-feature-ingress={{ .Values.ingress.enabled }}
         {{- end }}
         {{- if .Values.useExperimentalGatewayApi }}
         - --enable-feature-gateway={{ .Values.useExperimentalGatewayApi }}
+        {{- end }}
+        {{- if .Values.bindings.enabled }}
+        - --enable-feature-bindings={{ .Values.bindings.enabled }}
         {{- end }}
         - --zap-log-level={{ .Values.log.level }}
         - --zap-stacktrace-level={{ .Values.log.stacktraceLevel }}

--- a/helm/ngrok-operator/templates/controller-deployment.yaml
+++ b/helm/ngrok-operator/templates/controller-deployment.yaml
@@ -85,7 +85,7 @@ spec:
           {{- end }}
           {{- $metadataArgs | join "," }}
         {{- end }}
-        - --controller-name={{ .Values.controllerName }}
+        - --ingress-controller-name={{ .Values.controllerName | default .Values.ingress.controllerName }}
         {{- if (.Values.watchNamespace | default .Values.ingress.watchNamespace) }}
         - --ingress-watch-namespace={{ .Values.watchNamespace | default .Values.ingress.watchNamespace }}
         {{- end }}

--- a/helm/ngrok-operator/templates/controller-deployment.yaml
+++ b/helm/ngrok-operator/templates/controller-deployment.yaml
@@ -92,8 +92,10 @@ spec:
         {{- if .Values.ingress.enabled }}
         - --enable-feature-ingress={{ .Values.ingress.enabled }}
         {{- end }}
-        {{- if .Values.useExperimentalGatewayApi }}
-        - --enable-feature-gateway={{ .Values.useExperimentalGatewayApi }}
+        {{- if .Values.useExperimentalGatewayApi | default .Values.gateway.enabled }}
+        - --enable-feature-gateway=true
+        {{- else }}
+        - --enable-feature-gateway=false
         {{- end }}
         {{- if .Values.bindings.enabled }}
         - --enable-feature-bindings={{ .Values.bindings.enabled }}

--- a/helm/ngrok-operator/templates/controller-deployment.yaml
+++ b/helm/ngrok-operator/templates/controller-deployment.yaml
@@ -86,8 +86,8 @@ spec:
           {{- $metadataArgs | join "," }}
         {{- end }}
         - --controller-name={{ .Values.controllerName }}
-        {{- if .Values.watchNamespace }}
-        - --watch-namespace={{ .Values.watchNamespace}}
+        {{- if (.Values.watchNamespace | default .Values.ingress.watchNamespace) }}
+        - --ingress-watch-namespace={{ .Values.watchNamespace | default .Values.ingress.watchNamespace }}
         {{- end }}
         {{- if .Values.ingress.enabled }}
         - --enable-feature-ingress={{ .Values.ingress.enabled }}

--- a/helm/ngrok-operator/templates/ingress-class.yaml
+++ b/helm/ngrok-operator/templates/ingress-class.yaml
@@ -1,13 +1,13 @@
 {{- if .Values.ingress.enabled }}
-{{- if .Values.ingressClass.create -}}
+{{- if or ((.Values.ingress).ingressClass).create (.Values.ingressClass).create -}}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
     {{- include "ngrok-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
-  name: {{ .Values.ingressClass.name }}
-  {{- if .Values.ingressClass.default }}
+  name: {{ (.Values.ingressClass).name | default ((.Values.ingress.ingressClass).name) }}
+  {{- if (.Values.ingressClass).default | default ((.Values.ingress.ingressClass).default) }}
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
   {{- end }}

--- a/helm/ngrok-operator/templates/ingress-class.yaml
+++ b/helm/ngrok-operator/templates/ingress-class.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 {{- if .Values.ingressClass.create -}}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
@@ -12,4 +13,5 @@ metadata:
   {{- end }}
 spec:
   controller: {{ .Values.controllerName }}
+{{- end}}
 {{- end}}

--- a/helm/ngrok-operator/templates/ingress-class.yaml
+++ b/helm/ngrok-operator/templates/ingress-class.yaml
@@ -12,6 +12,6 @@ metadata:
     ingressclass.kubernetes.io/is-default-class: "true"
   {{- end }}
 spec:
-  controller: {{ .Values.controllerName }}
+  controller: {{ .Values.controllerName | default .Values.ingress.controllerName }}
 {{- end}}
 {{- end}}

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -55,6 +55,7 @@ Should match all-options snapshot:
                 - --description="The official ngrok Kubernetes Operator."
                 - --controller-name=k8s.ngrok.com/ingress-controller
                 - --enable-feature-ingress=true
+                - --enable-feature-gateway=false
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error
                 - --zap-encoder=json
@@ -701,6 +702,7 @@ Should match default snapshot:
                 - --description="The official ngrok Kubernetes Operator."
                 - --controller-name=k8s.ngrok.com/ingress-controller
                 - --enable-feature-ingress=true
+                - --enable-feature-gateway=false
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error
                 - --zap-encoder=json

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -53,7 +53,7 @@ Should match all-options snapshot:
           containers:
             - args:
                 - --description="The official ngrok Kubernetes Operator."
-                - --controller-name=k8s.ngrok.com/ingress-controller
+                - --ingress-controller-name=k8s.ngrok.com/ingress-controller
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=false
                 - --zap-log-level=info
@@ -700,7 +700,7 @@ Should match default snapshot:
           containers:
             - args:
                 - --description="The official ngrok Kubernetes Operator."
-                - --controller-name=k8s.ngrok.com/ingress-controller
+                - --ingress-controller-name=k8s.ngrok.com/ingress-controller
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=false
                 - --zap-log-level=info

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -54,6 +54,7 @@ Should match all-options snapshot:
             - args:
                 - --description="The official ngrok Kubernetes Operator."
                 - --controller-name=k8s.ngrok.com/ingress-controller
+                - --enable-feature-ingress=true
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error
                 - --zap-encoder=json
@@ -699,6 +700,7 @@ Should match default snapshot:
             - args:
                 - --description="The official ngrok Kubernetes Operator."
                 - --controller-name=k8s.ngrok.com/ingress-controller
+                - --enable-feature-ingress=true
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error
                 - --zap-encoder=json

--- a/helm/ngrok-operator/tests/controller-deployment_test.yaml
+++ b/helm/ngrok-operator/tests/controller-deployment_test.yaml
@@ -30,6 +30,45 @@ tests:
       mountPath: /test-volume
   asserts:
   - matchSnapshot: {}
+- it: Uses the new gateway.enabled value
+  set:
+    gateway.enabled: true
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --enable-feature-gateway=true
+- it: Uses the new gateway.enabled value when the old one is disabled
+  set:
+    useExperimentalGatewayApi: false
+    gateway.enabled: true
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --enable-feature-gateway=true
+- it: Disables the gateway feature when both are false
+  set:
+    useExperimentalGatewayApi: false
+    gateway.enabled: false
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --enable-feature-gateway=false
+- it: Enables the gateway feature when the old value is true (backwards compatibility)
+  set:
+    useExperimentalGatewayApi: true
+    gateway.enabled: false
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --enable-feature-gateway=true
 - it: Should use the specified cluster domain name
   set:
     clusterDomain: svc.example.com

--- a/helm/ngrok-operator/tests/controller-deployment_test.yaml
+++ b/helm/ngrok-operator/tests/controller-deployment_test.yaml
@@ -107,6 +107,26 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: --ingress-watch-namespace=test-namespace
+- it: Sets --ingress-controller-name
+  set:
+    ingress.enabled: true
+    ingress.controllerName: "my-controller"
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --ingress-controller-name=my-controller
+- it: Sets --ingress-controller-name when the old value is set
+  set:
+    controllerName: "my-controller"
+    ingress.controllerName: "" # unset on purpose
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --ingress-controller-name=my-controller
 - it: Should pass the region via container args to the controller if specified
   set:
     region: eu

--- a/helm/ngrok-operator/tests/controller-deployment_test.yaml
+++ b/helm/ngrok-operator/tests/controller-deployment_test.yaml
@@ -87,6 +87,26 @@ tests:
   - matchRegex:
       path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
       pattern: test-secret-name
+- it: Sets --ingress-watch-namespace
+  set:
+    ingress.enabled: true
+    ingress.watchNamespace: test-namespace
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --ingress-watch-namespace=test-namespace
+- it: Sets --ingress-watch-namespace when the old value is set
+  set:
+    watchNamespace: "test-namespace"
+    ingress.watchNamespace: "" # unset on purpose
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --ingress-watch-namespace=test-namespace
 - it: Should pass the region via container args to the controller if specified
   set:
     region: eu

--- a/helm/ngrok-operator/tests/ingress-class_test.yaml
+++ b/helm/ngrok-operator/tests/ingress-class_test.yaml
@@ -3,17 +3,54 @@ templates:
 - ingress-class.yaml
 tests:
 - it: Should match snapshot
+  set:
+    ingress.enabled: true
+    ingress.createIngressClass: true
   asserts:
   - matchSnapshot: {}
 - it: Creates an default ingress class called ngrok by default
+  set:
+    ingress.enabled: true
+    ingress.ingressClass.create: true
   asserts:
   - isKind:
       of: IngressClass
   - hasDocuments:
       count: 1
+- it: Does not create an ingress class when ingress.enabled is false
+  set:
+    ingress.enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
 - it: Does not create an ingress class when ingressClass.create is false
   set:
+    ingress.enabled: true
+    ingress.ingressClass.create: false
     ingressClass.create: false
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: Creates an ingress class when ingressClass.create is true (regardless of new values)
+  set:
+    ingress.enabled: true
+    ingress.ingressClass.create: false
+    ingressClass.create: true
+  asserts:
+  - hasDocuments:
+      count: 1
+- it: Creates an ingress class when ingress.ingressClass.create is true (regardless of old values)
+  set:
+    ingress.enabled: true
+    ingress.ingressClass.create: true
+    ingressClass.create: false
+  asserts:
+  - hasDocuments:
+      count: 1
+- it: Does not create an ingress class when no create is true
+  set:
+    ingressClass.create: false
+    ingress.ingressClass.create: false
   asserts:
   - hasDocuments:
       count: 0

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -26,6 +26,7 @@ podLabels: {}
 ##
 replicaCount: 1
 
+## @section Image configuration
 ## @param image.registry The ngrok operator image registry.
 ## @param image.repository The ngrok operator image repository.
 ## @param image.tag The ngrok operator image tag. Defaults to the chart's appVersion if not specified
@@ -49,6 +50,11 @@ ingressClass:
   name: ngrok
   create: true
   default: false
+
+## @section Kubernetes Ingress feature configuration
+## @param ingress.enabled When true, enable the Ingress controller features
+ingress:
+  enabled: true # enabled by default
 
 ## @param controllerName The name of the controller to look for matching ingress classes
 controllerName: "k8s.ngrok.com/ingress-controller"
@@ -196,7 +202,7 @@ serviceAccount:
   annotations: {}
 
 
-## Logging configuration
+## @section Logging configuration
 ## @param log.level The level to log at. One of 'debug', 'info', or 'error'.
 ## @param log.stacktraceLevel The level to report stacktrace logs one of 'info' or 'error'.
 ## @param log.format The log format to use. One of console, json.
@@ -210,6 +216,7 @@ log:
 ##
 lifecycle: {}
 
+## @section Kubernetes Bindings feature configuration
 ## @param bindings.enabled Whether to enable the Endpoint Bindings feature
 ## @param bindings.name Unique name of this kubernetes binding in your ngrok account
 ## @param bindings.description Description of this kubernetes binding in your ngrok account

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -47,6 +47,7 @@ image:
 ## @extra ingressClass.create DEPRECATED: Use ingress.ingressClass.create instead
 ## @extra ingressClass.default DEPRECATED: Use ingress.ingressClass.default instead
 ## @extra watchNamespace DEPRECATED: Use ingress.watchNamespace instead
+  ## @extra controllerName DEPRECATED: Use ingress.controllerName instead
 
 ## @section Kubernetes Ingress feature configuration
 ## @param ingress.enabled When true, enable the Ingress controller features
@@ -54,16 +55,15 @@ image:
 ## @param ingress.ingressClass.create Whether to create the ingress class.
 ## @param ingress.ingressClass.default Whether to set the ingress class as default.
 ## @param ingress.watchNamespace The namespace to watch for ingress resources (default all)
+## @param ingress.controllerName The name of the controller to look for matching ingress classes
 ingress:
   enabled: true # enabled by default
+  controllerName: "k8s.ngrok.com/ingress-controller"
   watchNamespace: "" # default all
   ingressClass:
     name: ngrok
     create: true
     default: false
-
-## @param controllerName The name of the controller to look for matching ingress classes
-controllerName: "k8s.ngrok.com/ingress-controller"
 
 ## @extra useExperimentalGatewayApi DEPRECATED: Use gateway.enabled instead
 

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -43,18 +43,21 @@ image:
   ##
   pullSecrets: []
 
-## @param ingressClass.name The name of the ingress class to use.
-## @param ingressClass.create Whether to create the ingress class.
-## @param ingressClass.default Whether to set the ingress class as default.
-ingressClass:
-  name: ngrok
-  create: true
-  default: false
+## @extra ingressClass.name DEPRECATED: Use ingress.ingressClass.name instead
+## @extra ingressClass.create DEPRECATED: Use ingress.ingressClass.create instead
+## @extra ingressClass.default DEPRECATED: Use ingress.ingressClass.default instead
 
 ## @section Kubernetes Ingress feature configuration
 ## @param ingress.enabled When true, enable the Ingress controller features
+## @param ingress.ingressClass.name The name of the ingress class to use.
+## @param ingress.ingressClass.create Whether to create the ingress class.
+## @param ingress.ingressClass.default Whether to set the ingress class as default.
 ingress:
   enabled: true # enabled by default
+  ingressClass:
+    name: ngrok
+    create: true
+    default: false
 
 ## @param controllerName The name of the controller to look for matching ingress classes
 controllerName: "k8s.ngrok.com/ingress-controller"

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -46,14 +46,17 @@ image:
 ## @extra ingressClass.name DEPRECATED: Use ingress.ingressClass.name instead
 ## @extra ingressClass.create DEPRECATED: Use ingress.ingressClass.create instead
 ## @extra ingressClass.default DEPRECATED: Use ingress.ingressClass.default instead
+## @extra watchNamespace DEPRECATED: Use ingress.watchNamespace instead
 
 ## @section Kubernetes Ingress feature configuration
 ## @param ingress.enabled When true, enable the Ingress controller features
 ## @param ingress.ingressClass.name The name of the ingress class to use.
 ## @param ingress.ingressClass.create Whether to create the ingress class.
 ## @param ingress.ingressClass.default Whether to set the ingress class as default.
+## @param ingress.watchNamespace The namespace to watch for ingress resources (default all)
 ingress:
   enabled: true # enabled by default
+  watchNamespace: "" # default all
   ingressClass:
     name: ngrok
     create: true
@@ -68,9 +71,6 @@ controllerName: "k8s.ngrok.com/ingress-controller"
 ## @param gateway.enabled When true, enable the Gateway controller
 gateway:
   enabled: false
-
-## @param watchNamespace The namespace to watch for ingress resources. Defaults to all
-watchNamespace: ""
 
 ## @param credentials.secret.name The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.
 ## @param credentials.apiKey Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well.

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -1,6 +1,6 @@
+##
 ## @section Common parameters
 ##
-
 ## @param nameOverride String to partially override generated resource names
 ## @param fullnameOverride String to fully override generated resource names
 ## @param description ngrok-operator description that will appear in the ngrok dashboard
@@ -12,26 +12,15 @@ description: "The official ngrok Kubernetes Operator."
 commonLabels: {}
 commonAnnotations: {}
 
-## @section Controller parameters
 ##
-
-## @param podAnnotations Used to apply custom annotations to the ingress pods.
-## @param podLabels Used to apply custom labels to the ingress pods.
-##
-podAnnotations: {}
-podLabels: {}
-
-## @param replicaCount The number of controllers to run.
-## A minimum of 2 is recommended in production for HA.
-##
-replicaCount: 1
-
 ## @section Image configuration
+##
 ## @param image.registry The ngrok operator image registry.
 ## @param image.repository The ngrok operator image repository.
 ## @param image.tag The ngrok operator image tag. Defaults to the chart's appVersion if not specified
 ## @param image.pullPolicy The ngrok operator image pull policy.
 ## @param image.pullSecrets An array of imagePullSecrets to be used when pulling the image.
+##
 image:
   registry: docker.io
   repository: ngrok/ngrok-operator
@@ -43,63 +32,47 @@ image:
   ##
   pullSecrets: []
 
-## @extra ingressClass.name DEPRECATED: Use ingress.ingressClass.name instead
-## @extra ingressClass.create DEPRECATED: Use ingress.ingressClass.create instead
-## @extra ingressClass.default DEPRECATED: Use ingress.ingressClass.default instead
-## @extra watchNamespace DEPRECATED: Use ingress.watchNamespace instead
-  ## @extra controllerName DEPRECATED: Use ingress.controllerName instead
-
-## @section Kubernetes Ingress feature configuration
-## @param ingress.enabled When true, enable the Ingress controller features
-## @param ingress.ingressClass.name The name of the ingress class to use.
-## @param ingress.ingressClass.create Whether to create the ingress class.
-## @param ingress.ingressClass.default Whether to set the ingress class as default.
-## @param ingress.watchNamespace The namespace to watch for ingress resources (default all)
-## @param ingress.controllerName The name of the controller to look for matching ingress classes
-ingress:
-  enabled: true # enabled by default
-  controllerName: "k8s.ngrok.com/ingress-controller"
-  watchNamespace: "" # default all
-  ingressClass:
-    name: ngrok
-    create: true
-    default: false
-
-## @extra useExperimentalGatewayApi DEPRECATED: Use gateway.enabled instead
-
-## @section Kubernetes Gateway feature configuration
-## @param gateway.enabled When true, enable the Gateway controller
-gateway:
-  enabled: false
-
-## @param credentials.secret.name The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.
-## @param credentials.apiKey Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well.
-## @param credentials.authtoken Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.
-credentials:
-  secret:
-    name: ""
-  apiKey: ""
-  authtoken: ""
-
+##
+## @section ngrok configuration
+##
 ## @param region ngrok region to create tunnels in. Defaults to connect to the closest geographical region.
+##
 region: "" # empty means global or all regions
 
 ## @param rootCAs Set to "trusted" for the ngrok agent CA or "host" to trust the host's CA. Defaults to "trusted".
+##
 rootCAs: ""
 
 ## @param serverAddr  This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address.
+##
 serverAddr: ""
 
-## @param clusterDomain Injects the cluster domain name for service discovery.
-clusterDomain: svc.cluster.local
-
 ## @param apiURL  This is the URL of the ngrok API. You should set this if you are using a custom API URL.
-# apiURL: "https://api.ngrok.com/"
+##
 apiURL: "" # default to ngrok-api-go SDK's default
 
 ## @extra metaData DEPRECATED: Use ngrokMetadata instead
 ## @param ngrokMetadata This is a map of key=value,key=value pairs that will be added as metadata to all ngrok api resources created
+##
 ngrokMetadata: {}
+
+## @param clusterDomain Configure the default cluster base domain for your kubernetes cluster DNS resolution
+##
+clusterDomain: svc.cluster.local
+
+##
+## @section Operator Manager parameters
+##
+## @param podAnnotations Used to apply custom annotations to the ingress pods.
+## @param podLabels Used to apply custom labels to the ingress pods.
+##
+podAnnotations: {}
+podLabels: {}
+
+## @param replicaCount The number of controllers to run.
+## A minimum of 2 is recommended in production for HA.
+##
+replicaCount: 1
 
 ## @param affinity Affinity for the controller pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
@@ -136,7 +109,13 @@ nodeAffinityPreset:
 
 ## @param priorityClassName Priority class for pod scheduling
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+##
 priorityClassName: ""
+
+## @param lifecycle an object containing lifecycle configuration
+## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+##
+lifecycle: {}
 
 ## Pod Disruption Budget configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
@@ -172,10 +151,11 @@ resources:
   ##
   requests: {}
 
-
 ## @param extraVolumes An array of extra volumes to add to the controller.
+##
 extraVolumes: []
 ## @param extraVolumeMounts An array of extra volume mounts to add to the controller.
+##
 extraVolumeMounts: []
 ##
 ## Example:
@@ -187,8 +167,8 @@ extraVolumeMounts: []
 ## - name: test-volume
 ##   mountPath: /test-volume
 
-
 ## @param extraEnv an object of extra environment variables to add to the controller.
+##
 extraEnv: {}
 ## Example:
 ##   MY_VAR: test
@@ -208,28 +188,74 @@ serviceAccount:
   name: ""
   annotations: {}
 
-
+##
 ## @section Logging configuration
+##
 ## @param log.level The level to log at. One of 'debug', 'info', or 'error'.
 ## @param log.stacktraceLevel The level to report stacktrace logs one of 'info' or 'error'.
 ## @param log.format The log format to use. One of console, json.
+##
 log:
   format: json
   level: info
   stacktraceLevel: error
 
-## @param lifecycle an object containing lifecycle configuration
-## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 ##
-lifecycle: {}
+## @section Credentials configuration
+##
+## @param credentials.secret.name The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.
+## @param credentials.apiKey Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well.
+## @param credentials.authtoken Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.
+##
+credentials:
+  secret:
+    name: ""
+  apiKey: ""
+  authtoken: ""
 
+##
+## @section Kubernetes Ingress feature configuration
+##
+## @extra ingressClass.name DEPRECATED: Use ingress.ingressClass.name instead
+## @extra ingressClass.create DEPRECATED: Use ingress.ingressClass.create instead
+## @extra ingressClass.default DEPRECATED: Use ingress.ingressClass.default instead
+## @extra watchNamespace DEPRECATED: Use ingress.watchNamespace instead
+## @extra controllerName DEPRECATED: Use ingress.controllerName instead
+## @param ingress.enabled When true, enable the Ingress controller features
+## @param ingress.ingressClass.name The name of the ingress class to use.
+## @param ingress.ingressClass.create Whether to create the ingress class.
+## @param ingress.ingressClass.default Whether to set the ingress class as default.
+## @param ingress.watchNamespace The namespace to watch for ingress resources (default all)
+## @param ingress.controllerName The name of the controller to look for matching ingress classes
+##
+ingress:
+  enabled: true # enabled by default
+  controllerName: "k8s.ngrok.com/ingress-controller"
+  watchNamespace: "" # default all
+  ingressClass:
+    name: ngrok
+    create: true
+    default: false
+
+##
+## @section Kubernetes Gateway feature configuration
+##
+## @extra useExperimentalGatewayApi DEPRECATED: Use gateway.enabled instead
+## @param gateway.enabled When true, enable the Gateway controller
+##
+gateway:
+  enabled: false
+
+##
 ## @section Kubernetes Bindings feature configuration
+##
 ## @param bindings.enabled Whether to enable the Endpoint Bindings feature
 ## @param bindings.name Unique name of this kubernetes binding in your ngrok account
 ## @param bindings.description Description of this kubernetes binding in your ngrok account
 ## @param bindings.allowedURLs List of allowed endpoint URL formats that this binding will project into the cluster
 ## @param bindings.serviceAnnotations Annotations to add to projected services bound to an endpoint
 ## @param bindings.serviceLabels Labels to add to projected services bound to an endpoint
+##
 bindings:
   enabled: false # in-development
   name: ""

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -62,8 +62,12 @@ ingress:
 ## @param controllerName The name of the controller to look for matching ingress classes
 controllerName: "k8s.ngrok.com/ingress-controller"
 
-## @param useExperimentalGatewayApi When true, enbale the Gateway controller
-useExperimentalGatewayApi: false
+## @extra useExperimentalGatewayApi DEPRECATED: Use gateway.enabled instead
+
+## @section Kubernetes Gateway feature configuration
+## @param gateway.enabled When true, enable the Gateway controller
+gateway:
+  enabled: false
 
 ## @param watchNamespace The namespace to watch for ingress resources. Defaults to all
 watchNamespace: ""


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
*Describe what the change is solving*

Namespace the feature sets in Helm values

## How
*Describe the solution*

Collect each feature set and put it into a namespaced section:
```yaml
ingress:
  enabled: true/false
  ...

gateway:
  enabled: true/false
  ...

bindings:
  enabled: true/false
  ...
```

## Breaking Changes
*Are there any breaking changes in this PR?*

I tried to make this backwards compatible but I suspect it's not 100% due to incompatible DeMorgan logic etc... between desired and expected behaviours.

So here's what's deprecated:
* Deprecate `useExperimentalGatewayApi`, instead use `gateway.enabled: true`
* Deprecate `ingressClass`, instead use `ingress.ingressClass`
* Deprecate `watchNamespace`, instead use `ingress.watchNamespace`
* Deprecate `controllerName`, instead use `ingress.controllerName`
