### PR TITLE
add cloud endpoint pooling support

### DIFF
--- a/api/ngrok/v1alpha1/cloudendpoint_types.go
+++ b/api/ngrok/v1alpha1/cloudendpoint_types.go
@@ -52,6 +52,14 @@ type CloudEndpointSpec struct {
 	// +kubebuilder:validation:Optional
 	TrafficPolicyName string `json:"trafficPolicyName,omitempty"`
 
+	// Controlls whether or not the Cloud Endpoint should allow pooling with other
+	// Cloud Endpoints sharing the same URL. When Cloud Endpoints are pooled, any requests
+	// going to the URL for the pooled endpoint will be distributed among all Cloud Endpoints
+	// in the pool. A URL can only be shared across multiple Cloud Endpoints if they all have pooling enabled.
+	//
+	// +kubebuilder:validation:Optional
+	PoolingEnabled bool `json:"poolingEnabled"`
+
 	// Allows inline definition of a TrafficPolicy object
 	//
 	// +kubebuilder:validation:Optional

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/sync v0.10.0
 	google.golang.org/protobuf v1.36.4
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.29.2
 	k8s.io/apimachinery v0.29.2
 	k8s.io/client-go v0.29.2
@@ -97,7 +98,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.2 // indirect
 	k8s.io/component-base v0.29.2 // indirect

--- a/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_cloudendpoints.yaml
+++ b/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_cloudendpoints.yaml
@@ -70,6 +70,13 @@ spec:
                 description: String of arbitrary data associated with the object in
                   the ngrok API/Dashboard
                 type: string
+              poolingEnabled:
+                description: |-
+                  Controlls whether or not the Cloud Endpoint should allow pooling with other
+                  Cloud Endpoints sharing the same URL. When Cloud Endpoints are pooled, any requests
+                  going to the URL for the pooled endpoint will be distributed among all Cloud Endpoints
+                  in the pool. A URL can only be shared across multiple Cloud Endpoints if they all have pooling enabled.
+                type: boolean
               trafficPolicy:
                 description: Allows inline definition of a TrafficPolicy object
                 properties:

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -43,6 +43,9 @@ const (
 	MappingStrategyAnnotationKey = "mapping-strategy"
 	MappingStrategy_Endpoints    = "endpoints"
 	MappingStrategy_Edges        = "edges"
+
+	EndpointPoolingAnnotation    = "k8s.ngrok.com/pooling-enabled"
+	EndpointPoolingAnnotationKey = "pooling-enabled"
 )
 
 type RouteModules struct {
@@ -147,4 +150,18 @@ func ExtractUseEndpoints(obj client.Object) (bool, error) {
 		return false, err
 	}
 	return strings.EqualFold(val, MappingStrategy_Endpoints), nil
+}
+
+// Whether or not we should use endpoint pooling
+// from the annotation "k8s.ngrok.com/pooling-enabled" if it is present. Otherwise, it defaults to false
+func ExtractUseEndpointPooling(obj client.Object) (bool, error) {
+	val, err := parser.GetStringAnnotation(EndpointPoolingAnnotationKey, obj)
+	if err != nil {
+		if errors.IsMissingAnnotations(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return strings.EqualFold(val, "true"), nil
 }

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -133,3 +133,64 @@ func TestExtractUseEndpoints(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractUseEndpointPooling(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+		expectedErr error
+	}{
+		{
+			name: "Pooling enabled",
+			annotations: map[string]string{
+				"k8s.ngrok.com/pooling-enabled": "true",
+			},
+			expected:    true,
+			expectedErr: nil,
+		},
+		{
+			name: "Pooling disabled",
+			annotations: map[string]string{
+				"k8s.ngrok.com/pooling-enabled": "false",
+			},
+			expected:    false,
+			expectedErr: nil,
+		},
+		{
+			name: "Invalid value",
+			annotations: map[string]string{
+				"k8s.ngrok.com/pooling-enabled": "foo",
+			},
+			expected:    false,
+			expectedErr: nil,
+		},
+		{
+			name:        "Annotation not present",
+			annotations: nil,
+			expected:    false,
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-ingress",
+					Namespace:   "default",
+					Annotations: tc.annotations,
+				},
+			}
+
+			useEndpoints, err := annotations.ExtractUseEndpointPooling(obj)
+			if tc.expectedErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, tc.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, useEndpoints)
+			}
+		})
+	}
+}

