### PR TITLE
add newly created agent endpoints to the map

### DIFF
--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -480,6 +480,7 @@ func (td *TunnelDriver) CreateAgentEndpoint(ctx context.Context, name string, sp
 	if err != nil {
 		return err
 	}
+	td.agentEndpoints.Add(name, tun)
 
 	upstreamPort, err := strconv.Atoi(upstreamURL.Port())
 	if err != nil {


### PR DESCRIPTION
We can't delete agent endpoints when the `AgentEndpoint` custom resources are deleted because we never add them to the map that tracks them. Adding the entry to the map makes this work as intended.