### PR TITLE
feat: Add in v6 ngrok-api-go client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/imdario/mergo v0.3.16
 	github.com/ngrok/ngrok-api-go/v5 v5.4.1
+	github.com/ngrok/ngrok-api-go/v6 v6.0.1-0.20241015200239-7c32f2a7d4d9
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -416,6 +416,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/ngrok/ngrok-api-go/v5 v5.4.1 h1:rjofyT5M4pi3PtobyNy+3RMhq2uUaKuqsP34IwXRE28=
 github.com/ngrok/ngrok-api-go/v5 v5.4.1/go.mod h1:UVTaHI5B4gEsfHCOZTlRg8WkT6+KBijIkVtjpDqCyIU=
+github.com/ngrok/ngrok-api-go/v6 v6.0.1-0.20241015200239-7c32f2a7d4d9 h1:/+K+wwWKOn4wScpjdSFGcOV5XJObTI/G7z90A8gei7A=
+github.com/ngrok/ngrok-api-go/v6 v6.0.1-0.20241015200239-7c32f2a7d4d9/go.mod h1:KtRxWqEomaHZfgeS+q/7nFHF+gPYFghS5wTl5AIUjIk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/ngrokapi/clientset.go
+++ b/internal/ngrokapi/clientset.go
@@ -11,6 +11,8 @@ import (
 	"github.com/ngrok/ngrok-api-go/v5/ip_policy_rules"
 	"github.com/ngrok/ngrok-api-go/v5/reserved_addrs"
 	"github.com/ngrok/ngrok-api-go/v5/reserved_domains"
+	v6 "github.com/ngrok/ngrok-api-go/v6"
+	"github.com/ngrok/ngrok-api-go/v6/kubernetes_operators"
 )
 
 type Clientset interface {
@@ -20,6 +22,7 @@ type Clientset interface {
 	HTTPSEdgeRoutes() *https_edge_routes.Client
 	IPPolicies() *ip_policies.Client
 	IPPolicyRules() *ip_policy_rules.Client
+	KubernetesOperators() *kubernetes_operators.Client
 	TCPAddresses() *reserved_addrs.Client
 	TCPEdges() *tcp_edges.Client
 	TLSEdges() *tls_edges.Client
@@ -33,6 +36,7 @@ type DefaultClientset struct {
 	httpsEdgeRoutesClient     *https_edge_routes.Client
 	ipPoliciesClient          *ip_policies.Client
 	ipPolicyRulesClient       *ip_policy_rules.Client
+	kubernetesOperatorsClient *kubernetes_operators.Client
 	tcpAddrsClient            *reserved_addrs.Client
 	tcpEdgesClient            *tcp_edges.Client
 	tlsEdgesClient            *tls_edges.Client
@@ -41,6 +45,12 @@ type DefaultClientset struct {
 
 // NewClientSet creates a new ClientSet from an ngrok client config.
 func NewClientSet(config *ngrok.ClientConfig) *DefaultClientset {
+	v6Config := &v6.ClientConfig{
+		APIKey:     config.APIKey,
+		BaseURL:    config.BaseURL,
+		HTTPClient: config.HTTPClient,
+		UserAgent:  config.UserAgent,
+	}
 	return &DefaultClientset{
 		domainsClient:             reserved_domains.NewClient(config),
 		edgeModulesClientset:      newEdgeModulesClientset(config),
@@ -48,6 +58,7 @@ func NewClientSet(config *ngrok.ClientConfig) *DefaultClientset {
 		httpsEdgeRoutesClient:     https_edge_routes.NewClient(config),
 		ipPoliciesClient:          ip_policies.NewClient(config),
 		ipPolicyRulesClient:       ip_policy_rules.NewClient(config),
+		kubernetesOperatorsClient: kubernetes_operators.NewClient(v6Config),
 		tcpAddrsClient:            reserved_addrs.NewClient(config),
 		tcpEdgesClient:            tcp_edges.NewClient(config),
 		tlsEdgesClient:            tls_edges.NewClient(config),
@@ -77,6 +88,10 @@ func (c *DefaultClientset) IPPolicies() *ip_policies.Client {
 
 func (c *DefaultClientset) IPPolicyRules() *ip_policy_rules.Client {
 	return c.ipPolicyRulesClient
+}
+
+func (c *DefaultClientset) KubernetesOperators() *kubernetes_operators.Client {
+	return c.kubernetesOperatorsClient
 }
 
 func (c *DefaultClientset) TCPAddresses() *reserved_addrs.Client {


### PR DESCRIPTION
## What

This will allow us to create the kubernetes operator api resource by using a pre-release of the ngrok-api-go client. Also will allow us to start using endpoints eventually as well.

## How

Add ngrok-api-go(v6) from a branch. The API and client is subject to change, but we want to start building on this.

## Breaking Changes

No, just adding in the new client & wiring it up.