### PR TITLE
Bindings forwarder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/go \
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/bin/api-manager /workspace/bin/agent-manager ./
+COPY --from=builder /workspace/bin/api-manager /workspace/bin/agent-manager /workspace/bin/bindings-forwarder-manager ./
 USER 65532:65532
 
 ENTRYPOINT ["/api-manager"]

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ _build:
 	go build -o bin/agent-manager -trimpath -ldflags "-s -w \
 		-X $(REPO_URL)/internal/version.gitCommit=$(GIT_COMMIT) \
 		-X $(REPO_URL)/internal/version.version=$(VERSION)" cmd/agent/main.go
+	go build -o bin/bindings-forwarder-manager -trimpath -ldflags "-s -w \
+		-X $(REPO_URL)/internal/version.gitCommit=$(GIT_COMMIT) \
+		-X $(REPO_URL)/internal/version.version=$(VERSION)" cmd/bindings-forwarder/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/Makefile
+++ b/Makefile
@@ -265,3 +265,6 @@ helm-test: _helm_setup ## Run helm unittest plugin
 .PHONY: helm-update-snapshots
 helm-update-snapshots: _helm_setup ## Update helm unittest snapshots
 	$(MAKE) -C $(HELM_CHART_DIR) update-snapshots
+
+helm-update-snapshots-no-deps: ## Update helm unittest snapshots without rebuilding dependencies
+	$(MAKE) -C $(HELM_CHART_DIR) update-snapshots

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -472,12 +472,14 @@ func enableGatewayFeatureSet(_ context.Context, _ managerOpts, mgr ctrl.Manager,
 func enableBindingsFeatureSet(_ context.Context, opts managerOpts, mgr ctrl.Manager, _ *store.Driver, _ ngrokapi.Clientset) error {
 	// EndpointBindings
 	if err := (&bindingscontroller.EndpointBindingReconciler{
-		Client:             mgr.GetClient(),
-		Scheme:             mgr.GetScheme(),
-		Log:                ctrl.Log.WithName("controllers").WithName("EndpointBinding"),
-		Recorder:           mgr.GetEventRecorderFor("bindings-controller"),
-		ClusterDomain:      opts.clusterDomain,
-		PodForwarderLabels: []string{}, // TODO(hkatz) Implement me
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Log:           ctrl.Log.WithName("controllers").WithName("EndpointBinding"),
+		Recorder:      mgr.GetEventRecorderFor("bindings-controller"),
+		ClusterDomain: opts.clusterDomain,
+		UpstreamServiceLabelSelector: map[string]string{
+			"app.kubernetes.io/component": "bindings-forwarder",
+		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EndpointBinding")
 		os.Exit(1)

--- a/cmd/bindings-forwarder/main.go
+++ b/cmd/bindings-forwarder/main.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
+	bindingscontroller "github.com/ngrok/ngrok-operator/internal/controller/bindings"
+	"github.com/ngrok/ngrok-operator/internal/version"
+	"github.com/ngrok/ngrok-operator/pkg/bindingsdriver"
+	//+kubebuilder:scaffold:imports
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(bindingsv1alpha1.AddToScheme(scheme))
+}
+
+func main() {
+	if err := cmd().Execute(); err != nil {
+		setupLog.Error(err, "error running bindings-forwarder-manager")
+		os.Exit(1)
+	}
+}
+
+type managerOpts struct {
+	// flags
+	metricsAddr string
+	probeAddr   string
+	description string
+	managerName string
+	zapOpts     *zap.Options
+
+	// env vars
+	namespace string
+}
+
+func cmd() *cobra.Command {
+	var opts managerOpts
+	c := &cobra.Command{
+		Use: "bindings-forwarder-manager",
+		RunE: func(c *cobra.Command, args []string) error {
+			return runController(c.Context(), opts)
+		},
+	}
+
+	c.Flags().StringVar(&opts.metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to")
+	c.Flags().StringVar(&opts.probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	c.Flags().StringVar(&opts.description, "description", "Created by the ngrok-operator", "Description for this installation")
+	c.Flags().StringVar(&opts.managerName, "manager-name", "bindings-forwarder-manager", "Manager name to identify unique ngrok operator agent instances")
+
+	opts.zapOpts = &zap.Options{}
+	goFlagSet := flag.NewFlagSet("manager", flag.ContinueOnError)
+	opts.zapOpts.BindFlags(goFlagSet)
+	c.Flags().AddGoFlagSet(goFlagSet)
+
+	return c
+}
+
+func runController(_ context.Context, opts managerOpts) error {
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(opts.zapOpts)))
+
+	buildInfo := version.Get()
+	setupLog.Info("starting bindings-forwarder-manager", "version", buildInfo.Version, "commit", buildInfo.GitCommit)
+
+	var ok bool
+	opts.namespace, ok = os.LookupEnv("POD_NAMESPACE")
+	if !ok {
+		return errors.New("POD_NAMESPACE environment variable should be set, but was not")
+	}
+
+	options := ctrl.Options{
+		Scheme: scheme,
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				opts.namespace: {},
+			},
+		},
+		Metrics: server.Options{
+			BindAddress: opts.metricsAddr,
+		},
+		WebhookServer:          webhook.NewServer(webhook.Options{Port: 9443}),
+		HealthProbeBindAddress: opts.probeAddr,
+		LeaderElection:         false,
+	}
+
+	// create default config and clientset for use outside the mgr.Start() blocking loop
+	k8sConfig := ctrl.GetConfigOrDie()
+	mgr, err := ctrl.NewManager(k8sConfig, options)
+	if err != nil {
+		return fmt.Errorf("unable to start bindings-forwarder-manager: %w", err)
+	}
+
+	bd := bindingsdriver.New()
+
+	if err = (&bindingscontroller.ForwarderReconciler{
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("bindings-forwarder"),
+		Scheme:         mgr.GetScheme(),
+		Recorder:       mgr.GetEventRecorderFor("bindings-forwarder-controller"),
+		BindingsDriver: bd,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "BindingsForwarder")
+		os.Exit(1)
+	}
+
+	// register healthchecks
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return fmt.Errorf("error setting up readyz check: %w", err)
+	}
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("error setting up health check: %w", err)
+	}
+
+	setupLog.Info("starting bindings-forwarder-manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		return fmt.Errorf("error starting bindings-forwarder-manager: %w", err)
+	}
+
+	return nil
+}

