### PR TITLE
fix: Make sure that we can't connect after we stop the bindings listener

### DIFF
--- a/pkg/bindingsdriver/driver_test.go
+++ b/pkg/bindingsdriver/driver_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand/v2"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -35,7 +36,7 @@ func TestBindingsListener(t *testing.T) {
 	assert.NotNil(t, bl)
 
 	// test that we can connect to the listener
-	conn, err := net.Dial("tcp", loopbackAddr(port))
+	conn, err := net.DialTimeout("tcp", loopbackAddr(port), 10*time.Millisecond)
 	assert.NoError(t, err)
 
 	out, err := io.ReadAll(conn)
@@ -44,6 +45,13 @@ func TestBindingsListener(t *testing.T) {
 	assert.Equal(t, "hello world", string(out))
 
 	assert.NotPanics(t, func() { bl.Stop() })
+
+	// test that we can't connect to the listener after it's stopped
+	conn, err = net.DialTimeout("tcp", loopbackAddr(port), 10*time.Millisecond)
+	assert.Error(t, err)
+	assert.Nil(t, conn)
+
+	// test that we can stop the listener multiple times
 	assert.NotPanics(t, func() { bl.Stop() })
 }
 


### PR DESCRIPTION
## What

This wasn't working as I had originally intended. The problem is the for loop and only doing a select at the top of the for loop from the channel. `b.listener.Accept()` will block until there is a new conn to accept. This means that if we call `Stop()` on a bindings listener, it wouldn't actually try to `Close()` the listener until a new connection comes in, which isn't what we want. 


## How

This fixes it so that we will only `Close()` the listener once and we will do it when `Stop()` is called for the first time. This will cause the `b.listener.Accept()` to return an error as well making sure that we immediately go back to the start of our for loop. Also, added some tests to make sure that the new code behaves as desired.

## Breaking Changes
No