### PR TITLE
chore(ci): Make codecov patch status informational for now as well

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,11 @@
 coverage:
   status:
+    patch:
+      default:
+        # Only run in informational mode for now. We want to track coverage
+        # without gating PRs on it until we have better mocking and can do
+        # more thourough testing.
+        informational: true
     project:
       default:
         # Only run in informational mode for now. We want to track coverage


### PR DESCRIPTION
## What

Minor change to our codecov.yml file so it stops showing red X on merges for now. We're in the process of mocking out the ngrok API and SDKs so that we can increase testing coverage, but we aren't there yet.

## How

Patch status is informational only.

## Breaking Changes
No