### PR TITLE
fix(ngrok-api-go): Update to client that doesn't panic for get_bound_endpoints

### DIFF
--- a/.github/actions/build-and-test/action.yaml
+++ b/.github/actions/build-and-test/action.yaml
@@ -17,14 +17,17 @@ inputs:
     description: "NGROK_AUTHTOKEN for e2e tests, if enabled"
     required: false
     default: "fake-authtoken"
+  kind-version:
+    description: "KIND version to use"
+    required: false
+    default: "v0.26.0"
 
 runs:
   using: "composite"
   steps:
-    - uses: debianmaster/actions-k3s@master
-      id: k3s
+    - uses: engineerd/setup-kind@v0.6.2
       with:
-        version: 'latest'
+        version: ${{ inputs.kind-version }}
 
     - shell: bash
       run: |
@@ -64,8 +67,6 @@ runs:
         NGROK_API_KEY: ${{ inputs.ngrok-api-key }}
         NGROK_AUTHTOKEN: ${{ inputs.ngrok-authtoken }}
         E2E_BINDING_NAME: k8s/e2e-${{ github.run_id }}
-        # use the latest image built in this run
-        IMG: ngrok/ngrok-operator
       run: |
         # create some namespaces for bindings tests
         kubectl create ns e2e || true

--- a/Makefile
+++ b/Makefile
@@ -197,12 +197,14 @@ deploy_with_bindings: _deploy-check-env-vars docker-build manifests kustomize _h
 
 .PHONY: deploy_for_e2e
 deploy_for_e2e: _deploy-check-env-vars docker-build manifests kustomize _helm_setup ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	kind load docker-image $(IMG)
 	helm upgrade $(HELM_RELEASE_NAME) $(HELM_CHART_DIR) --install \
 		--namespace $(KUBE_NAMESPACE) \
 		--create-namespace \
 		--set oneClickDemoMode=$(DEPLOY_ONE_CLICK_DEMO_MODE) \
 		--set image.repository=$(IMG) \
 		--set image.tag="latest" \
+		--set image.pullPolicy="Never" \
 		--set podAnnotations."k8s\.ngrok\.com/test"="\{\"env\": \"e2e\"\}" \
 		--set credentials.apiKey=$(NGROK_API_KEY) \
 		--set credentials.authtoken=$(NGROK_AUTHTOKEN) \

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.3.1
 	github.com/imdario/mergo v0.3.16
-	github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241219163904-f9bc510716c0
+	github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241219193420-f4e8c117e57f
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
-github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241219163904-f9bc510716c0 h1:CvkuidFUpHZA60ctarFLGX17nxCEIpGbZpY//iXNQ3I=
-github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241219163904-f9bc510716c0/go.mod h1:KtRxWqEomaHZfgeS+q/7nFHF+gPYFghS5wTl5AIUjIk=
+github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241219193420-f4e8c117e57f h1:+0NOrD1yO/psIunSg6Ea+PQXej8TWWNG5yKryppU/DI=
+github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241219193420-f4e8c117e57f/go.mod h1:KtRxWqEomaHZfgeS+q/7nFHF+gPYFghS5wTl5AIUjIk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What

Our code gen was wrong for getting bound endpoints on a kubernetes operator. This updates to a version that shouldn't panic.
 
## How
* Fix and regen our client
* Update to using the fixed version :crossed_fingers: 

## Breaking Changes
No