### PR TITLE
Hide ngrok-op API registration behind bindings feature flag

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -222,8 +222,11 @@ func runController(ctx context.Context, opts managerOpts) error {
 		return fmt.Errorf("unable to create k8s client: %w", err)
 	}
 
-	if err := createKubernetesOperator(ctx, k8sClient, opts); err != nil {
-		return fmt.Errorf("unable to create KubernetesOperator: %w", err)
+	// TODO(hkatz) for now we are hiding the k8sop API regstration behind the bindings feature flag
+	if opts.enableFeatureBindings {
+		if err := createKubernetesOperator(ctx, k8sClient, opts); err != nil {
+			return fmt.Errorf("unable to create KubernetesOperator: %w", err)
+		}
 	}
 
 	mgr, err := ctrl.NewManager(k8sConfig, options)


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
*Describe what the change is solving*

Hide `kind: KubernetesOperator` registration with ngrok API behind the bindings feature flag.

We're doing this so we can release v0.16.0 of ngrok-op without needing to figure out all the nitty-gritty details of k8sop registration (soon...)

## How
*Describe the solution*

## Breaking Changes
*Are there any breaking changes in this PR?*
No.