--- a/internal/controller/ngrok/cloudendpoint_controller.go
+++ b/internal/controller/ngrok/cloudendpoint_controller.go
@@ -154,12 +154,13 @@ func (r *CloudEndpointReconciler) create(ctx context.Context, clep *ngrokv1alpha
 	}
 
 	createParams := &ngrok.EndpointCreate{
-		Type:          "cloud",
-		URL:           clep.Spec.URL,
-		Description:   &clep.Spec.Description,
-		Metadata:      &clep.Spec.Metadata,
-		TrafficPolicy: policy,
-		Bindings:      clep.Spec.Bindings,
+		Type:           "cloud",
+		URL:            clep.Spec.URL,
+		Description:    &clep.Spec.Description,
+		Metadata:       &clep.Spec.Metadata,
+		TrafficPolicy:  policy,
+		Bindings:       clep.Spec.Bindings,
+		PoolingEnabled: clep.Spec.PoolingEnabled,
 	}
 
 	ngrokClep, err := r.NgrokClientset.Endpoints().Create(ctx, createParams)
@@ -184,12 +185,13 @@ func (r *CloudEndpointReconciler) update(ctx context.Context, clep *ngrokv1alpha
 	}
 
 	updateParams := &ngrok.EndpointUpdate{
-		ID:            clep.Status.ID,
-		Url:           &clep.Spec.URL,
-		Description:   &clep.Spec.Description,
-		Metadata:      &clep.Spec.Metadata,
-		TrafficPolicy: &policy,
-		Bindings:      clep.Spec.Bindings,
+		ID:             clep.Status.ID,
+		Url:            &clep.Spec.URL,
+		Description:    &clep.Spec.Description,
+		Metadata:       &clep.Spec.Metadata,
+		TrafficPolicy:  &policy,
+		Bindings:       clep.Spec.Bindings,
+		PoolingEnabled: clep.Spec.PoolingEnabled,
 	}
 
 	ngrokClep, err := r.NgrokClientset.Endpoints().Update(ctx, updateParams)

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -23,16 +23,19 @@ type IRHostname string
 type IRVirtualHost struct {
 	// The names of any resources (such as Ingress) that were used in the construction of this IRVirtualHost
 	// Currently only used for debug/error logs, but can be added to generated resource statuses
-	OwningResources []OwningResource
-	Hostname        string
+	OwningResources        []OwningResource
+	Hostname               string
+	EndpointPoolingEnabled bool
 
 	// Keeps track of the namespace for this hostname. Since we do not allow multiple endpoints with the same hostname, we cannot support multiple ingresses
 	// using the same hostname in different namespaces.
 	Namespace string
 
 	// This traffic policy will apply to all routes under this hostname
-	TrafficPolicy *trafficpolicy.TrafficPolicy
-	Routes        []*IRRoute
+	TrafficPolicy    *trafficpolicy.TrafficPolicy
+	TrafficPolicyObj *OwningResource // Reference to the object that the above traffic policy config was loaded from
+
+	Routes []*IRRoute
 
 	// The following is used to support ingress default backends (currently only supported for endpoints and not edges)
 	DefaultDestination *IRDestination

--- a/pkg/managerdriver/testdata/translator/endpoint-ingress-default-backend-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/endpoint-ingress-default-backend-conflict.yaml
@@ -1,0 +1,135 @@
+# Ingresses with conflicting default backends
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ngrok-operator
+        app.kubernetes.io/name: ngrok-operator
+        app.kubernetes.io/part-of: ngrok-operator
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+      name: test-ingress-1
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      defaultBackend:
+        service:
+          name: test-service-1
+          port:
+            number: 8080
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test-1
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-1
+                    port:
+                      number: 8080
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+      name: test-ingress-2
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      defaultBackend:
+        service:
+          name: test-service-2
+          port:
+            number: 8080
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test-2
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-2
+                    port:
+                      number: 8080
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies: []
+expected:
+  # Generated cloud endpoint should have the routes and default backend from the first ingress, but 
+  # the second ingress will not be processed due to the conflicting default destination
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-ingresses.ngrok.io
+      namespace: default
+    spec:
+      url: https://test-ingresses.ngrok.io
+      trafficPolicy:
+        policy:
+          on_http_request:
+          - name: Generated-Route-/test-1
+            expressions:
+            - req.url.path.startsWith("/test-1")
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-1-default-8080.internal
+
+          - name: Generated-Route-Default-Backend
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-1-default-8080.internal
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-8080.internal"
+      upstream:
+        url: "http://test-service-1.default:8080"
+

--- a/pkg/managerdriver/testdata/translator/endpoint-ingress-namespace-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/endpoint-ingress-namespace-conflict.yaml
@@ -1,0 +1,119 @@
+# Ingresses with conflicting namespaces
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ngrok-operator
+        app.kubernetes.io/name: ngrok-operator
+        app.kubernetes.io/part-of: ngrok-operator
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+      name: test-ingress-1
+      namespace: aaa
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test-1
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-1
+                    port:
+                      number: 8080
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+      name: test-ingress-2
+      namespace: zzz
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test-2
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-2
+                    port:
+                      number: 8080
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: aaa
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: zzz
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies: []
+expected:
+  # Generated cloud endpoint should have the first traffic policy, but the second ingress will not be processed due to the
+  # traffic policy conflict
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-ingresses.ngrok.io
+      namespace: aaa
+    spec:
+      url: https://test-ingresses.ngrok.io
+      trafficPolicy:
+        policy:
+          on_http_request:
+          - name: Generated-Route-/test-1
+            expressions:
+            - req.url.path.startsWith("/test-1")
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-1-aaa-8080.internal
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-aaa-8080
+      namespace: aaa
+    spec:
+      url: "https://e3b0c-test-service-1-aaa-8080.internal"
+      upstream:
+        url: "http://test-service-1.aaa:8080"
+

--- a/pkg/managerdriver/testdata/translator/endpoint-ingress-pooling-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/endpoint-ingress-pooling-conflict.yaml
@@ -1,0 +1,122 @@
+# Ingresses with conflicting traffic policy annotations
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ngrok-operator
+        app.kubernetes.io/name: ngrok-operator
+        app.kubernetes.io/part-of: ngrok-operator
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        k8s.ngrok.com/pooling-enabled: "true"
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+      name: test-ingress-1
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test-1
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-1
+                    port:
+                      number: 8080
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        k8s.ngrok.com/pooling-enabled: "false"
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+      name: test-ingress-2
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test-2
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-2
+                    port:
+                      number: 8080
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies: []
+expected:
+  # Generated cloud endpoint should have the first traffic policy, but the second ingress will not be processed due to the
+  # pooling support conflict
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-ingresses.ngrok.io
+      namespace: default
+    spec:
+      url: https://test-ingresses.ngrok.io
+      poolingEnabled: true
+      trafficPolicy:
+        policy:
+          on_http_request:
+          - name: Generated-Route-/test-1
+            expressions:
+            - req.url.path.startsWith("/test-1")
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-1-default-8080.internal
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-8080.internal"
+      upstream:
+        url: "http://test-service-1.default:8080"
+

--- a/pkg/managerdriver/testdata/translator/endpoint-ingress-trafficpolicy-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/endpoint-ingress-trafficpolicy-conflict.yaml
@@ -1,0 +1,167 @@
+# Ingresses with conflicting traffic policy annotations
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ngrok-operator
+        app.kubernetes.io/name: ngrok-operator
+        app.kubernetes.io/part-of: ngrok-operator
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        k8s.ngrok.com/traffic-policy: response-503
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+      name: test-ingress-1
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test-1
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-1
+                    port:
+                      number: 8080
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        k8s.ngrok.com/traffic-policy: response-404
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+      name: test-ingress-2
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test-2
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-2
+                    port:
+                      number: 8080
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies: 
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: NgrokTrafficPolicy
+    metadata:
+      name: response-503
+      namespace: default
+    spec:
+      policy:
+        on_http_request:
+          - name: response-503
+            expressions:
+              - req.url.path.startsWith("/foo")
+            actions:
+              - type: custom-response
+                config:
+                  status_code: 503
+                  content: "Service is temporarily unavailable"
+                  headers:
+                    content-type: text/plain
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: NgrokTrafficPolicy
+    metadata:
+      name: response-404
+      namespace: default
+    spec:
+      policy:
+        on_http_request:
+          - name: response-404
+            expressions:
+              - req.url.path.startsWith("/foo")
+            actions:
+              - type: custom-response
+                config:
+                  status_code: 404
+                  content: "Not found"
+                  headers:
+                    content-type: text/plain
+expected:
+  # Generated cloud endpoint should have the first traffic policy, but the second ingress will not be processed due to the
+  # traffic policy conflict
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-ingresses.ngrok.io
+      namespace: default
+    spec:
+      url: https://test-ingresses.ngrok.io
+      trafficPolicy:
+        policy:
+          on_http_request:
+          - name: response-503
+            expressions:
+              - req.url.path.startsWith("/foo")
+            actions:
+              - type: custom-response
+                config:
+                  status_code: 503
+                  content: "Service is temporarily unavailable"
+                  headers:
+                    content-type: text/plain
+          - name: Generated-Route-/test-1
+            expressions:
+            - req.url.path.startsWith("/test-1")
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-1-default-8080.internal
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-8080.internal"
+      upstream:
+        url: "http://test-service-1.default:8080"
+

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -79,6 +79,7 @@ func (t *translator) IRToEndpoints(irVHosts []*ir.IRVirtualHost) (parents map[ty
 			irVHost.Namespace,
 			irVHost.Hostname,
 			t.managedResourceLabels,
+			irVHost.EndpointPoolingEnabled,
 			t.defaultIngressMetadata,
 		)
 
@@ -244,7 +245,7 @@ func (t *translator) injectEndpointDefaultDestinationTPConfig(parentPolicy *traf
 }
 
 // buildCloudEndpoint initializes a new CloudEndpoint
-func buildCloudEndpoint(namespace, hostname string, labels map[string]string, metadata string) *ngrokv1alpha1.CloudEndpoint {
+func buildCloudEndpoint(namespace, hostname string, labels map[string]string, endpointPoolingEnabled bool, metadata string) *ngrokv1alpha1.CloudEndpoint {
 	return &ngrokv1alpha1.CloudEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sanitizeStringForK8sName(hostname),
@@ -252,8 +253,9 @@ func buildCloudEndpoint(namespace, hostname string, labels map[string]string, me
 			Labels:    labels,
 		},
 		Spec: ngrokv1alpha1.CloudEndpointSpec{
-			URL:      "https://" + hostname,
-			Metadata: metadata,
+			URL:            "https://" + hostname,
+			PoolingEnabled: endpointPoolingEnabled,
+			Metadata:       metadata,
 		},
 	}
 }


### PR DESCRIPTION
- adds support in the `CloudEndpoint` CRD for endpoint pooling configuration (default false)
  - passes this configuration to the API calls to create/update endpoints
- updates the `Ingress` -> `CloudEndpoint` translation to set the new field when the annotation `"k8s.ngrok.com/pooling-enabled": "true"` is present on the ingress.
  - ingresses with pooling enabled must have matching traffic policy annotations and must all have pooling enabled in order to share a url.
- updates the `Service` -> `CloudEndpoint` translation to set the new field as well