### PR TITLE
refactor(ngrokapi): Refactor ngrokapi package to better support mocking

### DIFF
--- a/internal/controller/ingress/domain_controller.go
+++ b/internal/controller/ingress/domain_controller.go
@@ -38,9 +38,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/ngrok/ngrok-api-go/v7"
-	"github.com/ngrok/ngrok-api-go/v7/reserved_domains"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
+	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
 )
 
 // DomainReconciler reconciles a Domain object
@@ -50,7 +50,7 @@ type DomainReconciler struct {
 	Log           logr.Logger
 	Scheme        *runtime.Scheme
 	Recorder      record.EventRecorder
-	DomainsClient *reserved_domains.Client
+	DomainsClient ngrokapi.DomainClient
 
 	controller *controller.BaseController[*ingressv1alpha1.Domain]
 }

--- a/internal/controller/ingress/httpsedge_controller.go
+++ b/internal/controller/ingress/httpsedge_controller.go
@@ -45,7 +45,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/ngrok/ngrok-api-go/v7"
-	"github.com/ngrok/ngrok-api-go/v7/backends/tunnel_group"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
 	ierr "github.com/ngrok/ngrok-operator/internal/errors"
@@ -508,11 +507,11 @@ func (r *HTTPSEdgeReconciler) listHTTPSEdgesForIPPolicy(ctx context.Context, obj
 
 // Tunnel Group Backend planner
 type tunnelGroupBackendReconciler struct {
-	client   *tunnel_group.Client
+	client   ngrokapi.TunnelGroupBackendsClient
 	backends []*ngrok.TunnelGroupBackend
 }
 
-func newTunnelGroupBackendReconciler(client *tunnel_group.Client) (*tunnelGroupBackendReconciler, error) {
+func newTunnelGroupBackendReconciler(client ngrokapi.TunnelGroupBackendsClient) (*tunnelGroupBackendReconciler, error) {
 	backends := make([]*ngrok.TunnelGroupBackend, 0)
 	iter := client.List(&ngrok.Paging{})
 	for iter.Next(context.Background()) {

--- a/internal/controller/ingress/ippolicy_controller.go
+++ b/internal/controller/ingress/ippolicy_controller.go
@@ -37,10 +37,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/ngrok/ngrok-api-go/v7"
-	"github.com/ngrok/ngrok-api-go/v7/ip_policies"
-	"github.com/ngrok/ngrok-api-go/v7/ip_policy_rules"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
+	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
 )
 
 const (
@@ -56,8 +55,8 @@ type IPPolicyReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 
-	IPPoliciesClient    *ip_policies.Client
-	IPPolicyRulesClient *ip_policy_rules.Client
+	IPPoliciesClient    ngrokapi.IPPoliciesClient
+	IPPolicyRulesClient ngrokapi.IPPolicyRulesClient
 
 	controller *controller.BaseController[*ingressv1alpha1.IPPolicy]
 }

--- a/internal/ngrokapi/bindingendpoint_aggregator_test.go
+++ b/internal/ngrokapi/bindingendpoint_aggregator_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	v6 "github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v7"
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 )
 
@@ -52,14 +52,14 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		endpoints []v6.Endpoint
+		endpoints []ngrok.Endpoint
 		want      AggregatedEndpoints
 		wantErr   bool
 	}{
-		{"empty", []v6.Endpoint{}, AggregatedEndpoints{}, false},
+		{"empty", []ngrok.Endpoint{}, AggregatedEndpoints{}, false},
 		{
 			name: "single",
-			endpoints: []v6.Endpoint{
+			endpoints: []ngrok.Endpoint{
 				{ID: "ep_123", PublicURL: "https://service1.namespace1"},
 			},
 			want: AggregatedEndpoints{
@@ -76,7 +76,7 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: v6.Ref{ID: "ep_123"}},
+							{Ref: ngrok.Ref{ID: "ep_123"}},
 						},
 					},
 				},
@@ -85,7 +85,7 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 		},
 		{
 			name: "full",
-			endpoints: []v6.Endpoint{
+			endpoints: []ngrok.Endpoint{
 				{ID: "ep_100", PublicURL: "https://service1.namespace1"},
 				{ID: "ep_101", PublicURL: "https://service1.namespace1"},
 				{ID: "ep_102", PublicURL: "https://service1.namespace1"},
@@ -108,9 +108,9 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: v6.Ref{ID: "ep_100"}},
-							{Ref: v6.Ref{ID: "ep_101"}},
-							{Ref: v6.Ref{ID: "ep_102"}},
+							{Ref: ngrok.Ref{ID: "ep_100"}},
+							{Ref: ngrok.Ref{ID: "ep_101"}},
+							{Ref: ngrok.Ref{ID: "ep_102"}},
 						},
 					},
 				},
