### PR TITLE
fix: Better migration path from the ngrok kuberntes-ingress-controller to the ngrok-operator

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -217,12 +217,12 @@ func runController(ctx context.Context, opts managerOpts) error {
 
 	// create default config and clientset for use outside the mgr.Start() blocking loop
 	k8sConfig := ctrl.GetConfigOrDie()
-	k8sClinet, err := client.New(k8sConfig, client.Options{Scheme: scheme})
+	k8sClient, err := client.New(k8sConfig, client.Options{Scheme: scheme})
 	if err != nil {
 		return fmt.Errorf("unable to create k8s client: %w", err)
 	}
 
-	if err := createKubernetesOperator(ctx, k8sClinet, opts); err != nil {
+	if err := createKubernetesOperator(ctx, k8sClient, opts); err != nil {
 		return fmt.Errorf("unable to create KubernetesOperator: %w", err)
 	}
 
@@ -244,7 +244,7 @@ func runController(ctx context.Context, opts managerOpts) error {
 		// Run a migration for migrating from the old ingress controller to the operator
 		// TODO: Delete me after the initial releae of the ngrok-operator
 		setupLog.Info("Migrating Kubernetes Ingress Controller labels to ngrok operator")
-		if err := k8sResourceDriver.MigrateKubernetesIngressControllerLabelsToNgrokOperator(ctx, k8sClinet); err != nil {
+		if err := k8sResourceDriver.MigrateKubernetesIngressControllerLabelsToNgrokOperator(ctx, k8sClient); err != nil {
 			return fmt.Errorf("unable to migrate Kubernetes Ingress Controller labels to ngrok operator: %w", err)
 		}
 		setupLog.Info("Kubernetes Ingress controller labels migrated to ngrok operator")

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -236,11 +236,18 @@ func runController(ctx context.Context, opts managerOpts) error {
 	var k8sResourceDriver *store.Driver
 	if opts.enableFeatureIngress || opts.enableFeatureGateway {
 		// we only need a driver if these features are enabled
-		if driver, err := getK8sResourceDriver(ctx, mgr, opts); err != nil {
+		k8sResourceDriver, err = getK8sResourceDriver(ctx, mgr, opts)
+		if err != nil {
 			return fmt.Errorf("unable to create Driver: %w", err)
-		} else {
-			k8sResourceDriver = driver
 		}
+
+		// Run a migration for migrating from the old ingress controller to the operator
+		// TODO: Delete me after the initial releae of the ngrok-operator
+		setupLog.Info("Migrating Kubernetes Ingress Controller labels to ngrok operator")
+		if err := k8sResourceDriver.MigrateKubernetesIngressControllerLabelsToNgrokOperator(ctx, k8sClinet); err != nil {
+			return fmt.Errorf("unable to migrate Kubernetes Ingress Controller labels to ngrok operator: %w", err)
+		}
+		setupLog.Info("Kubernetes Ingress controller labels migrated to ngrok operator")
 	}
 
 	if opts.enableFeatureIngress {


### PR DESCRIPTION
## What

Attempts to provide a better migration path between the kubernetes-ingress-controller and the ngrok-operator. One of the problems identified is that it duplicates CRs in existing environments because the `k8s.ngrok.com/controller-name` and `k8s.ngrok.com/controller-namespace` labels (that we b/c owner references are not allowed cross namespace) do not match what the new operator thinks it should.

## How

For the initial ngrok-operator release, include a migration on startup that will re-label the domains, httpsedges, and tunnels with the expected labels so that new objects are not created but are instead adopted.

## Breaking Changes

No