### PR TITLE
chore: Update ngrok-api-go to pull in new changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/imdario/mergo v0.3.16
 	github.com/ngrok/ngrok-api-go/v5 v5.4.1
-	github.com/ngrok/ngrok-api-go/v6 v6.0.1-0.20241015200239-7c32f2a7d4d9
+	github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241025160627-dcdb6f5b23f8
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/ngrok/ngrok-api-go/v5 v5.4.1 h1:rjofyT5M4pi3PtobyNy+3RMhq2uUaKuqsP34IwXRE28=
 github.com/ngrok/ngrok-api-go/v5 v5.4.1/go.mod h1:UVTaHI5B4gEsfHCOZTlRg8WkT6+KBijIkVtjpDqCyIU=
-github.com/ngrok/ngrok-api-go/v6 v6.0.1-0.20241015200239-7c32f2a7d4d9 h1:/+K+wwWKOn4wScpjdSFGcOV5XJObTI/G7z90A8gei7A=
-github.com/ngrok/ngrok-api-go/v6 v6.0.1-0.20241015200239-7c32f2a7d4d9/go.mod h1:KtRxWqEomaHZfgeS+q/7nFHF+gPYFghS5wTl5AIUjIk=
+github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241025160627-dcdb6f5b23f8 h1:HHfIX3/eXsnxwSxXpLJFSUO5sXWwxdNIkWVMsQd5f7o=
+github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241025160627-dcdb6f5b23f8/go.mod h1:KtRxWqEomaHZfgeS+q/7nFHF+gPYFghS5wTl5AIUjIk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
## What

Pulls in the latest changes from ngrok-api-go along with our k8s-operator branch that has the changes we need to dev for the k8s operator

## How

* Rebase the ngrok-api-go `k8s-operator` branch on the ngrok-api-go `main` branch.
* `go get -u github.com/ngrok/ngrok-api-go/v6@k8s-operator`
* `go mod tidy`

## Breaking Changes
No