### PR TITLE
Support one-click-demo mode

### DIFF
--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -35,13 +35,14 @@ To uninstall the chart:
 
 ### Common parameters
 
-| Name                | Description                                                        | Value                                     |
-| ------------------- | ------------------------------------------------------------------ | ----------------------------------------- |
-| `nameOverride`      | String to partially override generated resource names              | `""`                                      |
-| `fullnameOverride`  | String to fully override generated resource names                  | `""`                                      |
-| `description`       | ngrok-operator description that will appear in the ngrok dashboard | `The official ngrok Kubernetes Operator.` |
-| `commonLabels`      | Labels to add to all deployed objects                              | `{}`                                      |
-| `commonAnnotations` | Annotations to add to all deployed objects                         | `{}`                                      |
+| Name                | Description                                                                                                                    | Value                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| `nameOverride`      | String to partially override generated resource names                                                                          | `""`                                      |
+| `fullnameOverride`  | String to fully override generated resource names                                                                              | `""`                                      |
+| `description`       | ngrok-operator description that will appear in the ngrok dashboard                                                             | `The official ngrok Kubernetes Operator.` |
+| `commonLabels`      | Labels to add to all deployed objects                                                                                          | `{}`                                      |
+| `commonAnnotations` | Annotations to add to all deployed objects                                                                                     | `{}`                                      |
+| `oneClickDemoMode`  | If true, then the operator will startup without required fields or API registration, become Ready, but not actually be running | `false`                                   |
 
 ### Image configuration
 

--- a/helm/ngrok-operator/templates/agent/deployment.yaml
+++ b/helm/ngrok-operator/templates/agent/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.ingress.enabled (not .Values.oneClickDemoMode) }}
 {{- $component := "agent" }}
 {{- $rbacChecksum := include (print $.Template.BasePath "/agent/rbac.yaml") . | sha256sum }}
 {{- $agent := .Values.agent }}
@@ -124,3 +125,4 @@ spec:
       volumes:
         {{ toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}
+{{- end }}

--- a/helm/ngrok-operator/templates/bindings-forwarder/deployment.yaml
+++ b/helm/ngrok-operator/templates/bindings-forwarder/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.bindings.enabled }}
+{{- if and .Values.bindings.enabled (not .Values.oneClickDemoMode) }}
 {{- $component := "bindings-forwarder" }}
 {{- $rbacChecksum := include (print $.Template.BasePath "/bindings-forwarder/rbac.yaml") . | sha256sum }}
 {{- $forwarder := .Values.bindings.forwarder }}

--- a/helm/ngrok-operator/templates/controller-deployment.yaml
+++ b/helm/ngrok-operator/templates/controller-deployment.yaml
@@ -63,6 +63,9 @@ spec:
         args:
         - --release-name={{ .Release.Name }}
         {{- include "ngrok-operator.manager.cliFeatureFlags" . | nindent 8 }}
+        {{- if .Values.oneClickDemoMode }}
+        - --one-click-demo-mode
+        {{- end }}
         {{- if .Values.bindings.enabled }}
         - --bindings-name={{ .Values.bindings.name }}
         - --bindings-allowed-urls={{ join "," .Values.bindings.allowedURLs }}

--- a/helm/ngrok-operator/tests/agent/deployment_test.yaml
+++ b/helm/ngrok-operator/tests/agent/deployment_test.yaml
@@ -2,6 +2,9 @@ suite: test agent deployment
 templates:
 - agent/deployment.yaml
 - agent/rbac.yaml
+set:
+  ingress:
+    enabled: true
 tests:
 - it: Should match snapshot
   asserts:

--- a/helm/ngrok-operator/tests/controller-deployment_test.yaml
+++ b/helm/ngrok-operator/tests/controller-deployment_test.yaml
@@ -235,6 +235,15 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: --bindings-allowed-urls=test.example,http://*
+- it: Should pass one-click-demo mode if set
+  set:
+    oneClickDemoMode: true
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --one-click-demo-mode
 - it: Should pass log format argument if set
   set:
     log:

--- a/helm/ngrok-operator/values.schema.json
+++ b/helm/ngrok-operator/values.schema.json
@@ -27,6 +27,11 @@
             "description": "Annotations to add to all deployed objects",
             "default": {}
         },
+        "oneClickDemoMode": {
+            "type": "boolean",
+            "description": "If true, then the operator will startup without required fields or API registration, become Ready, but not actually be running",
+            "default": false
+        },
         "image": {
             "type": "object",
             "properties": {

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -6,11 +6,13 @@
 ## @param description ngrok-operator description that will appear in the ngrok dashboard
 ## @param commonLabels Labels to add to all deployed objects
 ## @param commonAnnotations Annotations to add to all deployed objects
+## @param oneClickDemoMode If true, then the operator will startup without required fields or API registration, become Ready, but not actually be running
 nameOverride: ""
 fullnameOverride: ""
 description: "The official ngrok Kubernetes Operator."
 commonLabels: {}
 commonAnnotations: {}
+oneClickDemoMode: false
 
 ##
 ## @section Image configuration


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
*Describe what the change is solving*

We would like to support a 1-click installation for marketplace environments.
However, these environments do not allow users to provide required config before 1-click installing.
And, the installation is only successful if the Pod goes Ready (helm install success).
But, our ngrok-op requires user configuration to work, namely API key and authtoken.

So we provide this new `oneClickDemoMode: true/false` value that can change the behaviour of the installed ngrok-op.
- When true, ngrok-op will become Ready and log messages about missing required configuration.
- When false, ngrok-op will run in its normal operator mode (and report errors for missing fields as NotReady, etc...)

## How
*Describe the solution*

Factor out startup functions

Add oneClickDemoMode to helm values.yaml


## Breaking Changes
*Are there any breaking changes in this PR?*
No.
