### PR TITLE
Ensure endpoint poller does not start until k8sop is regestered with API

### DIFF
--- a/helm/ngrok-operator/templates/controller-deployment.yaml
+++ b/helm/ngrok-operator/templates/controller-deployment.yaml
@@ -61,6 +61,7 @@ spec:
         command:
         - /api-manager
         args:
+        - --release-name={{ .Release.Name }}
         {{- include "ngrok-operator.manager.cliFeatureFlags" . | nindent 8 }}
         {{- if .Values.bindings.enabled }}
         - --bindings-name={{ .Values.bindings.name }}

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -52,6 +52,7 @@ Should match all-options snapshot:
                   weight: 1
           containers:
             - args:
+                - --release-name=RELEASE-NAME
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=false
                 - --description="The official ngrok Kubernetes Operator."
@@ -655,6 +656,7 @@ Should match default snapshot:
                   weight: 1
           containers:
             - args:
+                - --release-name=RELEASE-NAME
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=false
                 - --description="The official ngrok Kubernetes Operator."


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
*Describe what the change is solving*

Ensure the endpoint poller does not start polling until a k8sop ID is retrieved

## How
*Describe the solution*

## Breaking Changes
*Are there any breaking changes in this PR?*
No.
