### PR TITLE
fix endpoint url validation helper and add tests

### DIFF
--- a/internal/controller/agent/agent_endpoint_controller.go
+++ b/internal/controller/agent/agent_endpoint_controller.go
@@ -252,7 +252,7 @@ func (r *AgentEndpointReconciler) findTrafficPolicyByName(ctx context.Context, t
 
 // ensureDomainExists checks if the Domain CRD exists, and if not, creates it.
 func (r *AgentEndpointReconciler) ensureDomainExists(ctx context.Context, aep *ngrokv1alpha1.AgentEndpoint) error {
-	parsedURL, err := tunneldriver.ParseAndSanitizeURL(aep.Spec.URL)
+	parsedURL, err := tunneldriver.ParseAndSanitizeEndpointURL(aep.Spec.URL, true)
 	if err != nil {
 		r.Recorder.Event(aep, v1.EventTypeWarning, "InvalidURL", fmt.Sprintf("Failed to parse URL: %s", aep.Spec.URL))
 		return fmt.Errorf("failed to parse URL %q from AgentEndpoint \"%s.%s\"", aep.Spec.URL, aep.Name, aep.Namespace)

--- a/pkg/tunneldriver/utils.go
+++ b/pkg/tunneldriver/utils.go
@@ -1,0 +1,93 @@
+package tunneldriver
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// ParseAndSanitizeEndpointURL parses/sanitizes an input string for an endpoint url and provides a *url.URL following the restrictions for endpoints.
+// when isIngressURL is true, the input string does not require a port (excluding tcp addresses)
+func ParseAndSanitizeEndpointURL(input string, isIngressURL bool) (*url.URL, error) {
+	// Handle shorthand port format, ex: "8080"
+	if _, err := strconv.Atoi(input); err == nil {
+		// Port shorthand defaults to localhost and http scheme
+		return &url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort("localhost", input),
+		}, nil
+	}
+
+	// Check if the input contains a colon but no scheme (e.g., "service.default:8080")
+	if strings.Contains(input, ":") && !strings.Contains(input, "://") {
+		// Default to HTTP scheme
+		input = "http://" + input
+	}
+
+	// Parse the input as a URL
+	parsedURL, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	// No Scheme (domain shorthand), ex: "example.com"
+	if parsedURL.Scheme == "" {
+		parsedURL.Scheme = "http"
+		// Check if Host is set, and assign it if empty
+		if parsedURL.Host == "" {
+			// Assume the input itself is the hostname
+			parsedURL.Host = input
+		}
+		// Assign default port if no port is present
+		if parsedURL.Port() == "" {
+			parsedURL.Host = net.JoinHostPort(parsedURL.Hostname(), "80")
+		}
+		// Clear the Path to avoid appending the hostname as a path
+		parsedURL.Path = ""
+		return parsedURL, nil
+	}
+
+	// Handle unsupported schemes
+	switch parsedURL.Scheme {
+	case "http", "https", "tcp", "tls":
+		// Do nothing because these schemes are supported
+	default:
+		return nil, fmt.Errorf("unsupported scheme for URL (%q): %q", input, parsedURL.Scheme)
+	}
+
+	// Handle Scheme shorthand format, ex: "https://", "http://", "tcp://", "tls://"
+	if parsedURL.Host == "" {
+		switch parsedURL.Scheme {
+		case "http":
+			parsedURL.Host = "localhost:80"
+		case "https":
+			parsedURL.Host = "localhost:443"
+		case "tcp", "tls":
+			return nil, fmt.Errorf("invalid URL for scheme shorthand format (%q): \"tcp://\" and \"tls://\" must provide a hostname", input)
+		}
+		return parsedURL, nil
+	}
+
+	if parsedURL.Hostname() == "" {
+		return nil, fmt.Errorf("invalid URL (%q), shorthand format not detected and URL is missing a hostname", input)
+	}
+
+	// Auto infer port when empty or error for tcp schemes without a port
+	if parsedURL.Port() == "" {
+		switch parsedURL.Scheme {
+		// Default port inference for HTTP/S
+		case "http":
+			parsedURL.Host = net.JoinHostPort(parsedURL.Hostname(), "80")
+		case "https", "tls":
+			parsedURL.Host = net.JoinHostPort(parsedURL.Hostname(), "443")
+		case "tcp":
+			return nil, fmt.Errorf("invalid URL (%q), tcp schemes require a port and a hostname", input)
+		}
+	} else if parsedURL.Scheme == "tls" && isIngressURL && parsedURL.Port() != "443" {
+		return nil, fmt.Errorf("invalid url %q, tls:// scheme ingress urls only support port 443 for accepting incoming traffic", input)
+	}
+
+	return parsedURL, nil
+}

--- a/pkg/tunneldriver/utils_test.go
+++ b/pkg/tunneldriver/utils_test.go
@@ -1,0 +1,151 @@
+package tunneldriver_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/ngrok/ngrok-operator/pkg/tunneldriver"
+)
+
+func TestParseAndSanitizeEndpointURL(t *testing.T) {
+	successCases := []struct {
+		name         string
+		input        string
+		isIngressURL bool
+		expected     *url.URL
+	}{
+		{
+			"Port shorthand",
+			"8080",
+			false,
+			&url.URL{Scheme: "http", Host: "localhost:8080"},
+		},
+		{
+			"Shorthand with colon",
+			"service.default:8080",
+			false,
+			&url.URL{Scheme: "http", Host: "service.default:8080"},
+		},
+		{
+			"HTTP shorthand scheme",
+			"http://",
+			false, &url.URL{Scheme: "http", Host: "localhost:80"},
+		},
+		{
+			"HTTPS shorthand scheme",
+			"https://",
+			false,
+			&url.URL{Scheme: "https", Host: "localhost:443"},
+		},
+		{
+			"Domain shorthand",
+			"example.com",
+			false,
+			&url.URL{Scheme: "http", Host: "example.com:80"},
+		},
+		{
+			"Domain shorthand with port",
+			"example.com:8080",
+			false,
+			&url.URL{Scheme: "http", Host: "example.com:8080"},
+		},
+		{
+			"HTTP without port",
+			"http://example.com",
+			false,
+			&url.URL{Scheme: "http", Host: "example.com:80"},
+		},
+		{
+			"HTTPS without port",
+			"https://example.com",
+			false,
+			&url.URL{Scheme: "https", Host: "example.com:443"},
+		},
+		{
+			"TLS ingress with 443 port",
+			"tls://example.com:443",
+			true,
+			&url.URL{Scheme: "tls", Host: "example.com:443"},
+		},
+		{
+			"TLS non-ingress URL",
+			"tls://example.com:8443",
+			false,
+			&url.URL{Scheme: "tls", Host: "example.com:8443"},
+		},
+		{
+			"Internal endpoint",
+			"https://example.internal",
+			false,
+			&url.URL{Scheme: "https", Host: "example.internal:443"},
+		},
+	}
+
+	errorCases := []struct {
+		name         string
+		input        string
+		isIngressURL bool
+		expectedErr  string
+	}{
+		{
+			"Invalid TCP scheme",
+			"tcp://",
+			false,
+			`invalid URL for scheme shorthand format ("tcp://"): "tcp://" and "tls://" must provide a hostname`,
+		},
+		{
+			"Unsupported scheme",
+			"custom://service",
+			false,
+			`unsupported scheme for URL ("custom://service"): "custom"`,
+		},
+		{
+			"TCP missing port",
+			"tcp://example.com",
+			false,
+			`invalid URL ("tcp://example.com"), tcp schemes require a port and a hostname`,
+		},
+		{
+			"TLS ingress with non-443 port",
+			"tls://example.com:8443",
+			true,
+			`invalid url "tls://example.com:8443", tls:// scheme ingress urls only support port 443 for accepting incoming traffic`,
+		},
+		{
+			"Invalid URL with empty hostname",
+			"http://:8080",
+			false,
+			`invalid URL ("http://:8080"), shorthand format not detected and URL is missing a hostname`,
+		},
+	}
+
+	t.Run("Success cases", func(t *testing.T) {
+		for _, tt := range successCases {
+			t.Run(tt.name, func(t *testing.T) {
+				result, err := tunneldriver.ParseAndSanitizeEndpointURL(tt.input, tt.isIngressURL)
+				if err != nil {
+					t.Errorf("Unexpected error for input %q: %v", tt.input, err)
+					return
+				}
+				if result.String() != tt.expected.String() {
+					t.Errorf("Expected URL %q, got %q", tt.expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("Error cases", func(t *testing.T) {
+		for _, tt := range errorCases {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := tunneldriver.ParseAndSanitizeEndpointURL(tt.input, tt.isIngressURL)
+				if err == nil {
+					t.Errorf("Expected error for input %q, but got none", tt.input)
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("Expected error message %q, but got %q", tt.expectedErr, err.Error())
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
- Moves the agent endpoint url validation into its own utils file
- Fixes some issues with the initial logic
- Adds test coverage