### PR TITLE
fix: managerdriver tests not being run

### DIFF
--- a/pkg/managerdriver/suite_test.go
+++ b/pkg/managerdriver/suite_test.go
@@ -1,0 +1,13 @@
+package managerdriver
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestManagerDriver(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ManagerDriver package Test Suite")
+}


### PR DESCRIPTION
## What

Add back test to run Ginko specs for the manager driver. We had the test copied over in https://github.com/ngrok/ngrok-operator/pull/553, but Ginko needs a go test to run the specs.

## How
Add the test back so that Ginko runs and we test more code.

## Breaking Changes
No
