### PR TITLE
fix(helm): .Values.podLabels should not be included in the deployment selectors

### DIFF
--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -70,8 +70,8 @@ To uninstall the chart:
 
 | Name                                 | Description                                                                               | Value   |
 | ------------------------------------ | ----------------------------------------------------------------------------------------- | ------- |
-| `podAnnotations`                     | Used to apply custom annotations to the ingress pods.                                     | `{}`    |
-| `podLabels`                          | Used to apply custom labels to the ingress pods.                                          | `{}`    |
+| `podAnnotations`                     | Custom pod annotations to apply to all pods.                                              | `{}`    |
+| `podLabels`                          | Custom pod labels to apply to all pods.                                                   | `{}`    |
 | `replicaCount`                       | The number of controllers to run.                                                         | `1`     |
 | `affinity`                           | Affinity for the controller pod assignment                                                | `{}`    |
 | `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`    |

--- a/helm/ngrok-operator/templates/agent/deployment.yaml
+++ b/helm/ngrok-operator/templates/agent/deployment.yaml
@@ -18,9 +18,6 @@ spec:
   selector:
     matchLabels:
       {{- include "ngrok-operator.selectorLabels" . | nindent 6 }}
-      {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 6 }}
-      {{- end }}
       app.kubernetes.io/component: {{ $component }}
   template:
     metadata:

--- a/helm/ngrok-operator/templates/bindings-forwarder/deployment.yaml
+++ b/helm/ngrok-operator/templates/bindings-forwarder/deployment.yaml
@@ -18,9 +18,6 @@ spec:
   selector:
     matchLabels:
       {{- include "ngrok-operator.selectorLabels" . | nindent 6 }}
-      {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 6 }}
-      {{- end }}
       app.kubernetes.io/component: {{ $component }}
   template:
     metadata:

--- a/helm/ngrok-operator/templates/controller-deployment.yaml
+++ b/helm/ngrok-operator/templates/controller-deployment.yaml
@@ -15,9 +15,6 @@ spec:
   selector:
     matchLabels:
       {{- include "ngrok-operator.selectorLabels" . | nindent 6 }}
-      {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 6 }}
-      {{- end }}
       app.kubernetes.io/component: {{ $component }}
   template:
     metadata:

--- a/helm/ngrok-operator/tests/agent/deployment_test.yaml
+++ b/helm/ngrok-operator/tests/agent/deployment_test.yaml
@@ -9,3 +9,27 @@ tests:
 - it: Should match snapshot
   asserts:
   - matchSnapshot: {}
+- it: Adds .Values.podLabels to the controller deployment podspec
+  set:
+    podLabels:
+      labelKey1: labelValue1
+      labelKey2: labelValue2
+  template: agent/deployment.yaml
+  asserts:
+  - isSubset:
+      path: spec.template.metadata.labels
+      content:
+        labelKey1: labelValue1
+        labelKey2: labelValue2
+- it: Does not add .Values.podLabels to the controller deployment's selector
+  set:
+    podLabels:
+      labelKey1: labelValue1
+      labelKey2: labelValue2
+  template: agent/deployment.yaml
+  asserts:
+  - isNotSubset:
+      path: spec.selector.matchLabels
+      content:
+        labelKey1: labelValue1
+        labelKey2: labelValue2

--- a/helm/ngrok-operator/tests/bindings-forwarder/deployment_test.yaml
+++ b/helm/ngrok-operator/tests/bindings-forwarder/deployment_test.yaml
@@ -19,3 +19,27 @@ tests:
   - equal:
       path: metadata.name
       value: RELEASE-NAME-ngrok-operator-bindings-forwarder
+- it: Adds .Values.podLabels to the controller deployment podspec
+  set:
+    podLabels:
+      labelKey1: labelValue1
+      labelKey2: labelValue2
+  template: bindings-forwarder/deployment.yaml
+  asserts:
+  - isSubset:
+      path: spec.template.metadata.labels
+      content:
+        labelKey1: labelValue1
+        labelKey2: labelValue2
+- it: Does not add .Values.podLabels to the controller deployment's selector
+  set:
+    podLabels:
+      labelKey1: labelValue1
+      labelKey2: labelValue2
+  template: bindings-forwarder/deployment.yaml
+  asserts:
+  - isNotSubset:
+      path: spec.selector.matchLabels
+      content:
+        labelKey1: labelValue1
+        labelKey2: labelValue2

--- a/helm/ngrok-operator/tests/controller-deployment_test.yaml
+++ b/helm/ngrok-operator/tests/controller-deployment_test.yaml
@@ -354,3 +354,29 @@ tests:
   - equal:
       path: spec.template.spec.priorityClassName
       value: high-priority
+- it: Adds .Values.podLabels to the controller deployment podspec
+  set:
+    podLabels:
+      labelKey1: labelValue1
+      labelKey2: labelValue2
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - isSubset:
+      path: spec.template.metadata.labels
+      content:
+        labelKey1: labelValue1
+        labelKey2: labelValue2
+- it: Does not add .Values.podLabels to the controller deployment's selector
+  set:
+    podLabels:
+      labelKey1: labelValue1
+      labelKey2: labelValue2
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - isNotSubset:
+      path: spec.selector.matchLabels
+      content:
+        labelKey1: labelValue1
+        labelKey2: labelValue2

--- a/helm/ngrok-operator/values.schema.json
+++ b/helm/ngrok-operator/values.schema.json
@@ -95,12 +95,12 @@
         },
         "podAnnotations": {
             "type": "object",
-            "description": "Used to apply custom annotations to the ingress pods.",
+            "description": "Custom pod annotations to apply to all pods.",
             "default": {}
         },
         "podLabels": {
             "type": "object",
-            "description": "Used to apply custom labels to the ingress pods.",
+            "description": "Custom pod labels to apply to all pods.",
             "default": {}
         },
         "replicaCount": {

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -65,8 +65,8 @@ clusterDomain: svc.cluster.local
 ##
 ## @section Operator Manager parameters
 ##
-## @param podAnnotations Used to apply custom annotations to the ingress pods.
-## @param podLabels Used to apply custom labels to the ingress pods.
+## @param podAnnotations Custom pod annotations to apply to all pods.
+## @param podLabels Custom pod labels to apply to all pods.
 ##
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
Fixes #556 

## What

Fixes `.Values.podLabels` being included in the deployments' `spec.selector.matchLabels`.

## How

* Remove `podLabels` templates from the deployments' `spec.selector.matchLabels`.
* Add tests to verify that `podLabels` are added to the pod spec templates, but not the deployments' selector matchLabesl.

## Breaking Changes

Yes, the `.Values.podLabels` were previously added incorrectly as additional selector labels. If you had previously supplied `.Values.podLabels`, you will need to delete the existing deployment. You can do this with minimal downtime by [deleting the deployment and orphaning the resources](https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/#set-orphan-deletion-policy) controlled by the deployment. 