--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -143,12 +143,15 @@ To uninstall the chart:
 
 ### Kubernetes Bindings feature configuration
 
-| Name                          | Description                                                                          | Value                       |
-| ----------------------------- | ------------------------------------------------------------------------------------ | --------------------------- |
-| `bindings.enabled`            | Whether to enable the Endpoint Bindings feature                                      | `false`                     |
-| `bindings.name`               | Unique name of this kubernetes binding in your ngrok account                         | `""`                        |
-| `bindings.description`        | Description of this kubernetes binding in your ngrok account                         | `Created by ngrok-operator` |
-| `bindings.allowedURLs`        | List of allowed endpoint URL formats that this binding will project into the cluster | `["*"]`                     |
-| `bindings.serviceAnnotations` | Annotations to add to projected services bound to an endpoint                        | `{}`                        |
-| `bindings.serviceLabels`      | Labels to add to projected services bound to an endpoint                             | `{}`                        |
-
+| Name                                            | Description                                                                             | Value                       |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------- | --------------------------- |
+| `bindings.enabled`                              | Whether to enable the Endpoint Bindings feature                                         | `false`                     |
+| `bindings.name`                                 | Unique name of this kubernetes binding in your ngrok account                            | `""`                        |
+| `bindings.description`                          | Description of this kubernetes binding in your ngrok account                            | `Created by ngrok-operator` |
+| `bindings.allowedURLs`                          | List of allowed endpoint URL formats that this binding will project into the cluster    | `["*"]`                     |
+| `bindings.serviceAnnotations`                   | Annotations to add to projected services bound to an endpoint                           | `{}`                        |
+| `bindings.serviceLabels`                        | Labels to add to projected services bound to an endpoint                                | `{}`                        |
+| `bindings.forwarder.replicaCount`               | The number of bindings forwarders to run.                                               | `1`                         |
+| `bindings.forwarder.serviceAccount.create`      | Specifies whether a ServiceAccount should be created for the bindings forwarder pod(s). | `true`                      |
+| `bindings.forwarder.serviceAccount.name`        | The name of the ServiceAccount to use for the bindings forwarder pod(s).                | `""`                        |
+| `bindings.forwarder.serviceAccount.annotations` | Additional annotations to add to the bindings-forwarder ServiceAccount                  | `{}`                        |

