### PR TITLE
Error with invalid API key

### DIFF
--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -180,10 +180,9 @@ func New(ctx context.Context, logger logr.Logger, opts TunnelDriverOpts) (*Tunne
 			}
 		}),
 	)
-	//nolint:errcheck
-	go ngrok.Connect(ctx, connOpts...)
+	_, err := ngrok.Connect(ctx, connOpts...)
 
-	return td, nil
+	return td, err
 }
 
 // Ready implements the healthcheck.HealthChecker interface for when the TunnelDriver is ready to serve tunnels


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
*Describe what the change is solving*

Ensure the ngrok-api-manager fails to start with error messages if the API key is invalid.

## How
*Describe the solution*

Dummy request to list API keys using the given API key

tunnel driver already errors for bad authtoken
```
2024-11-18T21:23:13Z	DEBUG	drivers.tunnel	decoded response	{"obj": "csess", "id": "7838d5221914", "sid": 3, "resp": {"Version":"","ClientId":"","Error":"The authtoken you specified is properly formed, but it is invalid.\nYour authtoken: 2lssG3MpQZ5dIyCVLYNRBfXC5tg_INVALID\nThis usually happens when:\n    - You reset your authtoken\n    - Your authtoken was for a team account that you were removed from\n    - You are using ngrok link and this credential was explicitly revoked\nGo to your ngrok dashboard and double check that your authtoken is correct:\nhttps://dashboard.ngrok.com/get-started/your-authtoken\r\n\r\nERR_NGROK_107\r\n","Extra":{"Version":"","Region":"","Cookie":"","AccountName":"","SessionDuration":0,"PlanName":"","Banner":"","DeprecationWarning":null}}, "err": null}```

now api manager errors for bad api key:
```
2024-11-18T21:13:17Z	ERROR	setup	error running api-manager	{"error": "Unable to load ngrokClientSet: Unable to verify API Key or Authtoken: HTTP 403: The API authentication you specified does not look like a valid credential. Your credential: 'BROKEN'. API keys and instructions are available on your dashboard: https://dashboard.ngrok.com/api-keys [ERR_NGROK_202]\n\nOperation ID: op_2p2VwkFzzgSYJFJp6SCH86IMhpa"}```
```

## Breaking Changes
*Are there any breaking changes in this PR?*
No.
