### PR TITLE
Fix http endpoint scheme

### DIFF
--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -452,6 +452,12 @@ func (td *TunnelDriver) CreateAgentEndpoint(ctx context.Context, name string, sp
 			upstreamProto = string(*spec.Upstream.Protocol)
 		}
 		opts = append(opts, config.WithAppProtocol(upstreamProto))
+
+		// TODO: This should probably be inferred from the scheme in the URL
+		if ingressURL.Scheme == "http" {
+			opts = append(opts, config.WithScheme(config.SchemeHTTP))
+		}
+
 		tunnelConfig = config.HTTPEndpoint(opts...)
 	case "tls":
 		opts := []config.TLSEndpointOption{}

--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -469,6 +469,7 @@ func (td *TunnelDriver) CreateAgentEndpoint(ctx context.Context, name string, sp
 		return fmt.Errorf("unsupported protocol for spec.url: %s", ingressURL.Scheme)
 	}
 
+	log.V(1).Info("Adding agent endpoint to ngrok session")
 	tun, err = session.Listen(ctx, tunnelConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What

This fixes the agent endpoint getting created as a HTTPS endpoint even though the scheme in the url is HTTP.
 
## How
* Add some extra logging
* If the URL scheme is `http`, add the scheme opt so that the endpoint is created as a http endpoint instead of https. We may want to consider fixing this in the ngrok SDK going forward.

## Breaking Changes
No