### PR TITLE
skip no-op status and annotation updates for boundendpoint reconciliation

### DIFF
--- a/internal/controller/bindings/boundendpoint_controller.go
+++ b/internal/controller/bindings/boundendpoint_controller.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
@@ -146,6 +147,7 @@ func (r *BoundEndpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bindingsv1alpha1.BoundEndpoint{}).
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		Watches(
 			&v1.Service{},
 			r.controller.NewEnqueueRequestForMapFunc(r.findBoundEndpointsForService),


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
For tcp endpoints (and http too but it's more noticeable with tcp endpoints because a healthcheck makes it all the way to your agent) the reconciliation loop for bound endpoints was triggering itself by updating the status at the end of an update, causing another update to trigger and so on. This PR adds a predicate so that empty status updates (and annotation updates) don't trigger another object reconciliation.

## How
Adds predicates according to the controller-runtime docs: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.4/pkg/predicate#AnnotationChangedPredicate


## Breaking Changes
shouldn't be any!

## Validation
Previously, you could see your bound endpoint endlessly reconciling really quickly, and the number of connections to your agent climbing quickly. Now, when starting a tcp endpoint you see much fewer healthchecks/conns to your agents and much fewer reconciliations happening in the manager logs.