@@ -127,8 +127,8 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: v6.Ref{ID: "ep_200"}},
-							{Ref: v6.Ref{ID: "ep_201"}},
+							{Ref: ngrok.Ref{ID: "ep_200"}},
+							{Ref: ngrok.Ref{ID: "ep_201"}},
 						},
 					},
 				},
@@ -145,7 +145,7 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: v6.Ref{ID: "ep_300"}},
+							{Ref: ngrok.Ref{ID: "ep_300"}},
 						},
 					},
 				},
@@ -162,7 +162,7 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: v6.Ref{ID: "ep_400"}},
+							{Ref: ngrok.Ref{ID: "ep_400"}},
 						},
 					},
 				},

--- a/internal/ngrokapi/edge_modules_clientset.go
+++ b/internal/ngrokapi/edge_modules_clientset.go
@@ -1,11 +1,28 @@
 package ngrokapi
 
-import "github.com/ngrok/ngrok-api-go/v7"
+import (
+	"context"
+
+	"github.com/ngrok/ngrok-api-go/v7"
+)
 
 type EdgeModulesClientset interface {
 	TCP() TCPEdgeModulesClientset
 	HTTPS() HTTPSEdgeModulesClientset
 	TLS() TLSEdgeModulesClientset
+}
+
+type edgeModulesClient[R, T any] interface {
+	Deletor
+	Replace(context.Context, R) (T, error)
+}
+
+type EdgeRouteModulesDeletor interface {
+	Delete(context.Context, *ngrok.EdgeRouteItem) error
+}
+
+type EdgeRouteModulesReplacer[R, T any] interface {
+	Replace(context.Context, R) (T, error)
 }
 
 type defaultEdgeModulesClientset struct {

--- a/internal/ngrokapi/edge_modules_https_clientset.go
+++ b/internal/ngrokapi/edge_modules_https_clientset.go
@@ -19,10 +19,15 @@ import (
 )
 
 type HTTPSEdgeModulesClientset interface {
-	MutualTLS() *https_edge_mutual_tls.Client
+	MutualTLS() HTTPSEdgeModulesMutualTLSClient
 	Routes() HTTPSEdgeRouteModulesClientset
-	TLSTermination() *https_edge_tls_termination.Client
+	TLSTermination() HTTPSEdgeModulesTLSTerminationClient
 }
+
+type (
+	HTTPSEdgeModulesMutualTLSClient      = edgeModulesClient[*ngrok.EdgeMutualTLSReplace, *ngrok.EndpointMutualTLS]
+	HTTPSEdgeModulesTLSTerminationClient = edgeModulesClient[*ngrok.EdgeTLSTerminationAtEdgeReplace, *ngrok.EndpointTLSTermination]
+)
 
 type defaultHTTPSEdgeModulesClientset struct {
 	mutualTLS      *https_edge_mutual_tls.Client
@@ -38,7 +43,7 @@ func newHTTPSEdgeModulesClientset(config *ngrok.ClientConfig) *defaultHTTPSEdgeM
 	}
 }
 
-func (c *defaultHTTPSEdgeModulesClientset) MutualTLS() *https_edge_mutual_tls.Client {
+func (c *defaultHTTPSEdgeModulesClientset) MutualTLS() HTTPSEdgeModulesMutualTLSClient {
 	return c.mutualTLS
 }
 
@@ -46,23 +51,23 @@ func (c *defaultHTTPSEdgeModulesClientset) Routes() HTTPSEdgeRouteModulesClients
 	return c.routes
 }
 
