### PR TITLE
feat: Initial bindings driver

### DIFF
--- a/pkg/bindingsdriver/driver.go
+++ b/pkg/bindingsdriver/driver.go
@@ -1,0 +1,111 @@
+package bindingsdriver
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+type BindingsDriver struct {
+	listenerMap   map[int32]*bindingsListener
+	listenerMapMu sync.Mutex
+}
+
+func New() *BindingsDriver {
+	return &BindingsDriver{
+		listenerMap:   make(map[int32]*bindingsListener),
+		listenerMapMu: sync.Mutex{},
+	}
+}
+
+func (b *BindingsDriver) Listen(port int32, cnxnHandler ConnectionHandler) error {
+	b.listenerMapMu.Lock()
+	defer b.listenerMapMu.Unlock()
+
+	if _, ok := b.listenerMap[port]; ok {
+		return nil // already listening
+	}
+
+	bl, err := newBindingsListener(
+		fmt.Sprintf("0.0.0.0:%d", port),
+		cnxnHandler,
+	)
+	if err != nil {
+		return err
+	}
+
+	b.listenerMap[port] = bl
+	return nil
+}
+
+func (b *BindingsDriver) Close(port int32) {
+	b.listenerMapMu.Lock()
+	bl, ok := b.listenerMap[port]
+	if !ok {
+		// not listening
+		b.listenerMapMu.Unlock()
+		return
+	}
+
+	delete(b.listenerMap, port)
+	b.listenerMapMu.Unlock()
+
+	bl.Stop()
+}
+
+type ConnectionHandler func(net.Conn) error
+
+type bindingsListener struct {
+	listener    net.Listener
+	stop        chan struct{}
+	cnxnHandler ConnectionHandler
+	log         logr.Logger
+}
+
+func newBindingsListener(address string, cnxnHandler ConnectionHandler) (*bindingsListener, error) {
+	l, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+
+	bl := &bindingsListener{
+		listener:    l,
+		stop:        make(chan struct{}),
+		cnxnHandler: cnxnHandler,
+	}
+
+	go bl.run()
+
+	return bl, nil
+}
+
+// Stop stops the listener. It is safe to call stop multiple times.
+func (b *bindingsListener) Stop() {
+	select {
+	case b.stop <- struct{}{}:
+		close(b.stop)
+	default:
+	}
+}
+
+func (b *bindingsListener) run() {
+	for {
+		select {
+		case <-b.stop:
+			b.listener.Close()
+			return
+		default:
+		}
+
+		conn, err := b.listener.Accept()
+		if err != nil {
+			b.log.Error(err, "failed to accept connection")
+			continue
+		}
+
+		// handle connection
+		go b.cnxnHandler(conn) // nolint:errcheck
+	}
+}

--- a/pkg/bindingsdriver/driver_test.go
+++ b/pkg/bindingsdriver/driver_test.go
@@ -1,0 +1,74 @@
+package bindingsdriver
+
+import (
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func loopbackAddr(port int32) string {
+	return fmt.Sprintf("127.0.0.1:%d", port)
+}
+
+func randomPort() int32 {
+	p := 30000 + rand.IntN(1000)
+	return int32(p)
+}
+
+func testConnectionHandler(conn net.Conn) error {
+	defer conn.Close()
+	_, err := conn.Write([]byte("hello world"))
+	return err
+}
+
+func TestBindingsListener(t *testing.T) {
+	port := randomPort()
+	bl, err := newBindingsListener(
+		loopbackAddr(port),
+		testConnectionHandler,
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, bl)
+
+	// test that we can connect to the listener
+	conn, err := net.Dial("tcp", loopbackAddr(port))
+	assert.NoError(t, err)
+
+	out, err := io.ReadAll(conn)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "hello world", string(out))
+
+	assert.NotPanics(t, func() { bl.Stop() })
+	assert.NotPanics(t, func() { bl.Stop() })
+}
+
+func TestBindingsDriver(t *testing.T) {
+	b := New()
+	assert.NotNil(t, b)
+
+	port := randomPort()
+	err := b.Listen(port, testConnectionHandler)
+	assert.NoError(t, err)
+
+	// test that we can connect to the listener
+	conn, err := net.Dial("tcp", loopbackAddr(port))
+	assert.NoError(t, err)
+
+	out, err := io.ReadAll(conn)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "hello world", string(out))
+
+	// test that trying to start a listener on the same port doesn't cause an error
+	// and that only one listener exists
+	assert.NoError(t, b.Listen(port, testConnectionHandler))
+	assert.Len(t, b.listenerMap, 1)
+
+	assert.NotPanics(t, func() { b.Close(port) })
+	assert.NotPanics(t, func() { b.Close(port) })
+}


### PR DESCRIPTION
## What

Adds an initial bindings driver, similar to the TunnelDriver. This will be used in the bindings forwarder deployment to watch `EndpointBindings` and listen on a given port.

## How

Adds a bindings driver, similar to the TunnelDriver. It will be wired up in a subsequent PR to actually listen in a deployment.

## Breaking Changes
No