### PR TITLE
feature names can be lowercase

### DIFF
--- a/internal/controller/ngrok/kubernetesoperator_controller.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller.go
@@ -55,11 +55,10 @@ import (
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
 )
 
-// TODO: features need to be capitalized in the ngrok API currently, this is subject to change
 var featureMap = map[string]string{
-	ngrokv1alpha1.KubernetesOperatorFeatureBindings: "Bindings",
-	ngrokv1alpha1.KubernetesOperatorFeatureIngress:  "Ingress",
-	ngrokv1alpha1.KubernetesOperatorFeatureGateway:  "Gateway",
+	ngrokv1alpha1.KubernetesOperatorFeatureBindings: "bindings",
+	ngrokv1alpha1.KubernetesOperatorFeatureIngress:  "ingress",
+	ngrokv1alpha1.KubernetesOperatorFeatureGateway:  "gateway",
 }
 
 // KubernetesOperatorReconciler reconciles a KubernetesOperator object

--- a/internal/controller/ngrok/kubernetsoperator_controller_test.go
+++ b/internal/controller/ngrok/kubernetsoperator_controller_test.go
@@ -31,7 +31,7 @@ func TestCalculateFeaturesEnabled(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{"Bindings", "Ingress", "Gateway"},
+			expected: []string{"bindings", "ingress", "gateway"},
 		},
 	}
 


### PR DESCRIPTION
## What
The operator feature names had to be uppercase to conform to the api but now lowercase feature names are supported (and preferred).

## How
lowercase the feature name strings

## Breaking Changes
none