-func (c *defaultHTTPSEdgeModulesClientset) TLSTermination() *https_edge_tls_termination.Client {
+func (c *defaultHTTPSEdgeModulesClientset) TLSTermination() HTTPSEdgeModulesTLSTerminationClient {
 	return c.tlsTermination
 }
 
 type HTTPSEdgeRouteModulesClientset interface {
-	Backend() *https_edge_route_backend.Client
-	CircuitBreaker() *https_edge_route_circuit_breaker.Client
-	Compression() *https_edge_route_compression.Client
-	IPRestriction() *https_edge_route_ip_restriction.Client
-	OAuth() *https_edge_route_oauth.Client
-	TrafficPolicy() *https_edge_route_traffic_policy.Client
-	OIDC() *https_edge_route_oidc.Client
-	RequestHeaders() *https_edge_route_request_headers.Client
-	ResponseHeaders() *https_edge_route_response_headers.Client
-	SAML() *https_edge_route_saml.Client
-	WebhookVerification() *https_edge_route_webhook_verification.Client
-	WebsocketTCPConverter() *https_edge_route_websocket_tcp_converter.Client
+	Backend() HTTPSEdgeRouteBackendClient
+	CircuitBreaker() HTTPSEdgeRouteCircuitBreakerClient
+	Compression() HTTPSEdgeRouteCompressionClient
+	IPRestriction() HTTPSEdgeRouteIPRestrictionClient
+	OAuth() HTTPSEdgeRouteOAuthClient
+	OIDC() HTTPSEdgeRouteOIDCClient
+	RequestHeaders() HTTPSEdgeRouteRequestHeadersClient
+	ResponseHeaders() HTTPSEdgeRouteResponseHeadersClient
+	SAML() HTTPSEdgeRouteSAMLClient
+	TrafficPolicy() HTTPSEdgeRouteTrafficPolicyClient
+	WebhookVerification() HTTPSEdgeRouteWebhookVerificationClient
+	WebsocketTCPConverter() HTTPSEdgeRouteWebsocketTCPConverterClient
 }
 
 type defaultHTTPSEdgeRouteModulesClientset struct {
@@ -97,50 +102,70 @@ func newHTTPSEdgeRouteModulesClient(config *ngrok.ClientConfig) *defaultHTTPSEdg
 	}
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) Backend() *https_edge_route_backend.Client {
+type httpsEdgeRouteModulesClient[R, T any] interface {
+	EdgeRouteModulesDeletor
+	EdgeRouteModulesReplacer[R, T]
+}
+
+type (
+	HTTPSEdgeRouteBackendClient               = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteBackendReplace, *ngrok.EndpointBackend]
+	HTTPSEdgeRouteCircuitBreakerClient        = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteCircuitBreakerReplace, *ngrok.EndpointCircuitBreaker]
+	HTTPSEdgeRouteCompressionClient           = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteCompressionReplace, *ngrok.EndpointCompression]
+	HTTPSEdgeRouteIPRestrictionClient         = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteIPRestrictionReplace, *ngrok.EndpointIPPolicy]
+	HTTPSEdgeRouteOAuthClient                 = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteOAuthReplace, *ngrok.EndpointOAuth]
+	HTTPSEdgeRouteOIDCClient                  = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteOIDCReplace, *ngrok.EndpointOIDC]
+	HTTPSEdgeRouteRequestHeadersClient        = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteRequestHeadersReplace, *ngrok.EndpointRequestHeaders]
+	HTTPSEdgeRouteResponseHeadersClient       = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteResponseHeadersReplace, *ngrok.EndpointResponseHeaders]
+	HTTPSEdgeRouteSAMLClient                  = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteSAMLReplace, *ngrok.EndpointSAML]
+	HTTPSEdgeRouteTrafficPolicyClient         = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteTrafficPolicyReplace, *ngrok.EndpointTrafficPolicy]
+	HTTPSEdgeRouteWebhookVerificationClient   = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteWebhookVerificationReplace, *ngrok.EndpointWebhookValidation]
+	HTTPSEdgeRouteWebsocketTCPConverterClient = httpsEdgeRouteModulesClient[*ngrok.EdgeRouteWebsocketTCPConverterReplace, *ngrok.EndpointWebsocketTCPConverter]
+)
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) Backend() HTTPSEdgeRouteBackendClient {
 	return c.backend
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) CircuitBreaker() *https_edge_route_circuit_breaker.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) CircuitBreaker() HTTPSEdgeRouteCircuitBreakerClient {
 	return c.circuitBreaker
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) Compression() *https_edge_route_compression.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) Compression() HTTPSEdgeRouteCompressionClient {
 	return c.compression
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) IPRestriction() *https_edge_route_ip_restriction.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) IPRestriction() HTTPSEdgeRouteIPRestrictionClient {
 	return c.ipRestriction
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) OAuth() *https_edge_route_oauth.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) OAuth() HTTPSEdgeRouteOAuthClient {
 	return c.oauth
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) TrafficPolicy() *https_edge_route_traffic_policy.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) TrafficPolicy() HTTPSEdgeRouteTrafficPolicyClient {
 	return c.trafficPolicy
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) OIDC() *https_edge_route_oidc.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) OIDC() HTTPSEdgeRouteOIDCClient {
 	return c.oidc
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) RequestHeaders() *https_edge_route_request_headers.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) RequestHeaders() HTTPSEdgeRouteRequestHeadersClient {
 	return c.requestHeaders
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) ResponseHeaders() *https_edge_route_response_headers.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) ResponseHeaders() HTTPSEdgeRouteResponseHeadersClient {
 	return c.responseHeaders
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) SAML() *https_edge_route_saml.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) SAML() HTTPSEdgeRouteSAMLClient {
 	return c.saml
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) WebhookVerification() *https_edge_route_webhook_verification.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) WebhookVerification() HTTPSEdgeRouteWebhookVerificationClient {
 	return c.webhookVerification
 }
 
