### PR TITLE
update traffic policy for phase-based naming

### DIFF
--- a/api/ingress/v1alpha1/domain_types.go
+++ b/api/ingress/v1alpha1/domain_types.go
@@ -25,7 +25,7 @@ SOFTWARE.
 package v1alpha1
 
 import (
-	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v6"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/api/ingress/v1alpha1/httpsedge_types.go
+++ b/api/ingress/v1alpha1/httpsedge_types.go
@@ -27,7 +27,7 @@ package v1alpha1
 import (
 	"encoding/json"
 
-	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v6"
 	"golang.org/x/exp/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -76,7 +76,7 @@ type HTTPSEdgeRouteSpec struct {
 	// WebhookVerification is webhook verification configuration to apply to this route
 	WebhookVerification *EndpointWebhookVerification `json:"webhookVerification,omitempty"`
 
-	// raw json policy string that was applied to the ngrok API
+	// TrafficPolicy is the raw json policy string that was applied to the ngrok API
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Type=object

--- a/api/ingress/v1alpha1/httpsedge_types_test.go
+++ b/api/ingress/v1alpha1/httpsedge_types_test.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v6"
 )
 
 func TestHTTPSEdgeEqual(t *testing.T) {

--- a/api/ingress/v1alpha1/ngrok_common.go
+++ b/api/ingress/v1alpha1/ngrok_common.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"encoding/json"
 
-	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v6"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -487,62 +487,4 @@ type EndpointAction struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Type=object
 	Config json.RawMessage `json:"config,omitempty"`
-}
-
-func (policy *EndpointPolicy) ToNgrok() *ngrok.EndpointPolicy {
-	if policy == nil {
-		return nil
-	}
-
-	var inbound []ngrok.EndpointRule
-	for _, rule := range policy.Inbound {
-		p := rule
-		inbound = append(inbound, *p.ToNgrok())
-	}
-	var outbound []ngrok.EndpointRule
-	for _, rule := range policy.Outbound {
-		p := rule
-		mod := p.ToNgrok()
-		if mod != nil {
-			outbound = append(outbound, *mod)
-		}
-	}
-
-	return &ngrok.EndpointPolicy{
-		Enabled:  policy.Enabled,
-		Inbound:  inbound,
-		Outbound: outbound,
-	}
-}
-
-func (rule *EndpointRule) ToNgrok() *ngrok.EndpointRule {
-	if rule == nil {
-		return nil
-	}
-
-	var actions []ngrok.EndpointAction
-	for _, action := range rule.Actions {
-		a := action
-		mod := a.ToNgrok()
-		if mod != nil {
-			actions = append(actions, *mod)
-		}
-	}
-
-	return &ngrok.EndpointRule{
-		Expressions: rule.Expressions,
-		Actions:     actions,
-		Name:        rule.Name,
-	}
-}
-
-func (action *EndpointAction) ToNgrok() *ngrok.EndpointAction {
-	if action == nil {
-		return nil
-	}
-
-	return &ngrok.EndpointAction{
-		Type:   action.Type,
-		Config: action.Config,
-	}
 }

--- a/api/ingress/v1alpha1/ngrokmoduleset_types.go
+++ b/api/ingress/v1alpha1/ngrokmoduleset_types.go
@@ -39,7 +39,7 @@ type NgrokModuleSetModules struct {
 	IPRestriction *EndpointIPPolicy `json:"ipRestriction,omitempty"`
 	// OAuth configuration for this module set
 	OAuth *EndpointOAuth `json:"oauth,omitempty"`
-	// Policy configuration for this module set
+	// Policy module is deprecated, use the `NgrokTrafficPolicy` CRD or the Gateway API instead
 	Policy *EndpointPolicy `json:"policy,omitempty"`
 	// OIDC configuration for this module set
 	OIDC *EndpointOIDC `json:"oidc,omitempty"`

--- a/api/ingress/v1alpha1/tcpedge_types.go
+++ b/api/ingress/v1alpha1/tcpedge_types.go
@@ -45,7 +45,7 @@ type TCPEdgeSpec struct {
 	// IPRestriction is an IPRestriction to apply to this edge
 	IPRestriction *EndpointIPPolicy `json:"ipRestriction,omitempty"`
 
-	// raw json policy string that was applied to the ngrok API
+	// Policy is the raw json policy string that was applied to the ngrok API
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Type=object

--- a/api/ingress/v1alpha1/tlsedge_types.go
+++ b/api/ingress/v1alpha1/tlsedge_types.go
@@ -53,7 +53,7 @@ type TLSEdgeSpec struct {
 
 	MutualTLS *EndpointMutualTLS `json:"mutualTls,omitempty"`
 
-	// raw json policy string that was applied to the ngrok API
+	// Policy is the raw json policy string that was applied to the ngrok API
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Type=object

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -47,7 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v6"
 
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.3.1
 	github.com/imdario/mergo v0.3.16
-	github.com/ngrok/ngrok-api-go/v5 v5.4.1
 	github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241025160627-dcdb6f5b23f8
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
-github.com/ngrok/ngrok-api-go/v5 v5.4.1 h1:rjofyT5M4pi3PtobyNy+3RMhq2uUaKuqsP34IwXRE28=
-github.com/ngrok/ngrok-api-go/v5 v5.4.1/go.mod h1:UVTaHI5B4gEsfHCOZTlRg8WkT6+KBijIkVtjpDqCyIU=
 github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241025160627-dcdb6f5b23f8 h1:HHfIX3/eXsnxwSxXpLJFSUO5sXWwxdNIkWVMsQd5f7o=
 github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241025160627-dcdb6f5b23f8/go.mod h1:KtRxWqEomaHZfgeS+q/7nFHF+gPYFghS5wTl5AIUjIk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/helm/ngrok-operator/templates/crds/ingress.k8s.ngrok.com_httpsedges.yaml
+++ b/helm/ngrok-operator/templates/crds/ingress.k8s.ngrok.com_httpsedges.yaml
@@ -919,8 +919,8 @@ spec:
                           type: array
                       type: object
                     policy:
-                      description: raw json policy string that was applied to the
-                        ngrok API
+                      description: TrafficPolicy is the raw json policy string that
+                        was applied to the ngrok API
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     saml:

--- a/helm/ngrok-operator/templates/crds/ingress.k8s.ngrok.com_ngrokmodulesets.yaml
+++ b/helm/ngrok-operator/templates/crds/ingress.k8s.ngrok.com_ngrokmodulesets.yaml
@@ -848,7 +848,8 @@ spec:
                     type: array
                 type: object
               policy:
-                description: Policy configuration for this module set
+                description: Policy module is deprecated, use the `NgrokTrafficPolicy`
+                  CRD or the Gateway API instead
                 properties:
                   enabled:
                     description: Determines if the rule will be applied to traffic

--- a/helm/ngrok-operator/templates/crds/ingress.k8s.ngrok.com_tcpedges.yaml
+++ b/helm/ngrok-operator/templates/crds/ingress.k8s.ngrok.com_tcpedges.yaml
@@ -96,8 +96,8 @@ spec:
                   the object in the ngrok API/Dashboard
                 type: string
               policy:
-                description: raw json policy string that was applied to the ngrok
-                  API
+                description: Policy is the raw json policy string that was applied
+                  to the ngrok API
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
             type: object

--- a/helm/ngrok-operator/templates/crds/ingress.k8s.ngrok.com_tlsedges.yaml
+++ b/helm/ngrok-operator/templates/crds/ingress.k8s.ngrok.com_tlsedges.yaml
@@ -111,8 +111,8 @@ spec:
                     type: array
                 type: object
               policy:
-                description: raw json policy string that was applied to the ngrok
-                  API
+                description: Policy is the raw json policy string that was applied
+                  to the ngrok API
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               tlsTermination:

--- a/internal/controller/base_controller.go
+++ b/internal/controller/base_controller.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v6"
 	"github.com/ngrok/ngrok-operator/internal/util"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"

--- a/internal/controller/ingress/domain_controller.go
+++ b/internal/controller/ingress/domain_controller.go
@@ -37,8 +37,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v5"
-	"github.com/ngrok/ngrok-api-go/v5/reserved_domains"
+	"github.com/ngrok/ngrok-api-go/v6"
+	"github.com/ngrok/ngrok-api-go/v6/reserved_domains"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
 )

--- a/internal/controller/ingress/httpsedge_controller_test.go
+++ b/internal/controller/ingress/httpsedge_controller_test.go
@@ -3,7 +3,7 @@ package ingress
 import (
 	"testing"
 
-	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v6"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/internal/controller/ingress/ippolicy_controller.go
+++ b/internal/controller/ingress/ippolicy_controller.go
@@ -36,9 +36,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v5"
-	"github.com/ngrok/ngrok-api-go/v5/ip_policies"
-	"github.com/ngrok/ngrok-api-go/v5/ip_policy_rules"
+	"github.com/ngrok/ngrok-api-go/v6"
+	"github.com/ngrok/ngrok-api-go/v6/ip_policies"
+	"github.com/ngrok/ngrok-api-go/v6/ip_policy_rules"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
 )

--- a/internal/controller/ingress/ippolicy_controllers_test.go
+++ b/internal/controller/ingress/ippolicy_controllers_test.go
@@ -3,7 +3,7 @@ package ingress
 import (
 	"testing"
 
-	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v6"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"

--- a/internal/controller/ingress/tcpedge_controller.go
+++ b/internal/controller/ingress/tcpedge_controller.go
@@ -32,6 +32,7 @@ import (
 
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -42,10 +43,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v6"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
+	"github.com/ngrok/ngrok-operator/internal/events"
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
+	"github.com/ngrok/ngrok-operator/internal/util"
 )
 
 // TCPEdgeReconciler reconciles a TCPEdge object
@@ -451,14 +454,14 @@ func (r *TCPEdgeReconciler) listTCPEdgesForIPPolicy(ctx context.Context, obj cli
 func (r *TCPEdgeReconciler) updatePolicyModule(ctx context.Context, edge *ingressv1alpha1.TCPEdge, remoteEdge *ngrok.TCPEdge) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	policy := edge.Spec.Policy
-	client := r.NgrokClientset.EdgeModules().TCP().RawPolicy()
+	client := r.NgrokClientset.EdgeModules().TCP().TrafficPolicy()
+
+	trafficPolicy := edge.Spec.Policy
 
 	// Early return if nothing to be done
-	if policy == nil {
-		if remoteEdge.Policy == nil {
-			log.Info("Module matches desired state, skipping update", "module", "Policy", "comparison", routeModuleComparisonBothNil)
-
+	if trafficPolicy == nil {
+		if remoteEdge.TrafficPolicy == nil {
+			log.Info("Module matches desired state, skipping update", "module", "Traffic Policy", "comparison", routeModuleComparisonBothNil)
 			return nil
 		}
 
@@ -466,11 +469,36 @@ func (r *TCPEdgeReconciler) updatePolicyModule(ctx context.Context, edge *ingres
 		return client.Delete(ctx, edge.Status.ID)
 	}
 
-	log.Info("Updating Policy module")
-	_, err := client.Replace(ctx, &ngrokapi.EdgeRawTCPPolicyReplace{
-		ID:     remoteEdge.ID,
-		Module: policy,
+	parsedTrafficPolicy, err := util.NewTrafficPolicyFromJson(trafficPolicy)
+	if err != nil {
+		r.Recorder.Eventf(edge, v1.EventTypeWarning, events.TrafficPolicyParseFailed, "Failed to parse Traffic Policy, possibly malformed.")
+		return err
+	}
+
+	if parsedTrafficPolicy.IsLegacyPolicy() {
+		r.Recorder.Eventf(edge, v1.EventTypeWarning, events.PolicyDeprecation, "Traffic Policy is using legacy directions: ['inbound', 'outbound']. Update to new phases: ['on_tcp_connect', 'on_http_request', 'on_http_response']")
+	}
+
+	if parsedTrafficPolicy.Enabled() != nil {
+		r.Recorder.Eventf(edge, v1.EventTypeWarning, events.PolicyDeprecation, "Traffic Policy has 'enabled' set. This is a legacy option that will stop being supported soon.")
+	}
+
+	apiTrafficPolicy, err := parsedTrafficPolicy.ToAPIJson()
+	if err != nil {
+		return err
+	}
+
+	r.Recorder.Eventf(edge, v1.EventTypeNormal, "Update", "Updating Traffic Policy on edge.")
+	_, err = client.Replace(ctx, &ngrok.EdgeTrafficPolicyReplace{
+		ID: remoteEdge.ID,
+		Module: ngrok.EndpointTrafficPolicy{
+			Enabled: parsedTrafficPolicy.Enabled(),
+			Value:   string(apiTrafficPolicy),
+		},
 	})
+	if err == nil {
+		r.Recorder.Eventf(edge, v1.EventTypeNormal, "Update", "Traffic Policy successfully updated.")
+	}
 
 	return err
 }

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -1,0 +1,31 @@
+/*
+MIT License
+
+Copyright (c) 2024 ngrok, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package events
+
+// Policy/Traffic Policy event reason list
+const (
+	PolicyDeprecation        = "PolicyDeprecation"
+	TrafficPolicyParseFailed = "TrafficPolicyParseFailed"
+)

--- a/internal/ngrokapi/clientset.go
+++ b/internal/ngrokapi/clientset.go
@@ -1,18 +1,17 @@
 package ngrokapi
 
 import (
-	"github.com/ngrok/ngrok-api-go/v5"
-	tunnel_group_backends "github.com/ngrok/ngrok-api-go/v5/backends/tunnel_group"
-	https_edges "github.com/ngrok/ngrok-api-go/v5/edges/https"
-	https_edge_routes "github.com/ngrok/ngrok-api-go/v5/edges/https_routes"
-	tcp_edges "github.com/ngrok/ngrok-api-go/v5/edges/tcp"
-	tls_edges "github.com/ngrok/ngrok-api-go/v5/edges/tls"
-	"github.com/ngrok/ngrok-api-go/v5/ip_policies"
-	"github.com/ngrok/ngrok-api-go/v5/ip_policy_rules"
-	"github.com/ngrok/ngrok-api-go/v5/reserved_addrs"
-	"github.com/ngrok/ngrok-api-go/v5/reserved_domains"
-	v6 "github.com/ngrok/ngrok-api-go/v6"
+	"github.com/ngrok/ngrok-api-go/v6"
+	tunnel_group_backends "github.com/ngrok/ngrok-api-go/v6/backends/tunnel_group"
+	https_edges "github.com/ngrok/ngrok-api-go/v6/edges/https"
+	https_edge_routes "github.com/ngrok/ngrok-api-go/v6/edges/https_routes"
+	tcp_edges "github.com/ngrok/ngrok-api-go/v6/edges/tcp"
+	tls_edges "github.com/ngrok/ngrok-api-go/v6/edges/tls"
+	"github.com/ngrok/ngrok-api-go/v6/ip_policies"
+	"github.com/ngrok/ngrok-api-go/v6/ip_policy_rules"
 	"github.com/ngrok/ngrok-api-go/v6/kubernetes_operators"
+	"github.com/ngrok/ngrok-api-go/v6/reserved_addrs"
+	"github.com/ngrok/ngrok-api-go/v6/reserved_domains"
 )
 
 type Clientset interface {
@@ -45,12 +44,6 @@ type DefaultClientset struct {
 
 // NewClientSet creates a new ClientSet from an ngrok client config.
 func NewClientSet(config *ngrok.ClientConfig) *DefaultClientset {
-	v6Config := &v6.ClientConfig{
-		APIKey:     config.APIKey,
-		BaseURL:    config.BaseURL,
-		HTTPClient: config.HTTPClient,
-		UserAgent:  config.UserAgent,
-	}
 	return &DefaultClientset{
 		domainsClient:             reserved_domains.NewClient(config),
 		edgeModulesClientset:      newEdgeModulesClientset(config),
@@ -58,7 +51,7 @@ func NewClientSet(config *ngrok.ClientConfig) *DefaultClientset {
 		httpsEdgeRoutesClient:     https_edge_routes.NewClient(config),
 		ipPoliciesClient:          ip_policies.NewClient(config),
 		ipPolicyRulesClient:       ip_policy_rules.NewClient(config),
-		kubernetesOperatorsClient: kubernetes_operators.NewClient(v6Config),
+		kubernetesOperatorsClient: kubernetes_operators.NewClient(config),
 		tcpAddrsClient:            reserved_addrs.NewClient(config),
 		tcpEdgesClient:            tcp_edges.NewClient(config),
 		tlsEdgesClient:            tls_edges.NewClient(config),

--- a/internal/ngrokapi/clientset_test.go
+++ b/internal/ngrokapi/clientset_test.go
@@ -3,7 +3,7 @@ package ngrokapi
 import (
 	"testing"
 
-	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v6"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/ngrokapi/edge_modules_clientset.go
+++ b/internal/ngrokapi/edge_modules_clientset.go
@@ -1,6 +1,6 @@
 package ngrokapi
 
-import "github.com/ngrok/ngrok-api-go/v5"
+import "github.com/ngrok/ngrok-api-go/v6"
 
 type EdgeModulesClientset interface {
 	TCP() TCPEdgeModulesClientset

--- a/internal/ngrokapi/edge_modules_tcp_clientset.go
+++ b/internal/ngrokapi/edge_modules_tcp_clientset.go
@@ -1,82 +1,29 @@
 package ngrokapi
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
-	"net/url"
-	"text/template"
-
-	"github.com/ngrok/ngrok-api-go/v5"
-	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tcp_edge_backend"
-	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tcp_edge_ip_restriction"
-	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tcp_edge_policy"
+	"github.com/ngrok/ngrok-api-go/v6"
+	"github.com/ngrok/ngrok-api-go/v6/edge_modules/tcp_edge_backend"
+	"github.com/ngrok/ngrok-api-go/v6/edge_modules/tcp_edge_ip_restriction"
+	"github.com/ngrok/ngrok-api-go/v6/edge_modules/tcp_edge_traffic_policy"
 )
-
-type EdgeRawTCPPolicyReplace struct {
-	ID     string          `json:"id,omitempty"`
-	Module json.RawMessage `json:"module,omitempty"`
-}
-
-type RawTCPEdgePolicyClient interface {
-	Delete(context.Context, string) error
-	Replace(context.Context, EdgeRawTCPPolicyReplace) (*json.RawMessage, error)
-}
-type rawTCPPolicyClient struct {
-	base   *ngrok.BaseClient
-	policy *tcp_edge_policy.Client
-}
-
-func newRawTCPPolicyClient(config *ngrok.ClientConfig) *rawTCPPolicyClient {
-	return &rawTCPPolicyClient{
-		base:   ngrok.NewBaseClient(config),
-		policy: tcp_edge_policy.NewClient(config),
-	}
-}
-
-func (c *rawTCPPolicyClient) Delete(ctx context.Context, id string) error {
-	return c.policy.Delete(ctx, id)
-}
-
-func (c *rawTCPPolicyClient) Replace(ctx context.Context, policy *EdgeRawTCPPolicyReplace) (*json.RawMessage, error) {
-	if policy == nil {
-		return nil, errors.New("tcp edge policy replace cannot be nil")
-	}
-	var path bytes.Buffer
-	if err := template.Must(template.New("replace_path").Parse("/edges/tcp/{{ .ID }}/policy")).Execute(&path, policy); err != nil {
-		// api client panics on error also
-		panic(err)
-	}
-	var res json.RawMessage
-	apiURL := &url.URL{Path: path.String()}
-
-	if err := c.base.Do(ctx, "PUT", apiURL, policy.Module, &res); err != nil {
-		return nil, err
-	}
-	return &res, nil
-}
 
 type TCPEdgeModulesClientset interface {
 	Backend() *tcp_edge_backend.Client
 	IPRestriction() *tcp_edge_ip_restriction.Client
-	Policy() *tcp_edge_policy.Client
-	RawPolicy() *rawTCPPolicyClient
+	TrafficPolicy() *tcp_edge_traffic_policy.Client
 }
 
 type defaultTCPEdgeModulesClientset struct {
 	backend       *tcp_edge_backend.Client
 	ipRestriction *tcp_edge_ip_restriction.Client
-	policy        *tcp_edge_policy.Client
-	rawPolicy     *rawTCPPolicyClient
+	trafficPolicy *tcp_edge_traffic_policy.Client
 }
 
 func newTCPEdgeModulesClientset(config *ngrok.ClientConfig) *defaultTCPEdgeModulesClientset {
 	return &defaultTCPEdgeModulesClientset{
 		backend:       tcp_edge_backend.NewClient(config),
 		ipRestriction: tcp_edge_ip_restriction.NewClient(config),
-		policy:        tcp_edge_policy.NewClient(config),
-		rawPolicy:     newRawTCPPolicyClient(config),
+		trafficPolicy: tcp_edge_traffic_policy.NewClient(config),
 	}
 }
 
@@ -88,10 +35,6 @@ func (c *defaultTCPEdgeModulesClientset) IPRestriction() *tcp_edge_ip_restrictio
 	return c.ipRestriction
 }
 
-func (c *defaultTCPEdgeModulesClientset) Policy() *tcp_edge_policy.Client {
-	return c.policy
-}
-
-func (c *defaultTCPEdgeModulesClientset) RawPolicy() *rawTCPPolicyClient {
-	return c.rawPolicy
+func (c *defaultTCPEdgeModulesClientset) TrafficPolicy() *tcp_edge_traffic_policy.Client {
+	return c.trafficPolicy
 }

--- a/internal/ngrokapi/edge_modules_tls_clientset.go
+++ b/internal/ngrokapi/edge_modules_tls_clientset.go
@@ -1,70 +1,20 @@
 package ngrokapi
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
-	"net/url"
-	"text/template"
-
-	"github.com/ngrok/ngrok-api-go/v5"
-	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tls_edge_backend"
-	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tls_edge_ip_restriction"
-	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tls_edge_mutual_tls"
-	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tls_edge_policy"
-	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tls_edge_tls_termination"
+	"github.com/ngrok/ngrok-api-go/v6"
+	"github.com/ngrok/ngrok-api-go/v6/edge_modules/tls_edge_backend"
+	"github.com/ngrok/ngrok-api-go/v6/edge_modules/tls_edge_ip_restriction"
+	"github.com/ngrok/ngrok-api-go/v6/edge_modules/tls_edge_mutual_tls"
+	"github.com/ngrok/ngrok-api-go/v6/edge_modules/tls_edge_tls_termination"
+	"github.com/ngrok/ngrok-api-go/v6/edge_modules/tls_edge_traffic_policy"
 )
-
-type EdgeRawTLSPolicyReplace struct {
-	ID     string          `json:"id,omitempty"`
-	Module json.RawMessage `json:"module,omitempty"`
-}
-
-type RawTLSEdgePolicyClient interface {
-	Delete(context.Context, string) error
-	Replace(context.Context, EdgeRawTLSPolicyReplace) (*json.RawMessage, error)
-}
-type rawTLSPolicyClient struct {
-	base   *ngrok.BaseClient
-	policy *tls_edge_policy.Client
-}
-
-func newRawTLSPolicyClient(config *ngrok.ClientConfig) *rawTLSPolicyClient {
-	return &rawTLSPolicyClient{
-		base:   ngrok.NewBaseClient(config),
-		policy: tls_edge_policy.NewClient(config),
-	}
-}
-func (c *rawTLSPolicyClient) Delete(ctx context.Context, id string) error {
-	return c.policy.Delete(ctx, id)
-}
-
-func (c *rawTLSPolicyClient) Replace(ctx context.Context, policy *EdgeRawTLSPolicyReplace) (*json.RawMessage, error) {
-	if policy == nil {
-		return nil, errors.New("tls edge policy replace cannot be nil")
-	}
-	var path bytes.Buffer
-	if err := template.Must(template.New("replace_path").Parse("/edges/tls/{{ .ID }}/policy")).Execute(&path, policy); err != nil {
-		// api client panics on error also
-		panic(err)
-	}
-	var res json.RawMessage
-	apiURL := &url.URL{Path: path.String()}
-
-	if err := c.base.Do(ctx, "PUT", apiURL, policy.Module, &res); err != nil {
-		return nil, err
-	}
-	return &res, nil
-}
 
 type TLSEdgeModulesClientset interface {
 	Backend() *tls_edge_backend.Client
 	IPRestriction() *tls_edge_ip_restriction.Client
 	MutualTLS() *tls_edge_mutual_tls.Client
 	TLSTermination() *tls_edge_tls_termination.Client
-	Policy() *tls_edge_policy.Client
-	RawPolicy() *rawTLSPolicyClient
+	TrafficPolicy() *tls_edge_traffic_policy.Client
 }
 
 type defaultTLSEdgeModulesClientset struct {
@@ -72,8 +22,7 @@ type defaultTLSEdgeModulesClientset struct {
 	ipRestriction  *tls_edge_ip_restriction.Client
 	mutualTLS      *tls_edge_mutual_tls.Client
 	tlsTermination *tls_edge_tls_termination.Client
-	policy         *tls_edge_policy.Client
-	rawPolicy      *rawTLSPolicyClient
+	trafficPolicy  *tls_edge_traffic_policy.Client
 }
 
 func newTLSEdgeModulesClientset(config *ngrok.ClientConfig) *defaultTLSEdgeModulesClientset {
@@ -82,8 +31,7 @@ func newTLSEdgeModulesClientset(config *ngrok.ClientConfig) *defaultTLSEdgeModul
 		ipRestriction:  tls_edge_ip_restriction.NewClient(config),
 		mutualTLS:      tls_edge_mutual_tls.NewClient(config),
 		tlsTermination: tls_edge_tls_termination.NewClient(config),
-		policy:         tls_edge_policy.NewClient(config),
-		rawPolicy:      newRawTLSPolicyClient(config),
+		trafficPolicy:  tls_edge_traffic_policy.NewClient(config),
 	}
 }
 
@@ -103,10 +51,6 @@ func (c *defaultTLSEdgeModulesClientset) TLSTermination() *tls_edge_tls_terminat
 	return c.tlsTermination
 }
 
-func (c *defaultTLSEdgeModulesClientset) Policy() *tls_edge_policy.Client {
-	return c.policy
-}
-
-func (c *defaultTLSEdgeModulesClientset) RawPolicy() *rawTLSPolicyClient {
-	return c.rawPolicy
+func (c *defaultTLSEdgeModulesClientset) TrafficPolicy() *tls_edge_traffic_policy.Client {
+	return c.trafficPolicy
 }

--- a/internal/store/driver_test.go
+++ b/internal/store/driver_test.go
@@ -3,10 +3,14 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"testing"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,6 +24,7 @@ import (
 
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
+	"github.com/ngrok/ngrok-operator/internal/util"
 )
 
 const defaultManagerName = "ngrok-ingress-controller"
@@ -463,28 +468,39 @@ var _ = Describe("Driver", func() {
 		var rule *gatewayv1.HTTPRouteRule
 		var namespace string
 		var policyCrd *ngrokv1alpha1.NgrokTrafficPolicy
+		var legacyPolicyCrd *ngrokv1alpha1.NgrokTrafficPolicy
 
 		BeforeEach(func() {
 			rule = &gatewayv1.HTTPRouteRule{}
 			namespace = "test"
+
 			policyCrd = &ngrokv1alpha1.NgrokTrafficPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-policy",
 					Namespace: namespace,
 				},
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
-					Policy: []byte(`{"inbound": [{"name":"t","actions":[{"type":"deny"}]}], "outbound": []}`),
+					Policy: []byte(`{"on_http_request": [{"name":"t","actions":[{"type":"deny"}]}]}`),
 				},
 			}
 			Expect(driver.store.Add(policyCrd)).To(BeNil())
+
+			legacyPolicyCrd = &ngrokv1alpha1.NgrokTrafficPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "legacy-test-policy",
+					Namespace: namespace,
+				},
+				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
+					Policy: []byte(`{"inbound": [{"name":"t","actions":[{"type":"deny"}]}], "outbound": []}`),
+				},
+			}
+			Expect(driver.store.Add(legacyPolicyCrd)).To(BeNil())
 		})
 
 		It("Should return an empty policy if the rule has nothing in it", func() {
 			policy, err := driver.createEndpointPolicyForGateway(rule, namespace)
 			Expect(err).To(BeNil())
 			Expect(policy).ToNot(BeNil())
-			Expect(len(policy.Inbound)).To(BeZero())
-			Expect(len(policy.Outbound)).To(BeZero())
 		})
 
 		It("Should return a merged policy if there rules with extensionRef", func() {
@@ -523,7 +539,7 @@ var _ = Describe("Driver", func() {
 				},
 			}
 
-			expectedPolicy := `{"enabled":true,"inbound":[{"actions":[{"type":"add-headers","config":{"headers":{"test-header":"test-value"}}}],"name":"Inbound HTTPRouteRule 1"},{"actions":[{"type":"deny"}],"name":"t"},{"actions":[{"type":"add-headers","config":{"headers":{"Host":"test-hostname.com"}}}],"name":"Inbound HTTPRouteRule 2"}]}`
+			expectedPolicy := `{"on_http_request":[{"name":"Inbound HTTPRouteRule 1","actions":[{"type":"add-headers","config":{"headers":{"test-header":"test-value"}}}]},{"actions":[{"type":"deny"}],"name":"t"},{"name":"Inbound HTTPRouteRule 2","actions":[{"type":"add-headers","config":{"headers":{"Host":"test-hostname.com"}}}]}]}`
 
 			policy, err := driver.createEndpointPolicyForGateway(rule, namespace)
 			Expect(err).To(BeNil())
@@ -531,9 +547,53 @@ var _ = Describe("Driver", func() {
 
 			jsonString, err := json.Marshal(policy)
 			Expect(err).To(BeNil())
+			Expect(string(jsonString)).To(Equal(expectedPolicy))
+		})
 
-			Expect(len(policy.Inbound) == 3).To(BeTrue())
-			Expect(len(policy.Outbound)).To(BeZero())
+		It("Should return a merged policy if there rules with extensionRef, legacy policy is remapped", func() {
+			hostname := gatewayv1.PreciseHostname("test-hostname.com")
+			replacePrefixMatch := "/paprika"
+
+			rule.Filters = []gatewayv1.HTTPRouteFilter{
+				{
+					Type: "RequestHeaderModifier",
+					RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+						Add: []gatewayv1.HTTPHeader{
+							{
+								Name:  "test-header",
+								Value: "test-value",
+							},
+						},
+					},
+				},
+				{
+					Type: "ExtensionRef",
+					ExtensionRef: &gatewayv1.LocalObjectReference{
+						Name:  "legacy-test-policy",
+						Kind:  "NgrokTrafficPolicy",
+						Group: "ngrok.k8s.ngrok.com",
+					},
+				},
+				{
+					Type: "URLRewrite",
+					URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+						Hostname: &hostname,
+						Path: &gatewayv1.HTTPPathModifier{
+							Type:               "ReplacePrefixMatch",
+							ReplacePrefixMatch: &replacePrefixMatch,
+						},
+					},
+				},
+			}
+
+			expectedPolicy := `{"on_http_request":[{"name":"Inbound HTTPRouteRule 1","actions":[{"type":"add-headers","config":{"headers":{"test-header":"test-value"}}}]},{"actions":[{"type":"deny"}],"name":"t"},{"name":"Inbound HTTPRouteRule 2","actions":[{"type":"add-headers","config":{"headers":{"Host":"test-hostname.com"}}}]}]}`
+
+			policy, err := driver.createEndpointPolicyForGateway(rule, namespace)
+			Expect(err).To(BeNil())
+			Expect(policy).ToNot(BeNil())
+
+			jsonString, err := json.Marshal(policy)
+			Expect(err).To(BeNil())
 			Expect(string(jsonString)).To(Equal(expectedPolicy))
 		})
 	})
@@ -603,3 +663,75 @@ var _ = Describe("Driver", func() {
 		})
 	})
 })
+
+func TestExtractPolicy(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                  string
+		msg                   json.RawMessage
+		expectedTrafficPolicy map[string][]util.RawRule
+		expectedErr           error
+	}{
+		{
+			name: "legacy policy configuration",
+			msg:  []byte(`{"inbound":[{"name":"test-inbound","actions":[{"type":"deny"}]}],"outbound":[{"name":"test-outbound","actions":[{"type":"some-action"}]}]}`),
+			expectedTrafficPolicy: map[string][]util.RawRule{
+				util.PhaseOnHttpRequest: {
+					[]byte(`{"actions":[{"type":"deny"}],"name":"test-inbound"}`),
+				},
+				util.PhaseOnHttpResponse: {
+					[]byte(`{"actions":[{"type":"some-action"}],"name":"test-outbound"}`),
+				},
+			},
+		},
+		{
+			name: "phase-based policy config",
+			msg:  []byte(`{"on_http_request":[{"name":"test-inbound","actions":[{"type":"deny"}]}],"on_http_response":[{"name":"test-outbound","actions":[{"type":"some-action"}]}]}`),
+			expectedTrafficPolicy: map[string][]util.RawRule{
+				util.PhaseOnHttpRequest: {
+					[]byte(`{"actions":[{"type":"deny"}],"name":"test-inbound"}`),
+				},
+				util.PhaseOnHttpResponse: {
+					[]byte(`{"actions":[{"type":"some-action"}],"name":"test-outbound"}`),
+				},
+			},
+		},
+		{
+			name:        "invalid json message",
+			msg:         []byte(`ngrok operates a global network where it accepts traffic to your upstream services from clients.`),
+			expectedErr: fmt.Errorf("invalid character 'g' in literal null (expecting 'u')"),
+		},
+		{
+			name:        "empty json message",
+			msg:         []byte(""),
+			expectedErr: fmt.Errorf("unexpected end of JSON input"),
+		},
+		{
+			name:        "nil json message",
+			expectedErr: fmt.Errorf("unexpected end of JSON input"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			trafficPolicy, err := extractPolicy(tc.msg)
+
+			if tc.expectedTrafficPolicy == nil {
+				assert.Nil(t, trafficPolicy)
+			} else {
+				assert.Equal(t, tc.expectedTrafficPolicy, trafficPolicy.Deconstruct())
+			}
+
+			if tc.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				// Can't compare the exact error as we don't have access to json SyntaxError underlying `msg` field`
+				assert.Equal(t, tc.expectedErr.Error(), err.Error())
+			}
+		})
+	}
+}

--- a/internal/util/traffic_policy.go
+++ b/internal/util/traffic_policy.go
@@ -1,0 +1,278 @@
+package util
+
+import (
+	"encoding/json"
+)
+
+const (
+	PhaseOnHttpRequest  = "on_http_request"
+	PhaseOnHttpResponse = "on_http_response"
+
+	LegacyPhaseInbound  = "inbound"
+	LegacyPhaseOutbound = "outbound"
+
+	// backwardsCompatEnabledKey exists because previous implementations would store this value in the CRD and might exist
+	// in traffic policy JSON.
+	backwardsCompatEnabledKey = "enabled"
+)
+
+// These types are different than the v1alpha1 types because:
+//    1. These are more generic types, allowing "generated" policy to more easily interact with unstructured user-provided policy.
+//    2. Gateway code is now decoupled from module code, which is now deprecated.
+
+type Actions struct {
+	EndpointActions []RawAction
+}
+
+type EndpointAction struct {
+	Type   string    `json:"type"`
+	Config RawConfig `json:"config"`
+}
+
+type EndpointRule struct {
+	Name    string      `json:"name"`
+	Actions []RawAction `json:"actions"`
+}
+
+// RawRule exists to make generic raw json/map manipulation more legible. It adds no additional functionality on top of RawMessage.
+type RawRule = json.RawMessage
+
+// RawAction exists to make generic raw json/map manipulation more legible. It adds no additional functionality on top of RawMessage.
+type RawAction = json.RawMessage
+
+// RawConfig exists to make generic raw json/map manipulation more legible. It adds no additional functionality on top of RawMessage.
+type RawConfig = json.RawMessage
+
+type TrafficPolicy interface {
+	// Merge takes another instance of TrafficPolicy and merges them.
+	Merge(TrafficPolicy)
+	// MergeRawRule merges the rule into the list of existing rules in the specified phase.
+	MergeEndpointRule(rule EndpointRule, phase string) error
+	// Deconstruct must be implemented such that two differing underlying implementations can be represented as the same
+	// format during merges.
+	Deconstruct() map[string][]RawRule
+	// ToCRDJson returns a raw json version of the underlying traffic policy document to be saved to an Edge CRD.
+	ToCRDJson() (json.RawMessage, error)
+	// ToAPIJson() returns a raw json version of the underlying traffic policy document to be sent to the backend API.
+	ToAPIJson() (json.RawMessage, error)
+	// IsLegacyPolicy determines if the specified policy contains legacy phases.
+	IsLegacyPolicy() bool
+	// Enabled returns the value if it was present in a traffic policy document, nil if not.
+	Enabled() *bool
+	// ConvertLegacyPhases explicitly maps old phases to new phases. This doesn't guarantee in a resulting "valid" phase set,
+	// so users will need to check the implementation used for this interface.
+	ConvertLegacyDirectionsToPhases()
+}
+
+func NewTrafficPolicy() TrafficPolicy {
+	return &trafficPolicyImpl{
+		trafficPolicy: map[string][]RawRule{},
+	}
+}
+
+func NewTrafficPolicyFromJson(msg json.RawMessage) (TrafficPolicy, error) {
+	strippedMsg, enabled, err := filterEnabled(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	var trafficPolicy map[string][]RawRule
+	if err := json.Unmarshal(strippedMsg, &trafficPolicy); err != nil {
+		return nil, err
+	}
+
+	return &trafficPolicyImpl{
+		trafficPolicy: trafficPolicy,
+		enabled:       enabled,
+	}, nil
+}
+
+type trafficPolicyImpl struct {
+	trafficPolicy map[string][]RawRule
+	enabled       *bool
+}
+
+// MergeEndpointRule marshals the rule, then merges it into the correct phase within the traffic policy document.
+func (t *trafficPolicyImpl) MergeEndpointRule(rule EndpointRule, phase string) error {
+	rawRule, err := json.Marshal(&rule)
+	if err != nil {
+		return err
+	}
+
+	mergeSinglePhase(t.trafficPolicy, []RawRule{rawRule}, phase)
+
+	return nil
+}
+
+func (t *trafficPolicyImpl) Deconstruct() map[string][]json.RawMessage {
+	return t.trafficPolicy
+}
+
+// Merge merges addedTP traffic policy into that of the receivers traffic policy. If a phase from the incoming traffic policy
+// already exists in the original, the associated rules are appended. If not, the phase is added to the original traffic
+// policy.
+func (t *trafficPolicyImpl) Merge(addedTP TrafficPolicy) {
+	t.mergeEnabled(addedTP.Enabled())
+
+	deconAddedTP := addedTP.Deconstruct()
+	originalTP := t.trafficPolicy
+
+	for phase, rules := range deconAddedTP {
+		mergeSinglePhase(originalTP, rules, phase)
+	}
+}
+
+// ToCRDJson creates a json from the traffic policy, but embeds the "enabled" field at the top level. This is necessary
+// for backwards compatability where we let users set this.
+func (t *trafficPolicyImpl) ToCRDJson() (json.RawMessage, error) {
+	// no special processing needed if enabled wasn't set.
+	if t.enabled == nil {
+		return t.ToAPIJson()
+	}
+
+	output := map[string]any{}
+
+	output[backwardsCompatEnabledKey] = *t.enabled
+
+	for k, v := range t.trafficPolicy {
+		output[k] = v
+	}
+
+	return json.Marshal(&output)
+}
+
+// ToCRDJson creates a json blob that is compatible with the `traffic_policy` API. This should be used when sending traffic
+// policy to the backend. Unlike ToCRDJson, this does not embed "enabled" data.
+func (t *trafficPolicyImpl) ToAPIJson() (json.RawMessage, error) {
+	tp := t.trafficPolicy
+
+	return json.Marshal(&tp)
+}
+
+// IsLegacyPolicy determines if the configured policy matches the old inbound/outbound format as opposed to the
+// current phase-based format.
+func (t *trafficPolicyImpl) IsLegacyPolicy() bool {
+	if t.trafficPolicy == nil {
+		return false
+	}
+
+	if _, ok := t.trafficPolicy[LegacyPhaseInbound]; ok {
+		return true
+	}
+
+	if _, ok := t.trafficPolicy[LegacyPhaseOutbound]; ok {
+		return true
+	}
+
+	return false
+}
+
+func (t *trafficPolicyImpl) Enabled() *bool {
+	return t.enabled
+}
+
+// ConvertLegacyDirectionsToPhases converts inbound to on_http_request and outbound to on_http_response. This conversion is
+// only necessary for the Gateway API, which only supported HTTP when inbound/outbound were valid. If the new phases already
+// exist in the traffic policy, the rules are merged into that phase.
+func (t *trafficPolicyImpl) ConvertLegacyDirectionsToPhases() {
+	if len(t.trafficPolicy) == 0 {
+		return
+	}
+
+	newMap := map[string][]RawRule{}
+
+	for k, v := range t.trafficPolicy {
+		switch k {
+		case LegacyPhaseInbound:
+			mergeSinglePhase(newMap, v, PhaseOnHttpRequest)
+		case LegacyPhaseOutbound:
+			mergeSinglePhase(newMap, v, PhaseOnHttpResponse)
+		default:
+			mergeSinglePhase(newMap, v, k)
+		}
+	}
+
+	t.trafficPolicy = newMap
+}
+
+// mergeEnabled applies the supplied "enabled" value to the traffic policy. If there is a value set for both,
+// we set to "false" is present in either.
+func (t *trafficPolicyImpl) mergeEnabled(incomingEnabled *bool) {
+	if incomingEnabled == nil {
+		return
+	}
+
+	// original traffic policy had no enabled set, take on new value
+	if t.enabled == nil {
+		// don't want to copy the pointer, as the value will still be linked to a different policy
+		temp := *incomingEnabled
+		t.enabled = &temp
+	}
+
+	// both being set likely won't happen. However, if we have a mismatch, we should keep it enabled. Otherwise,
+	// we might accidentally turn off something important like auth.
+	resolvedEnabled := *t.enabled || *incomingEnabled
+	t.enabled = &resolvedEnabled
+}
+
+// filterEnabled looks for a top level "enabled" in the json, removes it, and returns the value. For the module and gateway
+// configuration paths, this value may be present. We need to respect this value and also can't include it in the policy payload.
+//
+// If the "enabled" field is not present in the message, the message is returned unmodified.
+func filterEnabled(msg json.RawMessage) (json.RawMessage, *bool, error) {
+	if msg == nil {
+		return nil, nil, nil
+	}
+
+	var trafficPolicy map[string]any
+
+	if err := json.Unmarshal(msg, &trafficPolicy); err != nil {
+		return nil, nil, err
+	}
+
+	enabled, err := extractEnabledField(trafficPolicy)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rawTrafficPolicy, err := json.Marshal(trafficPolicy)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rawTrafficPolicy, enabled, nil
+}
+
+// extractEnabledField removes the "enabled" field from the map, if present. The value is returned provided the associated value
+// is a boolean.
+func extractEnabledField(trafficPolicy map[string]any) (*bool, error) {
+	if len(trafficPolicy) == 0 {
+		return nil, nil
+	}
+
+	if enabledSetVal, ok := trafficPolicy["enabled"]; ok {
+		delete(trafficPolicy, "enabled")
+		var setVal *bool
+		if enabled, ok := enabledSetVal.(bool); ok {
+			setVal = &enabled
+		}
+
+		return setVal, nil
+	}
+
+	return nil, nil
+}
+
+// mergeEndpointRule adds the rules to the specified phase. If the phase isn't already present, it's added.
+func mergeSinglePhase(originalTP map[string][]RawRule, addedRules []RawRule, phase string) {
+	if len(addedRules) == 0 {
+		return
+	}
+
+	if rules, ok := originalTP[phase]; ok {
+		originalTP[phase] = append(rules, addedRules...)
+		return
+	}
+
+	originalTP[phase] = addedRules
+}

--- a/internal/util/traffic_policy_test.go
+++ b/internal/util/traffic_policy_test.go
@@ -1,0 +1,591 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLegacyPolicy(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		trafficPolicy    map[string][]RawRule
+		expectedIsLegacy bool
+	}{
+		{
+			name: "has legacy inbound",
+			trafficPolicy: map[string][]RawRule{
+				LegacyPhaseInbound: nil,
+				"some-other-phase": nil,
+			},
+			expectedIsLegacy: true,
+		},
+		{
+			name: "has legacy outbound",
+			trafficPolicy: map[string][]RawRule{
+				LegacyPhaseOutbound: nil,
+				"some-other-phase":  nil,
+			},
+			expectedIsLegacy: true,
+		},
+		{
+			name: "has both legacy fields",
+			trafficPolicy: map[string][]RawRule{
+				LegacyPhaseOutbound: nil,
+				LegacyPhaseInbound:  nil,
+			},
+			expectedIsLegacy: true,
+		},
+		{
+			name: "has no legacy names anywhere",
+			trafficPolicy: map[string][]RawRule{
+				PhaseOnHttpRequest:  nil,
+				PhaseOnHttpResponse: nil,
+			},
+			expectedIsLegacy: false,
+		},
+		{
+			name: "had legacy name, not as top level key",
+			trafficPolicy: map[string][]RawRule{
+				PhaseOnHttpRequest:  {[]byte(LegacyPhaseOutbound), []byte(LegacyPhaseOutbound)},
+				PhaseOnHttpResponse: {[]byte(LegacyPhaseOutbound), []byte(LegacyPhaseOutbound)},
+			},
+			expectedIsLegacy: false,
+		},
+		{
+			name:             "nil map",
+			expectedIsLegacy: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tpImpl := trafficPolicyImpl{
+				trafficPolicy: tc.trafficPolicy,
+			}
+
+			assert.Equal(t, tc.expectedIsLegacy, tpImpl.IsLegacyPolicy())
+		})
+	}
+
+}
+
+func OldTestIsLegacyPolicy(t *testing.T) {
+	t.Helper()
+
+	_ = []struct {
+		name             string
+		msg              json.RawMessage
+		expectedIsLegacy bool
+	}{
+		{
+			name:             "json has top-level 'inbound' legacy keys",
+			msg:              []byte(`{"inbound":["some_val"], "on_http_request":[{"a": "b"}]}`),
+			expectedIsLegacy: true,
+		},
+		{
+			name:             "json has top-level 'outbound' legacy keys",
+			msg:              []byte(`{"top_level_key":["some_val"],"outbound":[{"eleven":"twelve"}]}`),
+			expectedIsLegacy: true,
+		},
+		{
+			name:             "json only has phase-based naming top-level keys",
+			msg:              []byte(`{"on_tcp_connect":"some_val","on_http_request":{"eleven":"twelve"},"on_http_response":"hello"}`),
+			expectedIsLegacy: false,
+		},
+		{
+			name:             "legacy key exists, but not at top level",
+			msg:              []byte(`{"on_tcp_connect":"inbound"}`),
+			expectedIsLegacy: false,
+		},
+	}
+
+}
+
+func TestConvertLegacyDirectionsToPhases(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name                  string
+		trafficPolicy         *trafficPolicyImpl
+		expectedTrafficPolicy map[string][]RawRule
+	}{
+		{
+			name: "has inbound and outbound legacy phases",
+			trafficPolicy: &trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{
+					LegacyPhaseInbound:  {[]byte(`from inbound`)},
+					LegacyPhaseOutbound: {[]byte(`from outbound`)},
+					"some-other-phase":  {[]byte(`my-phase`)},
+				},
+			},
+			expectedTrafficPolicy: map[string][]RawRule{
+				PhaseOnHttpRequest:  {[]byte(`from inbound`)},
+				PhaseOnHttpResponse: {[]byte(`from outbound`)},
+				"some-other-phase":  {[]byte(`my-phase`)},
+			},
+		},
+		{
+			name: "inbound and outbound merged into existing phases",
+			trafficPolicy: &trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{
+					LegacyPhaseInbound:  {[]byte(`from inbound`)},
+					LegacyPhaseOutbound: {[]byte(`from outbound`)},
+					PhaseOnHttpRequest:  {[]byte(PhaseOnHttpRequest)},
+					PhaseOnHttpResponse: {[]byte(PhaseOnHttpResponse)},
+				},
+			},
+			expectedTrafficPolicy: map[string][]RawRule{
+				PhaseOnHttpRequest:  {[]byte(`from inbound`), []byte(PhaseOnHttpRequest)},
+				PhaseOnHttpResponse: {[]byte(`from outbound`), []byte(PhaseOnHttpResponse)},
+			},
+		},
+		{
+			name: "had no legacy phases",
+			trafficPolicy: &trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{
+					PhaseOnHttpRequest:  {[]byte(PhaseOnHttpRequest)},
+					PhaseOnHttpResponse: {[]byte(PhaseOnHttpResponse)},
+				},
+			},
+			expectedTrafficPolicy: map[string][]RawRule{
+				PhaseOnHttpRequest:  {[]byte(PhaseOnHttpRequest)},
+				PhaseOnHttpResponse: {[]byte(PhaseOnHttpResponse)},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tc.trafficPolicy.ConvertLegacyDirectionsToPhases()
+
+			actualTrafficPolicy := tc.trafficPolicy.trafficPolicy
+			// the impl iterates over map keys, which is not deterministic. We need to test somewhat more manually here instead
+			// of directly comparing.
+			assert.Equal(t, len(tc.expectedTrafficPolicy), len(actualTrafficPolicy))
+			assert.ElementsMatch(t, tc.expectedTrafficPolicy[PhaseOnHttpRequest], actualTrafficPolicy[PhaseOnHttpRequest])
+			assert.ElementsMatch(t, tc.expectedTrafficPolicy[PhaseOnHttpResponse], actualTrafficPolicy[PhaseOnHttpResponse])
+		})
+	}
+}
+
+func TestToCRDJson(t *testing.T) {
+	t.Parallel()
+
+	trueVal := true
+
+	testCases := []struct {
+		name          string
+		trafficPolicy *trafficPolicyImpl
+		expectedJson  json.RawMessage
+		expectedErr   error
+	}{
+		{
+			name: "no enabled set, just trafficPolicy gets marshalled",
+			trafficPolicy: &trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{
+					PhaseOnHttpRequest: {[]byte(`{"a":"b"}`)},
+				},
+			},
+			expectedJson: []byte(`{"on_http_request":[{"a":"b"}]}`),
+		},
+		{
+			name: "enabled set, in json",
+			trafficPolicy: &trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{
+					PhaseOnHttpRequest: {[]byte(`{"a":"b"}`)},
+				},
+				enabled: &trueVal,
+			},
+			expectedJson: []byte(`{"enabled":true,"on_http_request":[{"a":"b"}]}`),
+		},
+		{
+			name: "invalid json",
+			trafficPolicy: &trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{
+					PhaseOnHttpRequest: {[]byte(`ngrok is built to deliver applications and APIs with  zero networking configuration and zero hardware`)},
+				},
+			},
+			expectedErr: fmt.Errorf(`json: error calling MarshalJSON for type json.RawMessage: invalid character 'g' in literal null (expecting 'u')`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			crdJson, err := tc.trafficPolicy.ToCRDJson()
+
+			assert.Equal(t, tc.expectedJson, crdJson)
+			if tc.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				// Can't compare the exact error as we don't have access to json SyntaxError underlying `msg` field`
+				assert.Equal(t, tc.expectedErr.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestFilterEnabled(t *testing.T) {
+	t.Parallel()
+
+	expectedTrue := true
+	expectedFalse := false
+
+	testCases := []struct {
+		name                  string
+		msg                   json.RawMessage
+		expectedReturnedMsg   json.RawMessage
+		expectedSetEnabledVal *bool
+		expectedErr           error
+	}{
+		{
+			name:                  "message has enabled in top level field (true)",
+			msg:                   []byte(`{"enabled":true,"on_tcp_connect":"some_val"}`),
+			expectedReturnedMsg:   []byte(`{"on_tcp_connect":"some_val"}`),
+			expectedSetEnabledVal: &expectedTrue,
+		},
+		{
+			name:                  "message has enabled in top level field (false)",
+			msg:                   []byte(`{"enabled":false,"on_tcp_connect":"some_val"}`),
+			expectedReturnedMsg:   []byte(`{"on_tcp_connect":"some_val"}`),
+			expectedSetEnabledVal: &expectedFalse,
+		},
+		{
+			name:                  "message is valid, enabled isn't present whatsoever",
+			msg:                   []byte(`{"on_tcp_connect":{"config":"yes"}}`),
+			expectedReturnedMsg:   []byte(`{"on_tcp_connect":{"config":"yes"}}`),
+			expectedSetEnabledVal: nil,
+			expectedErr:           nil,
+		},
+		{
+			name:                  "message is valid, enabled isn't top level",
+			msg:                   []byte(`{"on_tcp_connect":{"enabled":true}}`),
+			expectedReturnedMsg:   []byte(`{"on_tcp_connect":{"enabled":true}}`),
+			expectedSetEnabledVal: nil,
+			expectedErr:           nil,
+		},
+		{
+			name:                  "message is entirely invalid",
+			msg:                   []byte(`Industry leaders rely on ngrok`),
+			expectedReturnedMsg:   nil,
+			expectedSetEnabledVal: nil,
+			expectedErr:           fmt.Errorf("invalid character 'I' looking for beginning of value"),
+		},
+		{
+			name:                  "message is empty json",
+			msg:                   []byte(""),
+			expectedReturnedMsg:   nil,
+			expectedSetEnabledVal: nil,
+			expectedErr:           fmt.Errorf("unexpected end of JSON input"),
+		},
+		{
+			name:                  "message is nil",
+			msg:                   nil,
+			expectedReturnedMsg:   nil,
+			expectedSetEnabledVal: nil,
+			expectedErr:           nil,
+		},
+		{
+			name:                  "enabled present but doesn't map to anything meaningful",
+			msg:                   []byte(`{"enabled":"howdidthisgethere","on_http_request":{"config":"yes"}}`),
+			expectedReturnedMsg:   []byte(`{"on_http_request":{"config":"yes"}}`),
+			expectedSetEnabledVal: nil,
+			expectedErr:           nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			returnedMsg, setEnabledVal, err := filterEnabled(tc.msg)
+
+			assert.Equal(t, tc.expectedReturnedMsg, returnedMsg)
+			assert.Equal(t, tc.expectedSetEnabledVal, setEnabledVal)
+			if tc.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				// Can't compare the exact error as we don't have access to json SyntaxError underlying `msg` field`
+				assert.Equal(t, tc.expectedErr.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+
+	// used so we can get pointers to these values
+	trueVal := true
+	falseVal := false
+
+	testCases := []struct {
+		name                        string
+		addedTrafficPolicy          trafficPolicyImpl
+		baseTrafficPolicyEnabled    *bool
+		expectedMergedTrafficPolicy trafficPolicyImpl
+	}{
+		{
+			name: "added traffic policy, existing and new phases",
+			addedTrafficPolicy: trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{
+					PhaseOnHttpRequest: {
+						[]byte(`b`),
+					},
+					PhaseOnHttpResponse: {
+						[]byte(`c`),
+					},
+				}},
+			expectedMergedTrafficPolicy: trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{
+					PhaseOnHttpRequest: {
+						[]byte(`a`),
+						[]byte(`b`),
+					},
+					PhaseOnHttpResponse: {
+						[]byte(`c`),
+					},
+				}},
+		},
+		{
+			name:                        "base traffic policy has enabled set, added doesn't",
+			baseTrafficPolicyEnabled:    &trueVal,
+			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, &trueVal),
+		},
+		{
+			name: "base traffic policy has no enabled set, added does",
+			addedTrafficPolicy: trafficPolicyImpl{
+				enabled: &trueVal,
+			},
+			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, &trueVal),
+		},
+		{
+			name:                     "both have enabled set, base is false",
+			baseTrafficPolicyEnabled: &falseVal,
+			addedTrafficPolicy: trafficPolicyImpl{
+				enabled: &trueVal,
+			},
+			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, &trueVal),
+		},
+		{
+			name:                     "both have enabled set, added is false",
+			baseTrafficPolicyEnabled: &trueVal,
+			addedTrafficPolicy: trafficPolicyImpl{
+				enabled: &falseVal,
+			},
+			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, &trueVal),
+		},
+		{
+			name:                     "both have enabled set, both false",
+			baseTrafficPolicyEnabled: &falseVal,
+			addedTrafficPolicy: trafficPolicyImpl{
+				enabled: &falseVal,
+			},
+			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, &falseVal),
+		},
+		{
+			name:                     "both have enabled set, both true",
+			baseTrafficPolicyEnabled: &trueVal,
+			addedTrafficPolicy: trafficPolicyImpl{
+				enabled: &trueVal,
+			},
+			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, &trueVal),
+		},
+		{
+			name: "empty added map",
+			addedTrafficPolicy: trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{},
+			},
+			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, nil),
+		},
+		{
+			name:                        "nil added map",
+			addedTrafficPolicy:          trafficPolicyImpl{},
+			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			baseTrafficPolicy := newBaseTrafficPolicy(t, tc.baseTrafficPolicyEnabled)
+
+			baseTrafficPolicy.Merge(&tc.addedTrafficPolicy)
+
+			assert.Equal(t, tc.expectedMergedTrafficPolicy, *baseTrafficPolicy)
+		})
+	}
+}
+
+func TestMergeEndpointRule(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                        string
+		addedRule                   EndpointRule
+		addedPhase                  string
+		expectedMergedTrafficPolicy trafficPolicyImpl
+		expectedErr                 error
+	}{
+		{
+			name: "rule added to existing phase",
+			addedRule: EndpointRule{
+				Name: "test-rule",
+				Actions: []RawAction{
+					[]byte(`{"c":"d"}`),
+				},
+			},
+			addedPhase: PhaseOnHttpRequest,
+			expectedMergedTrafficPolicy: trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{
+					PhaseOnHttpRequest: {
+						[]byte(`a`),
+						[]byte(`{"name":"test-rule","actions":[{"c":"d"}]}`),
+					},
+				},
+			},
+		},
+		{
+			name: "rule added to new phase",
+			addedRule: EndpointRule{
+				Name: "test-rule",
+				Actions: []RawAction{
+					[]byte(`{"c":"d"}`),
+				},
+			},
+			addedPhase: PhaseOnHttpResponse,
+			expectedMergedTrafficPolicy: trafficPolicyImpl{
+				trafficPolicy: map[string][]RawRule{
+					PhaseOnHttpRequest: {
+						[]byte(`a`),
+					},
+					PhaseOnHttpResponse: {
+						[]byte(`{"name":"test-rule","actions":[{"c":"d"}]}`),
+					},
+				}},
+		},
+		{
+			name: "malformed json",
+			addedRule: EndpointRule{
+				Name: "test-rule",
+				Actions: []RawAction{
+					[]byte(`invalid-json`),
+				},
+			},
+			addedPhase: PhaseOnHttpRequest,
+			// original traffic policy should be unaffected
+			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, nil),
+			expectedErr:                 fmt.Errorf("json: error calling MarshalJSON for type json.RawMessage: invalid character 'i' looking for beginning of value"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			baseTrafficPolicy := newBaseTrafficPolicy(t, nil)
+
+			err := baseTrafficPolicy.MergeEndpointRule(tc.addedRule, tc.addedPhase)
+
+			assert.Equal(t, tc.expectedMergedTrafficPolicy, *baseTrafficPolicy)
+			if tc.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				// Can't compare the exact error as we don't have access to json SyntaxError underlying `msg` field`
+				assert.Equal(t, tc.expectedErr.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestMergeSinglePhase(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                        string
+		addedRules                  []RawRule
+		addedPhase                  string
+		expectedMergedTrafficPolicy map[string][]RawRule
+	}{
+		{
+			name: "rules merged into existing phase",
+			addedRules: []RawRule{
+				[]byte(`b`),
+				[]byte(`c`),
+			},
+			addedPhase: PhaseOnHttpRequest,
+			expectedMergedTrafficPolicy: map[string][]RawRule{
+				PhaseOnHttpRequest: {
+					[]byte(`a`),
+					[]byte(`b`),
+					[]byte(`c`),
+				},
+			},
+		},
+		{
+			name: "rules merged into non-existing phase",
+			addedRules: []RawRule{
+				[]byte(`b`),
+				[]byte(`c`),
+			},
+			addedPhase: PhaseOnHttpResponse,
+			expectedMergedTrafficPolicy: map[string][]RawRule{
+				PhaseOnHttpRequest: {
+					[]byte(`a`),
+				},
+				PhaseOnHttpResponse: {
+					[]byte(`b`),
+					[]byte(`c`),
+				},
+			},
+		},
+		{
+			name:                        "empty added rules",
+			addedRules:                  []RawRule{},
+			addedPhase:                  PhaseOnHttpRequest,
+			expectedMergedTrafficPolicy: newBaseTrafficPolicy(t, nil).Deconstruct(),
+		},
+		{
+			name:                        "nil added rules",
+			addedRules:                  nil,
+			addedPhase:                  PhaseOnHttpResponse,
+			expectedMergedTrafficPolicy: newBaseTrafficPolicy(t, nil).Deconstruct(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			baseTrafficPolicy := newBaseTrafficPolicy(t, nil).Deconstruct()
+
+			mergeSinglePhase(baseTrafficPolicy, tc.addedRules, tc.addedPhase)
+
+			assert.Equal(t, tc.expectedMergedTrafficPolicy, baseTrafficPolicy)
+		})
+	}
+}
+
+// newBaseTrafficPolicy gives a simple base that the "merge" functions can use for testing.
+func newBaseTrafficPolicy(t *testing.T, enabled *bool) *trafficPolicyImpl {
+	t.Helper()
+
+	return &trafficPolicyImpl{
+		trafficPolicy: map[string][]RawRule{
+			PhaseOnHttpRequest: {
+				[]byte(`a`),
+			},
+		},
+		enabled: enabled,
+	}
+
+}


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
This change updates our `TrafficPolicy` offerings to support the new phase-based names as well as the new `TrafficPolicy` API. This changelist aims to support the new options without breaking current configurations.

## How
### update `ngrok-api-go` dependency
`6.0.0` is out! I've updated it across the entire controller. Maybe this is a bad idea but :shrug: 

### Edge Reconcile Functions
- updated to use new API
- support both `Policy` and `TrafficPolicy` in the CRD spec
  - this allows us to read newly created and older policy
- removed custom client implementation
  - the shape of the API no longer matches the shape we store our Edge CRDs in, so the custom client is no longer convenience
- if using legacy format (inbound/outbound), emit K8s event warning them to update
  - we still send legacy formats to the backend, where they are still supported
- if policy JSON has "enabled" set, extract it and set on the API call (and send k8s event!)
  - this is only "documented" in the module, which is being deprecated. eventually we can remove this processing

### Gateway API
- Filters were updated to use the new phases
- extension ref was update to use the new phases, which get merged with the policy generated from the gateway API
- legacy policy configured in the extension ref is converted to new phase
  - tls/tcp edges are currently not supported on the Gateway API, so this is a safe translation for now
- merging extension ref policy with Filter policy now uses more generic types instead of strict types from the Module config
  - this allows user supplied config to utilize new phases/formats without having to necessarily update the operator
  - decoupling from the deprecated Module types will make it easier to fully remove in the future 
 
### Ingress TrafficPolicy CRD
- save policy to Edge CRD as `TrafficPolicy` instead of `Policy`

### Module
- mark `Policy` module as deprecated
- save policy to Edge CRD as `TrafficPolicy` instead of `Policy`

### <Proto>Edge CRD
- adds `TrafficPolicy` option
- marks `Policy` as deprecated

## Breaking Changes
This PR should not have any breaking changes and instead opts to punt breaking changes to later down the road.

## Validation

### `NgrokTrafficPolicy` CRD
- creating new resources after the controller upgrade works
- existing policy CRDs using `inbound`/`outbound` continue to work during/after upgrade

### `NgrokModuleSet` CRD
Even though this is deprecated, we need to make sure older configurations continue to work on upgrade

- existing policy CRDs using `inbound`/`outbound` continue to work during/after upgrade

### Gateway API
- after upgrade, existing policy is mapped to new phases, properly merged with "hard-coded" filters
- changing configured policy correctly gets reflected on edge

### `e2e` scripts

Run without failure!

Well...

I did get this failure. However, this appears to possibly be something with the setup/test case vs something not functioning. It does 404?
```--- 
Testing './e2e-fixtures/ingress-class/config-different.yaml' with Edge 'k8s-ops-test-2.ngrok.app'
Testing 'https://k8s-ops-test-2.ngrok.app/' expecting 'HTTP/2 404': FAILED!
  Expected:"HTTP/2 404" received:"HTTP/1.1 404 Not Found" with:

        HTTP/1.1 404 Not Found
        Connection: close
        Content-Type: text/html
        Ngrok-Error-Code: ERR_NGROK_3200
        Referrer-Policy: no-referrer
        Date: Tue, 22 Oct 2024 19:09:50 GMT
```