--- a/helm/ngrok-operator/templates/_helpers.tpl
+++ b/helm/ngrok-operator/templates/_helpers.tpl
@@ -97,10 +97,21 @@ Create the name of the controller service account to use
 Create the name of the agent service account to use
 */}}
 {{- define "ngrok-operator.agent.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (printf "%s-agent" (include "ngrok-operator.fullname" .)) .Values.serviceAccount.name }}
+{{- if .Values.agent.serviceAccount.create -}}
+    {{ default (printf "%s-agent" (include "ngrok-operator.fullname" .)) .Values.agent.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+    {{ default "default" .Values.agent.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the bindings-forwarder service account to use
+*/}}
+{{- define "ngrok-operator.bindings.forwarder.serviceAccountName" -}}
+{{- if .Values.bindings.forwarder.serviceAccount.create -}}
+    {{ default (printf "%s-bindings-forwarder" (include "ngrok-operator.fullname" .)) .Values.bindings.forwarder.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.bindings.forwarder.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/ngrok-operator/templates/bindings-forwarder/deployment.yaml
+++ b/helm/ngrok-operator/templates/bindings-forwarder/deployment.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.bindings.enabled }}
+{{- $component := "bindings-forwarder" }}
+{{- $rbacChecksum := include (print $.Template.BasePath "/bindings-forwarder/rbac.yaml") . | sha256sum }}
+{{- $forwarder := .Values.bindings.forwarder }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $component }}
+  name: {{ include "ngrok-operator.fullname" . }}-bindings-forwarder
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    checksum/rbac: {{ $rbacChecksum }}
+spec:
+  replicas: {{ $forwarder.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ngrok-operator.selectorLabels" . | nindent 6 }}
+      {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 6 }}
+      {{- end }}
+      app.kubernetes.io/component: {{ $component }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.podAnnotations }}
+          {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+        prometheus.io/path: /metrics
+        prometheus.io/port: '8080'
+        prometheus.io/scrape: 'true'
+        checksum/rbac: {{ $rbacChecksum }}
+      labels:
+        {{- include "ngrok-operator.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+          {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+        app.kubernetes.io/component: {{ $component }}
+    spec:
+      {{- if $forwarder.priorityClassName }}
+      priorityClassName: {{ $forwarder.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "component" $component "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "component" $component "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      serviceAccountName: {{ template "ngrok-operator.bindings.forwarder.serviceAccountName" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: forwarder
+        image: {{ include "ngrok-operator.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - /bindings-forwarder-manager
+        args:
+        {{- if .Values.description }}
+        - --description={{ .Values.description | quote }}
+        {{- end }}
+        - --zap-log-level={{ .Values.log.level }}
+        - --zap-stacktrace-level={{ .Values.log.stacktraceLevel }}
+        - --zap-encoder={{ .Values.log.format }}
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=:8080
+        - --manager-name={{ include "ngrok-operator.fullname" . }}-bindings-forwarder
+        securityContext:
+          allowPrivilegeEscalation: false
+        env:
+        - name: NGROK_AUTHTOKEN
+          valueFrom:
+            secretKeyRef:
+              key: AUTHTOKEN
+              name: {{ include "ngrok-operator.credentialsSecretName" . }}
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: HELM_RELEASE_NAME
+          value: {{ .Release.Name | quote }}
+        {{- range $key, $value := .Values.extraEnv }}
+        - name: {{ $key }}
+          value: {{- toYaml $value | nindent 12 }}
+        {{- end }}
+        {{- if .Values.extraVolumeMounts  }}
+        volumeMounts:
+        {{ toYaml .Values.extraVolumeMounts | nindent 10 }}
+        {{- end }}
+        {{- if .Values.lifecycle }}
+        lifecycle:
+        {{ toYaml .Values.lifecycle | nindent 10 }}
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+        {{- toYaml .Values.resources | nindent 10 }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+        {{ toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/helm/ngrok-operator/templates/bindings-forwarder/rbac.yaml
+++ b/helm/ngrok-operator/templates/bindings-forwarder/rbac.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.bindings.enabled }}
+{{ $bindingForwarderRole := printf "%s-bindings-forwarder" (include "ngrok-operator.fullname" .) }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $bindingForwarderRole }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - bindings.k8s.ngrok.com
+  resources:
+  - endpointbindings
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ngrok-operator.fullname" . }}-bindings-forwarder-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $bindingForwarderRole }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "ngrok-operator.bindings.forwarder.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/ngrok-operator/templates/bindings-forwarder/service-account.yaml
+++ b/helm/ngrok-operator/templates/bindings-forwarder/service-account.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.bindings.enabled }}
+{{- if .Values.bindings.forwarder.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "ngrok-operator.bindings.forwarder.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ngrok-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+  {{- if .Values.bindings.forwarder.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.bindings.forwarder.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/ngrok-operator/tests/agent/service-account_test.yaml
+++ b/helm/ngrok-operator/tests/agent/service-account_test.yaml
@@ -22,3 +22,10 @@ tests:
   asserts:
   - hasDocuments:
       count: 0
+- it: Creates a service account using .Values.agent.serviceAccount.name if set
+  set:
+    agent.serviceAccount.name: test-serviceaccount
+  asserts:
+  - equal:
+      path: metadata.name
+      value: test-serviceaccount

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
@@ -1,0 +1,93 @@
+Should match snapshot:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        checksum/rbac: 2c79f18bfeb71e9ec363f715df607b994ee4a9a5fe3552f6840bf273fc375868
+      labels:
+        app.kubernetes.io/component: bindings-forwarder
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ngrok-operator
+        app.kubernetes.io/part-of: ngrok-operator
+        app.kubernetes.io/version: 0.12.2
+        helm.sh/chart: ngrok-operator-0.15.0
+      name: RELEASE-NAME-ngrok-operator-bindings-forwarder
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: bindings-forwarder
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: ngrok-operator
+      template:
+        metadata:
+          annotations:
+            checksum/rbac: 2c79f18bfeb71e9ec363f715df607b994ee4a9a5fe3552f6840bf273fc375868
+            prometheus.io/path: /metrics
+            prometheus.io/port: "8080"
+            prometheus.io/scrape: "true"
+          labels:
+            app.kubernetes.io/component: bindings-forwarder
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: ngrok-operator
+        spec:
+          affinity:
+            nodeAffinity: null
+            podAffinity: null
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/component: bindings-forwarder
+                        app.kubernetes.io/instance: RELEASE-NAME
+                        app.kubernetes.io/name: ngrok-operator
+                    topologyKey: kubernetes.io/hostname
+                  weight: 1
+          containers:
+            - args:
+                - --description="The official ngrok Kubernetes Operator."
+                - --zap-log-level=info
+                - --zap-stacktrace-level=error
+                - --zap-encoder=json
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=:8080
+                - --manager-name=RELEASE-NAME-ngrok-operator-bindings-forwarder
+              command:
+                - /bindings-forwarder-manager
+              env:
+                - name: NGROK_AUTHTOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: AUTHTOKEN
+                      name: RELEASE-NAME-ngrok-operator-credentials
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: HELM_RELEASE_NAME
+                  value: RELEASE-NAME
+              image: docker.io/ngrok/ngrok-operator:0.12.2
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8081
+                initialDelaySeconds: 15
+                periodSeconds: 20
+              name: forwarder
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8081
+                initialDelaySeconds: 5
+                periodSeconds: 10
+              resources:
+                limits: {}
+                requests: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+          serviceAccountName: RELEASE-NAME-ngrok-operator-bindings-forwarder

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/rbac_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/rbac_test.yaml.snap
@@ -1,0 +1,38 @@
+Should match snapshot:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: RELEASE-NAME-ngrok-operator-bindings-forwarder
+      namespace: NAMESPACE
+    rules:
+      - apiGroups:
+          - bindings.k8s.ngrok.com
+        resources:
+          - endpointbindings
+        verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: RELEASE-NAME-ngrok-operator-bindings-forwarder-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: RELEASE-NAME-ngrok-operator-bindings-forwarder
+    subjects:
+      - kind: ServiceAccount
+        name: RELEASE-NAME-ngrok-operator-bindings-forwarder
+        namespace: NAMESPACE

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/service-account_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/service-account_test.yaml.snap
@@ -1,0 +1,15 @@
+Should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ngrok-operator
+        app.kubernetes.io/part-of: ngrok-operator
+        app.kubernetes.io/version: 0.12.2
+        helm.sh/chart: ngrok-operator-0.15.0
+      name: test-release-ngrok-operator-bindings-forwarder
+      namespace: test-namespace

--- a/helm/ngrok-operator/tests/bindings-forwarder/deployment_test.yaml
+++ b/helm/ngrok-operator/tests/bindings-forwarder/deployment_test.yaml
@@ -1,0 +1,21 @@
+suite: test bindings forwarder deployment
+templates:
+- bindings-forwarder/deployment.yaml
+- bindings-forwarder/rbac.yaml
+set:
+  bindings.enabled: true
+tests:
+- it: Should match snapshot
+  template: bindings-forwarder/deployment.yaml
+  asserts:
+  - matchSnapshot: {}
+- it: should create a deployment if bindings.enabled is true
+  template: bindings-forwarder/deployment.yaml
+  asserts:
+  - isKind:
+      of: Deployment
+  - isAPIVersion:
+      of: apps/v1
+  - equal:
+      path: metadata.name
+      value: RELEASE-NAME-ngrok-operator-bindings-forwarder

--- a/helm/ngrok-operator/tests/bindings-forwarder/rbac_test.yaml
+++ b/helm/ngrok-operator/tests/bindings-forwarder/rbac_test.yaml
@@ -1,0 +1,35 @@
+suite: test bindings forwarder rbac
+templates:
+- bindings-forwarder/rbac.yaml
+set:
+  bindings.enabled: true
+tests:
+- it: Should match snapshot
+  asserts:
+  - matchSnapshot: {}
+- it: should not create a role or role binding if bindings.enabled is false
+  set:
+    bindings.enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: should create a role if bindings.enabled is true
+  documentIndex: 0
+  asserts:
+  - isKind:
+      of: Role
+  - isAPIVersion:
+      of: rbac.authorization.k8s.io/v1
+  - equal:
+      path: metadata.name
+      value: RELEASE-NAME-ngrok-operator-bindings-forwarder
+- it: should create a rolebinding if bindings.enabled is true
+  documentIndex: 1
+  asserts:
+  - isKind:
+      of: RoleBinding
+  - isAPIVersion:
+      of: rbac.authorization.k8s.io/v1
+  - equal:
+      path: metadata.name
+      value: RELEASE-NAME-ngrok-operator-bindings-forwarder-rolebinding

--- a/helm/ngrok-operator/tests/bindings-forwarder/service-account_test.yaml
+++ b/helm/ngrok-operator/tests/bindings-forwarder/service-account_test.yaml
@@ -1,0 +1,39 @@
+suite: test bindings forwarder serviceaccount
+templates:
+- bindings-forwarder/service-account.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+set:
+  bindings.enabled: true
+tests:
+- it: Should match snapshot
+  asserts:
+  - matchSnapshot: {}
+- it: should not create a serviceaccount if bindings.enabled is false
+  set:
+    bindings.enabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: should create the bindings forwarder serviceaccount
+  asserts:
+  - isKind:
+      of: ServiceAccount
+  - isAPIVersion:
+      of: v1
+  - hasDocuments:
+      count: 1
+- it: does not generate a serviceaccount when bindings.forwarder.serviceAccount.create is false
+  set:
+    bindings.forwarder.serviceAccount.create: false
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: Creates a service account using .Values.bindings.forwarder.serviceAccount.name if set
+  set:
+    bindings.forwarder.serviceAccount.name: test-serviceaccount
+  asserts:
+  - equal:
+      path: metadata.name
+      value: test-serviceaccount

--- a/helm/ngrok-operator/tests/credentials-secret_test.yaml
+++ b/helm/ngrok-operator/tests/credentials-secret_test.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/quintush/helm-unittest/master/schema/helm-testsuite.json
 suite: test credentials-secret
 templates:
 - credentials-secret.yaml

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -283,3 +283,18 @@ bindings:
   - "*" # TODO(hkatz) only supporting this for now, implement others later
   serviceAnnotations: {}
   serviceLabels: {}
+
+  forwarder:
+    ## @param bindings.forwarder.replicaCount The number of bindings forwarders to run.
+    ##
+    replicaCount: 1
+
+    ## @param bindings.forwarder.serviceAccount.create Specifies whether a ServiceAccount should be created for the bindings forwarder pod(s).
+    ## @param bindings.forwarder.serviceAccount.name The name of the ServiceAccount to use for the bindings forwarder pod(s).
+    ## If not set and create is true, a name is generated using the fullname template
+    ## @param bindings.forwarder.serviceAccount.annotations Additional annotations to add to the bindings-forwarder ServiceAccount
+    ##
+    serviceAccount:
+      create: true
+      name: ""
+      annotations: {}

--- a/internal/controller/bindings/endpointbinding_controller_test.go
+++ b/internal/controller/bindings/endpointbinding_controller_test.go
@@ -25,7 +25,6 @@ SOFTWARE.
 package bindings
 
 import (
-	"context"
 	"testing"
 
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
@@ -66,7 +65,7 @@ func Test_convertEndpointBindingToServices(t *testing.T) {
 		},
 	}
 
-	targetService, upstreamService := controller.convertEndpointBindingToServices(context.TODO(), endpointBinding)
+	targetService, upstreamService := controller.convertEndpointBindingToServices(endpointBinding)
 
 	assert.Equal(targetService.Name, "client-service")
 	assert.Equal(targetService.Namespace, "client-namespace")

--- a/internal/controller/bindings/forwarder_controller.go
+++ b/internal/controller/bindings/forwarder_controller.go
@@ -1,0 +1,171 @@
+/*
+MIT License
+
+Copyright (c) 2024 ngrok, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package bindings
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/go-logr/logr"
+	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
+	"github.com/ngrok/ngrok-operator/internal/controller"
+	"github.com/ngrok/ngrok-operator/pkg/bindingsdriver"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerruntime "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type ForwarderReconciler struct {
+	client.Client
+
+	Log            logr.Logger
+	Scheme         *runtime.Scheme
+	Recorder       record.EventRecorder
+	BindingsDriver *bindingsdriver.BindingsDriver
+
+	controller *controller.BaseController[*bindingsv1alpha1.EndpointBinding]
+}
+
+func (r *ForwarderReconciler) SetupWithManager(mgr ctrl.Manager) (err error) {
+	if r.BindingsDriver == nil {
+		return fmt.Errorf("BindingsDriver is required")
+	}
+
+	r.controller = &controller.BaseController[*bindingsv1alpha1.EndpointBinding]{
+		Kube:     r.Client,
+		Log:      r.Log,
+		Recorder: r.Recorder,
+
+		Update:   r.update,
+		Delete:   r.delete,
+		StatusID: r.statusID,
+	}
+
+	cont, err := controllerruntime.NewUnmanaged("bindings-forwarder-controller", mgr, controllerruntime.Options{
+		Reconciler: r,
+		LogConstructor: func(_ *reconcile.Request) logr.Logger {
+			return r.Log
+		},
+		NeedLeaderElection: ptr.To(false),
+	})
+	if err != nil {
+		return
+	}
+
+	err = cont.Watch(
+		source.Kind(mgr.GetCache(), &bindingsv1alpha1.EndpointBinding{}),
+		&handler.EnqueueRequestForObject{},
+		predicate.Or(
+			predicate.AnnotationChangedPredicate{},
+			predicate.GenerationChangedPredicate{},
+		),
+	)
+	if err != nil {
+		return
+	}
+
+	err = mgr.Add(cont)
+	return
+}
+
+func (r *ForwarderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return r.controller.Reconcile(ctx, req, new(bindingsv1alpha1.EndpointBinding))
+}
+
+func (r *ForwarderReconciler) update(ctx context.Context, epb *bindingsv1alpha1.EndpointBinding) error {
+	log := ctrl.LoggerFrom(ctx).WithValues(
+		"endpoint-binding", map[string]string{
+			"namespace": epb.Namespace,
+			"name":      epb.Name,
+		},
+		"port", epb.Spec.Port,
+	)
+
+	log.Info("Listening on port")
+	port := int32(epb.Spec.Port)
+
+	// TODO: wire this up to ngrok. For now, we'll just use the example connection handler
+	return r.BindingsDriver.Listen(port, exampleConnectionHandler(epb))
+}
+
+func (r *ForwarderReconciler) delete(ctx context.Context, epb *bindingsv1alpha1.EndpointBinding) error {
+	port := int32(epb.Spec.Port)
+	r.BindingsDriver.Close(port)
+	return nil
+}
+
+// Always returns the endpoint binding's "namespace/name". This is different than most of our other
+// controllers which return a .Status.ID field. We do this to always trigger the update handler of
+// the base controller.
+func (r *ForwarderReconciler) statusID(epb *bindingsv1alpha1.EndpointBinding) string {
+	return fmt.Sprintf("%s/%s", epb.Namespace, epb.Name)
+}
+
+// exampleConnectionHandler is a simple example of a connection handler that echos back each line
+// it reads from the client. It also sends a welcome message to the client.
+func exampleConnectionHandler(epb *bindingsv1alpha1.EndpointBinding) bindingsdriver.ConnectionHandler {
+	return func(conn net.Conn) error {
+		defer conn.Close()
+		_, err := conn.Write([]byte(
+			fmt.Sprintf(
+				`
+Hello from the ngrok-operator bindings-forwarder
+
+You are connected to my port: %d
+The endpoint binding is: %s/%s
+
+Type anything and hit enter to see it echoed back
+Type an empty line to close the connection
+
+>`, epb.Spec.Port, epb.Namespace, epb.Name,
+			),
+		))
+		if err != nil {
+			return err
+		}
+		scanner := bufio.NewScanner(conn)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" { // empty line means the client is done
+				break
+			}
+
+			_, err := conn.Write([]byte(line + "\n> "))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/internal/controller/ngrok/kubernetesoperator_controller.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller.go
@@ -432,9 +432,12 @@ func generateCSR(privKey *ecdsa.PrivateKey) ([]byte, error) {
 		SignatureAlgorithm: x509.ECDSAWithSHA512,
 	}
 
-	var buf bytes.Buffer
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, privKey)
+	if err != nil {
+		return nil, err
+	}
 
-	csrBytes, _ := x509.CreateCertificateRequest(rand.Reader, &template, privKey)
+	var buf bytes.Buffer
 	if err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

This adds in a new bindings forwarder deployment. The bindings forwarder watches for `bindingsv1alpha1.EndpointBindings` CRs and listens on the desired port so that incoming connections destined for the service have something to connect to. We still need to wire this up to connect to ngrok and forward the bytes there so that the endpoint is fully bound. For now, we simply use an example connection handler that prints information about the connection and echos back what the user inputs.

## How

* Added the initial bindings forwarder program, `bindings-forwarder-manager`. This sets up another manager and makes a new non leader elected controller with the `ForwarderReconciler`. The `ForwarderReconcile` listens starts and stop listening on the configured ports as needed.
* Added an example ConnectionHandler. We'll change this later, but for now it'll help us test
* Added in a new Deployment, Role, Rolebinding, and (optional) service account to the helm chart

## Breaking Changes
No, this is all hidden behind the helm values `bindings.enabled` which defaults to `false`.