### PR TITLE
Update template to use the correctly cased values property for allowed urls

### DIFF
--- a/helm/ngrok-operator/templates/binding-configuration.yaml
+++ b/helm/ngrok-operator/templates/binding-configuration.yaml
@@ -12,7 +12,7 @@ spec:
   name: {{ .Values.bindings.name }}
   description: {{ .Values.bindings.description }}
   allowedURLs:
-    {{- toYaml .Values.bindings.allowedUrls | nindent 6 }}
+    {{- toYaml .Values.bindings.allowedURLs | nindent 6 }}
   tlsSecretName: "default-tls"
   region: {{ .Values.region }}
   projectedMetadata:

--- a/helm/ngrok-operator/tests/__snapshot__/binding-configuration_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/binding-configuration_test.yaml.snap
@@ -14,7 +14,8 @@ Should match snapshot:
       name: default-configuration
       namespace: NAMESPACE
     spec:
-      allowedURLs: null
+      allowedURLs:
+        - '*'
       description: Created by ngrok-operator
       name: test-1
       projectedMetadata:


### PR DESCRIPTION
## What

when attempting to install the controller with binding enabled (like by using `make deploy_with_bindings`) it errors on main

```
Error: UPGRADE FAILED: cannot patch "default-configuration" with kind BindingConfiguration: BindingConfiguration.bindings.k8s.ngrok.com "default-configuration" is invalid: spec.allowedURLs: Required value
make: *** [deploy_with_bindings] Error 1
```

## How
*Describe the solution*

The casing is just incorrect so it doesn't get the default value of `"*"` and instead is null