-func (c *defaultHTTPSEdgeRouteModulesClientset) WebsocketTCPConverter() *https_edge_route_websocket_tcp_converter.Client {
+func (c *defaultHTTPSEdgeRouteModulesClientset) WebsocketTCPConverter() HTTPSEdgeRouteWebsocketTCPConverterClient {
 	return c.websocketTCPConverter
 }

--- a/internal/ngrokapi/edge_modules_tcp_clientset.go
+++ b/internal/ngrokapi/edge_modules_tcp_clientset.go
@@ -8,10 +8,16 @@ import (
 )
 
 type TCPEdgeModulesClientset interface {
-	Backend() *tcp_edge_backend.Client
-	IPRestriction() *tcp_edge_ip_restriction.Client
-	TrafficPolicy() *tcp_edge_traffic_policy.Client
+	Backend() TCPEdgeModulesBackendClient
+	IPRestriction() TCPEdgeModulesIPRestrictionClient
+	TrafficPolicy() TCPEdgeModulesTrafficPolicyClient
 }
+
+type (
+	TCPEdgeModulesBackendClient       = edgeModulesClient[*ngrok.EdgeBackendReplace, *ngrok.EndpointBackend]
+	TCPEdgeModulesIPRestrictionClient = edgeModulesClient[*ngrok.EdgeIPRestrictionReplace, *ngrok.EndpointIPPolicy]
+	TCPEdgeModulesTrafficPolicyClient = edgeModulesClient[*ngrok.EdgeTrafficPolicyReplace, *ngrok.EndpointTrafficPolicy]
+)
 
 type defaultTCPEdgeModulesClientset struct {
 	backend       *tcp_edge_backend.Client
@@ -27,14 +33,14 @@ func newTCPEdgeModulesClientset(config *ngrok.ClientConfig) *defaultTCPEdgeModul
 	}
 }
 
