### PR TITLE
fix(service-controller): Service controller uses configured cluster domain

### DIFF
--- a/api/common/v1alpha1/common_types.go
+++ b/api/common/v1alpha1/common_types.go
@@ -31,3 +31,7 @@ func (t ProxyProtocolVersion) IsKnown() bool {
 		return false
 	}
 }
+
+const (
+	DefaultClusterDomain = "svc.cluster.local"
+)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/ngrok/ngrok-api-go/v6/api_keys"
 
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
+	common "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/annotations"
@@ -156,7 +157,7 @@ func cmd() *cobra.Command {
 	c.Flags().StringVar(&opts.ingressWatchNamespace, "ingress-watch-namespace", "", "Namespace to watch for Kubernetes Ingress resources. Defaults to all namespaces.")
 	// TODO(operator-rename): Same as above, but for the manager name.
 	c.Flags().StringVar(&opts.managerName, "manager-name", "ngrok-ingress-controller-manager", "Manager name to identify unique ngrok ingress controller instances")
-	c.Flags().StringVar(&opts.clusterDomain, "cluster-domain", "svc.cluster.local", "Cluster domain used in the cluster")
+	c.Flags().StringVar(&opts.clusterDomain, "cluster-domain", common.DefaultClusterDomain, "Cluster domain used in the cluster")
 	c.Flags().BoolVar(&opts.oneClickDemoMode, "one-click-demo-mode", false, "Run the operator in one-click-demo mode (Ready, but not running)")
 
 	// feature flags
@@ -450,12 +451,12 @@ func enableIngressFeatureSet(_ context.Context, opts managerOpts, mgr ctrl.Manag
 	}
 
 	if err := (&ingresscontroller.ServiceReconciler{
-		Client:    mgr.GetClient(),
-		Log:       ctrl.Log.WithName("controllers").WithName("service"),
-		Scheme:    mgr.GetScheme(),
-		Recorder:  mgr.GetEventRecorderFor("service-controller"),
-		Namespace: opts.namespace,
-		Driver:    driver,
+		Client:        mgr.GetClient(),
+		Log:           ctrl.Log.WithName("controllers").WithName("service"),
+		Scheme:        mgr.GetScheme(),
+		Recorder:      mgr.GetEventRecorderFor("service-controller"),
+		Namespace:     opts.namespace,
+		ClusterDomain: opts.clusterDomain,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Service")
 		os.Exit(1)

--- a/internal/controller/ingress/service_controller.go
+++ b/internal/controller/ingress/service_controller.go
@@ -31,13 +31,13 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	common "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/annotations"
 	"github.com/ngrok/ngrok-operator/internal/annotations/parser"
 	"github.com/ngrok/ngrok-operator/internal/controller"
 	"github.com/ngrok/ngrok-operator/internal/errors"
-	"github.com/ngrok/ngrok-operator/pkg/managerdriver"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,10 +71,15 @@ type ServiceReconciler struct {
 	Scheme    *runtime.Scheme
 	Recorder  record.EventRecorder
 	Namespace string
-	Driver    *managerdriver.Driver
+
+	ClusterDomain string
 }
 
 func (r *ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.ClusterDomain == "" {
+		r.ClusterDomain = common.DefaultClusterDomain
+	}
+
 	owns := []client.Object{
 		&ingressv1alpha1.Tunnel{},
 		&ingressv1alpha1.TCPEdge{},
@@ -368,7 +373,7 @@ func (r *ServiceReconciler) buildTunnelAndEdge(ctx context.Context, svc *corev1.
 			},
 		},
 		Spec: ingressv1alpha1.TunnelSpec{
-			ForwardsTo: fmt.Sprintf("%s.%s.%s:%d", svc.Name, svc.Namespace, "svc.cluster.local", port),
+			ForwardsTo: fmt.Sprintf("%s.%s.%s:%d", svc.Name, svc.Namespace, r.ClusterDomain, port),
 			Labels:     backendLabels,
 		},
 	}

--- a/pkg/managerdriver/driver.go
+++ b/pkg/managerdriver/driver.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	common "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 
@@ -25,8 +26,6 @@ import (
 	"github.com/ngrok/ngrok-operator/internal/store"
 	"github.com/ngrok/ngrok-operator/internal/util"
 )
-
-const defaultClusterDomain = "svc.cluster.local"
 
 const (
 	labelControllerNamespace = "k8s.ngrok.com/controller-namespace"
@@ -90,7 +89,7 @@ func NewDriver(logger logr.Logger, scheme *runtime.Scheme, controllerName string
 		scheme:         scheme,
 		managerName:    managerName,
 		gatewayEnabled: false,
-		clusterDomain:  defaultClusterDomain,
+		clusterDomain:  common.DefaultClusterDomain,
 	}
 
 	for _, opt := range opts {
@@ -461,14 +460,14 @@ func (d *Driver) Sync(ctx context.Context, c client.Client) error {
 	}
 
 	// UpdateGatewayStatuses
-	//if err := d.updateGatewayStatuses(ctx, c); err != nil {
-	//	return err
-	//}
+	// if err := d.updateGatewayStatuses(ctx, c); err != nil {
+	// 	return err
+	// }
 
 	// UpdateHTTPRouteStatuses
-	//if err := d.updateHTTPRouteStatuses(ctx, c); err != nil {
-	//	return err
-	//}
+	// if err := d.updateHTTPRouteStatuses(ctx, c); err != nil {
+	// 	return err
+	// }
 
 	return nil
 }
@@ -945,7 +944,7 @@ func (d *Driver) handleURLRewriteFilter(filter *gatewayv1.HTTPURLRewriteFilter, 
 			}
 		}
 	case "ReplaceFullPath":
-		from := ".*" //"^https?://[^/]+(:[0-9]*)?(/[^\\?]*)?(\\?.*)?$"
+		from := ".*" // "^https?://[^/]+(:[0-9]*)?(/[^\\?]*)?(\\?.*)?$"
 		to := fmt.Sprintf("$scheme://$authority%s$is_args$args", *filter.Path.ReplaceFullPath)
 		err := d.createURLRewriteConfig(from, to, actions)
 		if err != nil {
@@ -977,7 +976,7 @@ func (d *Driver) handleRequestRedirectFilter(filter *gatewayv1.HTTPRequestRedire
 	}
 
 	if filter.Path == nil {
-		from := ".*" //"^https?://[^/]+(:[0-9]*)?(/[^\\?]*)?(\\?.*)?$"
+		from := ".*" // "^https?://[^/]+(:[0-9]*)?(/[^\\?]*)?(\\?.*)?$"
 		to := fmt.Sprintf("%s://%s%s$uri", scheme, hostname, port)
 		err := d.createUrlRedirectConfig(from, to, requestHeaders, filter.StatusCode, actions)
 		if err != nil {
@@ -997,7 +996,7 @@ func (d *Driver) handleRequestRedirectFilter(filter *gatewayv1.HTTPRequestRedire
 			}
 		}
 	case "ReplaceFullPath":
-		from := ".*" //"^https?://[^/]+(:[0-9]*)?(/[^\\?]*)?(\\?.*)?$"
+		from := ".*" // "^https?://[^/]+(:[0-9]*)?(/[^\\?]*)?(\\?.*)?$"
 		to := fmt.Sprintf("%s://%s%s%s$is_args$args", scheme, hostname, port, *filter.Path.ReplaceFullPath)
 		err := d.createUrlRedirectConfig(from, to, requestHeaders, filter.StatusCode, actions)
 		if err != nil {


### PR DESCRIPTION
## What

While working on migrating LB services from edges -> endpoints, I noticed that we weren't respecting the cluster domain configuration option. This makes it so that LB services also respect the configured cluster domain

## How

* Set the default cluster domain const in the go code in 1 place, update the other places we reference it so we can change it in a single place.

## Breaking Changes
No