### PR TITLE
Ensure the TLS secret is valid otherwise upsert

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -546,7 +546,6 @@ func createKubernetesOperator(ctx context.Context, client client.Client, opts ma
 			Namespace: opts.namespace,
 		},
 	}
-
 	_, err := controllerutil.CreateOrUpdate(ctx, client, k8sOperator, func() error {
 		k8sOperator.Spec = ngrokv1alpha1.KubernetesOperatorSpec{
 			Deployment: &ngrokv1alpha1.KubernetesOperatorDeployment{


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
*Describe what the change is solving*

Sometimes the TLS secret can be invalid:
```
% {kind-kind/ngrok-operator} kb get secret -oyaml ngrok-operator-default-tls
apiVersion: v1
data:
  tls.crt: ""
  tls.csr: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlHNk1HSUNBUUF3QURCWk1CTUdCeXFHU000OUFnRUdDQ3FHU000OUF3RUhBMElBQkFYbDlPcmE4TDNqV2orbwpjMDJvVE9KOHNXSU9ZUHRGa09vQVdFcWU5Qjk5N2NxU1dRK3dIY2VWQzY5MmQwMW0rYUNsUmozSXE4NjZ4Q0tGCnJlbWx3VGVnQURBS0JnZ3Foa2pPUFFRREJBTklBREJGQWlFQWpDOUJsb2JPU1I3VjdiSFlObTJiZ0FmT0lId2gKVlBDbDVaN3oyZkk2OS9BQ0lFRytlN1BURHByZUpRVHl4cVc1ZVUvU0srb3p4dmxvMWc1amhBSkQwTjRYCi0tLS0tRU5EIENFUlRJRklDQVRFIFJFUVVFU1QtLS0tLQo=
  tls.key: LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KTUhjQ0FRRUVJQjVjREFtQ0xIVDdNNzVYVURoTHhUb2I0dFBDdjhUVWNhdk9Cc1RJbkZDWW9Bb0dDQ3FHU000OQpBd0VIb1VRRFFnQUVCZVgwNnRyd3ZlTmFQNmh6VGFoTTRueXhZZzVnKzBXUTZnQllTcDcwSDMzdHlwSlpEN0FkCng1VUxyM1ozVFdiNW9LVkdQY2lyenJyRUlvV3Q2YVhCTnc9PQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K
kind: Secret
metadata:
  creationTimestamp: "2024-11-05T14:37:41Z"
  name: ngrok-operator-default-tls
  namespace: ngrok-operator
  resourceVersion: "967"
  uid: 702f5cab-530e-409e-9cd6-997b03cf8c11
type: kubernetes.io/tls
```

Such as missing keys.


In these cases we should regen the CSR and Cert

## How
*Describe the solution*

Do that.

## Breaking Changes
*Are there any breaking changes in this PR?*
No.