-func (c *defaultTCPEdgeModulesClientset) Backend() *tcp_edge_backend.Client {
+func (c *defaultTCPEdgeModulesClientset) Backend() TCPEdgeModulesBackendClient {
 	return c.backend
 }
 
-func (c *defaultTCPEdgeModulesClientset) IPRestriction() *tcp_edge_ip_restriction.Client {
+func (c *defaultTCPEdgeModulesClientset) IPRestriction() TCPEdgeModulesIPRestrictionClient {
 	return c.ipRestriction
 }
 
-func (c *defaultTCPEdgeModulesClientset) TrafficPolicy() *tcp_edge_traffic_policy.Client {
+func (c *defaultTCPEdgeModulesClientset) TrafficPolicy() TCPEdgeModulesTrafficPolicyClient {
 	return c.trafficPolicy
 }

--- a/internal/ngrokapi/edge_modules_tls_clientset.go
+++ b/internal/ngrokapi/edge_modules_tls_clientset.go
@@ -10,12 +10,20 @@ import (
 )
 
 type TLSEdgeModulesClientset interface {
-	Backend() *tls_edge_backend.Client
-	IPRestriction() *tls_edge_ip_restriction.Client
-	MutualTLS() *tls_edge_mutual_tls.Client
-	TLSTermination() *tls_edge_tls_termination.Client
-	TrafficPolicy() *tls_edge_traffic_policy.Client
+	Backend() TLSEdgeModulesBackendClient
+	IPRestriction() TLSEdgeModulesIPRestrictionClient
+	MutualTLS() TLSEdgeModulesMutualTLSClient
+	TLSTermination() TLSEdgeModulesTLSTerminationClient
+	TrafficPolicy() TLSEdgeModulesTrafficPolicyClient
 }
+
+type (
+	TLSEdgeModulesBackendClient        = edgeModulesClient[*ngrok.EdgeBackendReplace, *ngrok.EndpointBackend]
+	TLSEdgeModulesIPRestrictionClient  = edgeModulesClient[*ngrok.EdgeIPRestrictionReplace, *ngrok.EndpointIPPolicy]
+	TLSEdgeModulesMutualTLSClient      = edgeModulesClient[*ngrok.EdgeMutualTLSReplace, *ngrok.EndpointMutualTLS]
+	TLSEdgeModulesTLSTerminationClient = edgeModulesClient[*ngrok.EdgeTLSTerminationReplace, *ngrok.EndpointTLSTermination]
+	TLSEdgeModulesTrafficPolicyClient  = edgeModulesClient[*ngrok.EdgeTrafficPolicyReplace, *ngrok.EndpointTrafficPolicy]
+)
 
 type defaultTLSEdgeModulesClientset struct {
 	backend        *tls_edge_backend.Client
@@ -35,22 +43,22 @@ func newTLSEdgeModulesClientset(config *ngrok.ClientConfig) *defaultTLSEdgeModul
 	}
 }
 
-func (c *defaultTLSEdgeModulesClientset) Backend() *tls_edge_backend.Client {
+func (c *defaultTLSEdgeModulesClientset) Backend() TLSEdgeModulesBackendClient {
 	return c.backend
 }
 
-func (c *defaultTLSEdgeModulesClientset) IPRestriction() *tls_edge_ip_restriction.Client {
+func (c *defaultTLSEdgeModulesClientset) IPRestriction() TLSEdgeModulesIPRestrictionClient {
 	return c.ipRestriction
 }
 
-func (c *defaultTLSEdgeModulesClientset) MutualTLS() *tls_edge_mutual_tls.Client {
+func (c *defaultTLSEdgeModulesClientset) MutualTLS() TLSEdgeModulesMutualTLSClient {
 	return c.mutualTLS
 }
 
-func (c *defaultTLSEdgeModulesClientset) TLSTermination() *tls_edge_tls_termination.Client {
+func (c *defaultTLSEdgeModulesClientset) TLSTermination() TLSEdgeModulesTLSTerminationClient {
 	return c.tlsTermination
 }
 
-func (c *defaultTLSEdgeModulesClientset) TrafficPolicy() *tls_edge_traffic_policy.Client {
+func (c *defaultTLSEdgeModulesClientset) TrafficPolicy() TLSEdgeModulesTrafficPolicyClient {
 	return c.trafficPolicy
 }


### PR DESCRIPTION
## What

Step 1 in beefing up our test coverage. Rather than returning clients for everything, return interfaces that behave like the actual clients. This will allow us to rely on the interfaces in the rest of the code and eventually substitute mock clients so we can test the behavior of our controllers better.

## How

Make interfaces for our clients and replace the actual implementation with the interfaces.

## Breaking Changes
No
