### PR TITLE
fix(agent-endpoints): Delete agent endpoint instead of tunnel

### DIFF
--- a/internal/controller/agent/agent_endpoint_controller.go
+++ b/internal/controller/agent/agent_endpoint_controller.go
@@ -156,7 +156,7 @@ func (r *AgentEndpointReconciler) update(ctx context.Context, endpoint *ngrokv1a
 
 func (r *AgentEndpointReconciler) delete(ctx context.Context, endpoint *ngrokv1alpha1.AgentEndpoint) error {
 	tunnelName := r.statusID(endpoint)
-	return r.TunnelDriver.DeleteTunnel(ctx, tunnelName)
+	return r.TunnelDriver.DeleteAgentEndpoint(ctx, tunnelName)
 	// TODO: Delete any associated domain
 }
 


### PR DESCRIPTION
## What

I missed this copy/pasting the tunnel controller. We want to delete from the AgentEndpoint map, not the Tunnel map.

## How
Delete from the AgentEndpointMap instead

## Breaking Changes
No