### PR TITLE
fix(httpsedges): HTTPS Edges should retry on hostport already in use

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        # Only run in informational mode for now. We want to track coverage
+        # without gating PRs on it until we have better mocking and can do
+        # more thourough testing.
+        informational: true

--- a/internal/controller/ingress/httpsedge_controller.go
+++ b/internal/controller/ingress/httpsedge_controller.go
@@ -91,7 +91,10 @@ func (r *HTTPSEdgeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			if errors.As(err, &ierr.ErrInvalidConfiguration{}) {
 				return ctrl.Result{}, nil
 			}
-			if ngrok.IsErrorCode(err, 7117) { // https://ngrok.com/docs/errors/err_ngrok_7117, domain not found
+			if ngrok.IsErrorCode(err,
+				7117, // https://ngrok.com/docs/errors/err_ngrok_7117, domain not found
+				7132, // https://ngrok.com/docs/errors/err_ngrok_7132, hostport already in use
+			) {
 				return ctrl.Result{}, err
 			}
 			return controller.CtrlResultForErr(err)


### PR DESCRIPTION
## What

When migrating back to edges from endpoints, the httpsedges controller does not retry on the 'hostport already in use'. It should retry because the cloudendpoint may not have been deleted yet and the hostport is still in use.

## How
* Re-reconcile on hostport conflict
* Add codecov.yml to control how codecov treats status checks

## Breaking Changes
No