### PR TITLE
fix: domain stuck when ID is not found

### DIFF
--- a/internal/controller/ingress/domain_controller.go
+++ b/internal/controller/ingress/domain_controller.go
@@ -137,6 +137,12 @@ func (r *DomainReconciler) create(ctx context.Context, domain *ingressv1alpha1.D
 func (r *DomainReconciler) update(ctx context.Context, domain *ingressv1alpha1.Domain) error {
 	resp, err := r.DomainsClient.Get(ctx, domain.Status.ID)
 	if err != nil {
+		// If the domain is gone, clear the status and trigger a re-reconcile
+		if ngrok.IsNotFound(err) {
+			domain.Status = ingressv1alpha1.DomainStatus{}
+			return r.controller.ReconcileStatus(ctx, domain, err)
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
## What

Fixes an issue where we would not retry to reconcile domains when receiving a 404 from the ngrok API. This could happen when the resource was deleted either in the dashboard or via the API outside of the ngrok operator.

## How

* If a domain can't be found in the ngrok API, clear the status and return the original not found error
* Also, update our base controller's error handling to retry on not found errors. This was probably affecting all resources that were clearing their status but would not be re-reconciled because we were swallowing them in `CtrlResultForErr`.

## Breaking Changes

No