### PR TITLE
Oauth & OIDC conversion

### DIFF
--- a/internal/trafficpolicy/policy.go
+++ b/internal/trafficpolicy/policy.go
@@ -21,6 +21,8 @@ const (
 	ActionType_ForwardInternal  ActionType = "forward-internal"
 	ActionType_JWTValidation    ActionType = "jwt-validation"
 	ActionType_Log              ActionType = "log"
+	ActionType_OAuth            ActionType = "oauth"
+	ActionType_OIDC             ActionType = "openid-connect"
 	ActionType_RateLimit        ActionType = "rate-limit"
 	ActionType_Redirect         ActionType = "redirect"
 	ActionType_RemoveHeaders    ActionType = "remove-headers"
@@ -29,6 +31,29 @@ const (
 	ActionType_URLRewrite       ActionType = "url-rewrite"
 	ActionType_VerifyWebhook    ActionType = "verify-webhook"
 )
+
+func ActionTypes() []ActionType {
+	return []ActionType{
+		ActionType_AddHeaders,
+		ActionType_BasicAuth,
+		ActionType_CircuitBreaker,
+		ActionType_CompressResponse,
+		ActionType_CustomResponse,
+		ActionType_Deny,
+		ActionType_ForwardInternal,
+		ActionType_JWTValidation,
+		ActionType_Log,
+		ActionType_OAuth,
+		ActionType_OIDC,
+		ActionType_RateLimit,
+		ActionType_Redirect,
+		ActionType_RemoveHeaders,
+		ActionType_RestrictIPs,
+		ActionType_TerminateTLS,
+		ActionType_URLRewrite,
+		ActionType_VerifyWebhook,
+	}
+}
 
 // TrafficPolicy is the configuration language for handling traffic received by ngrok
 // for Edges and Endpoints. Specifically, it allows you to define rules for each
@@ -224,6 +249,93 @@ func NewCircuitBreakerAction(errorThreshold float64, volumeThreshold *uint32, wi
 	}
 	return Action{
 		Type:   ActionType_CircuitBreaker,
+		Config: config,
+	}
+}
+
+// NewCustomResponseAction creates a new action that enables you to return a hard-coded response back to the client that made a request to your endpoint.
+func NewCustomResponseAction(statusCode int, content string, headers map[string]string) Action {
+	config := struct {
+		StatusCode int               `json:"status_code"`
+		Content    string            `json:"content,omitempty"`
+		Headers    map[string]string `json:"headers,omitempty"`
+	}{
+		StatusCode: statusCode,
+		Content:    content,
+		Headers:    headers,
+	}
+	return Action{
+		Type:   ActionType_CustomResponse,
+		Config: config,
+	}
+}
+
+// OAuthConfig is the configuration for protecting an endpoint with OAuth.
+type OAuthConfig struct {
+	// The name of the OAuth identity provider to be used for authentication.
+	Provider string `json:"provider,omitempty"`
+	// Allow CORS preflight requests to bypass authentication checks. Enable if the endpoint needs to be accessible via CORS.
+	AllowCORSPreflight *bool `json:"allow_cors_preflight,omitempty"`
+	// Sets the allowed domain for the auth cookie.
+	AuthCookieDomain *string `json:"auth_cookie_domain,omitempty"`
+	// Unique authentication identifier for this provider. This value will be used for the cookie, redirect, authentication and logout purposes.
+	AuthID *string `json:"auth_id,omitempty"`
+	// A map of additional URL parameters to apply to the authorization endpoint URL.
+	AuthzURLParams map[string]string `json:"authz_url_params,omitempty"`
+	// Your OAuth app's client ID. Set to nil if you want to use ngrok’s managed application.
+	ClientID *string `json:"client_id,omitempty"`
+	// Your OAuth app's client secret. Set to nil if you want to use a managed application.
+	ClientSecret *string `json:"client_secret,omitempty"`
+	// Defines the period of inactivity after which a user's session is automatically ended, requiring re-authentication.
+	IdleSessionTimeout *time.Duration `json:"idle_session_timeout,omitempty"`
+	// Defines the maximum lifetime of a session regardless of activity.
+	MaxSessionDuration *time.Duration `json:"max_session_duration,omitempty"`
+	// A list of additional scopes to request when users authenticate with the identity provider.
+	Scopes []string `json:"scopes,omitempty"`
+	// How often should ngrok refresh data about the authenticated user from the identity provider.
+	UserinfoRefreshInterval *time.Duration `json:"userinfo_refresh_interval,omitempty"`
+}
+
+// NewOAuthAction creates a new OAuth action that restricts access to only authorized users by enforcing OAuth
+// through an identity provider of your choice.
+func NewOAuthAction(config OAuthConfig) Action {
+	return Action{
+		Type:   ActionType_OAuth,
+		Config: config,
+	}
+}
+
+// OIDCConfig is the configuration for protecting an endpoint with OIDC.
+type OIDCConfig struct {
+	// The base URL of the Open ID provider that serves an OpenID Provider Configuration Document at /.well-known/openid-configuration.
+	IssuerURL string `json:"issuer_url,omitempty"`
+	// Allow CORS preflight requests to bypass authentication checks. Enable if the endpoint needs to be accessible via CORS.
+	AllowCORSPreflight *bool `json:"allow_cors_preflight,omitempty"`
+	// Sets the allowed domain for the auth cookie.
+	AuthCookieDomain *string `json:"auth_cookie_domain,omitempty"`
+	// Unique authentication identifier for this provider. This value will be used for the cookie, redirect, authentication and logout purposes.
+	AuthID *string `json:"auth_id,omitempty"`
+	// A map of additional URL parameters to apply to the authorization endpoint URL.
+	AuthzURLParams map[string]string `json:"authz_url_params,omitempty"`
+	// Your OAuth app's client ID. Set to nil if you want to use ngrok’s managed application.
+	ClientID *string `json:"client_id,omitempty"`
+	// Your OAuth app's client secret. Set to nil if you want to use a managed application.
+	ClientSecret *string `json:"client_secret,omitempty"`
+	// Defines the period of inactivity after which a user's session is automatically ended, requiring re-authentication.
+	IdleSessionTimeout *time.Duration `json:"idle_session_timeout,omitempty"`
+	// Defines the maximum lifetime of a session regardless of activity.
+	MaxSessionDuration *time.Duration `json:"max_session_duration,omitempty"`
+	// A list of additional scopes to request when users authenticate with the identity provider.
+	Scopes []string `json:"scopes,omitempty"`
+	// How often should ngrok refresh data about the authenticated user from the identity provider.
+	UserinfoRefreshInterval *time.Duration `json:"userinfo_refresh_interval,omitempty"`
+}
+
+// NewOIDCAction creates a new OIDC action that restricts access to only authorized users by enforcing OIDC
+// through an identity provider of your choice.
+func NewOIDCAction(config OIDCConfig) Action {
+	return Action{
+		Type:   ActionType_OIDC,
 		Config: config,
 	}
 }

--- a/internal/trafficpolicy/testdata/policy-2.json
+++ b/internal/trafficpolicy/testdata/policy-2.json
@@ -25,12 +25,38 @@
     ],
     "on_http_request": [
         {
+            "expressions": [
+                "req.url.path == '/example'"
+            ],
+            "actions": [
+                {
+                    "type": "custom-response",
+                    "config": {
+                        "status_code": 404,
+                        "content": "Not Found"
+                    }
+                }
+            ]
+        },
+        {
             "actions": [
                 {
                     "type": "circuit-breaker",
                     "config": {
                         "error_threshold": 0.1,
                         "tripped_duration": 120000000000
+                    }
+                },
+                {
+                    "type": "oauth",
+                    "config": {
+                        "provider": "google"
+                    }
+                },
+                {
+                    "type": "forward-internal",
+                    "config": {
+                        "url": "http://test.internal:8080"
                     }
                 }
             ]

--- a/internal/util/traffic_policy.go
+++ b/internal/util/traffic_policy.go
@@ -3,6 +3,8 @@ package util
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
@@ -299,13 +301,13 @@ func NewTrafficPolicyFromModuleset(ctx context.Context, ms *ingressv1alpha1.Ngro
 		convertModuleSetIPRestriction(ipPolicyResolver),
 		convertModuleSetTLS,
 		// On HTTP Request Rules
+		convertModuleSetOAuth(secretResolver),
+		convertModuleSetOIDC,
+		convertModuleSetSAML,
 		convertModuleSetCompression,
 		convertModuleSetCircuitBreaker,
 		convertModuleSetHeaders,
 		convertModuleSetWebhookVerification(secretResolver),
-		convertModuleSetSAML,
-		convertModuleSetOIDC,
-		convertModuleSetOAuth,
 	}
 
 	for _, converter := range converters {
@@ -503,10 +505,116 @@ func convertModuleSetOIDC(_ context.Context, ms ingressv1alpha1.NgrokModuleSet, 
 	return errors.NewErrModulesetNotConvertibleToTrafficPolicy("OIDC module is not supported at this time")
 }
 
-func convertModuleSetOAuth(_ context.Context, ms ingressv1alpha1.NgrokModuleSet, tp *trafficpolicy.TrafficPolicy) error {
-	if ms.Modules.OAuth == nil {
+func convertModuleSetOAuth(secretRsolver resolvers.SecretResolver) modulesetConverterFunc {
+	return func(ctx context.Context, ms ingressv1alpha1.NgrokModuleSet, tp *trafficpolicy.TrafficPolicy) error {
+		if ms.Modules.OAuth == nil {
+			return nil
+		}
+
+		var config trafficpolicy.OAuthConfig
+		var common ingressv1alpha1.OAuthProviderCommon
+
+		switch {
+		case ms.Modules.OAuth.Amazon != nil:
+			config.Provider = "amazon"
+			common = ms.Modules.OAuth.Amazon.OAuthProviderCommon
+		case ms.Modules.OAuth.Facebook != nil:
+			config.Provider = "facebook"
+			common = ms.Modules.OAuth.Facebook.OAuthProviderCommon
+		case ms.Modules.OAuth.Github != nil:
+			config.Provider = "github"
+			common = ms.Modules.OAuth.Github.OAuthProviderCommon
+		case ms.Modules.OAuth.Gitlab != nil:
+			config.Provider = "gitlab"
+			common = ms.Modules.OAuth.Gitlab.OAuthProviderCommon
+		case ms.Modules.OAuth.Google != nil:
+			config.Provider = "google"
+			common = ms.Modules.OAuth.Google.OAuthProviderCommon
+		case ms.Modules.OAuth.Microsoft != nil:
+			config.Provider = "microsoft"
+			common = ms.Modules.OAuth.Microsoft.OAuthProviderCommon
+		case ms.Modules.OAuth.Linkedin != nil:
+			config.Provider = "linkedin"
+			common = ms.Modules.OAuth.Linkedin.OAuthProviderCommon
+		case ms.Modules.OAuth.Twitch != nil:
+			config.Provider = "twitch"
+			common = ms.Modules.OAuth.Twitch.OAuthProviderCommon
+		default:
+			return errors.NewErrModulesetNotConvertibleToTrafficPolicy("Unable to determine OAuth provider")
+		}
+
+		config.ClientID = common.ClientID
+		if common.ClientSecret != nil {
+			secret, err := secretRsolver.GetSecret(ctx, ms.Namespace, common.ClientSecret.Name, common.ClientSecret.Key)
+			if err != nil {
+				return err
+			}
+			config.ClientSecret = &secret
+		}
+
+		if common.OptionsPassthrough {
+			config.AllowCORSPreflight = &common.OptionsPassthrough
+		}
+
+		if common.CookiePrefix != "" {
+			config.AuthCookieDomain = &common.CookiePrefix
+		}
+		config.Scopes = common.Scopes
+
+		if common.InactivityTimeout.Duration > 0 {
+			config.IdleSessionTimeout = &common.InactivityTimeout.Duration
+		}
+
+		if common.MaximumDuration.Duration > 0 {
+			config.MaxSessionDuration = &common.MaximumDuration.Duration
+		}
+
+		if common.AuthCheckInterval.Duration > 0 {
+			config.UserinfoRefreshInterval = &common.AuthCheckInterval.Duration
+		}
+
+		tp.AddRuleOnHTTPRequest(
+			trafficpolicy.Rule{
+				Actions: []trafficpolicy.Action{
+					trafficpolicy.NewOAuthAction(config),
+				},
+			},
+		)
+
+		emailExpressions := []string{}
+		if len(common.EmailAddresses) > 0 {
+			emails := make([]string, len(common.EmailAddresses))
+			for i, email := range common.EmailAddresses {
+				emails[i] = fmt.Sprintf("'%s'", email)
+			}
+			cond := fmt.Sprintf("!actions.ngrok.oauth.identity.email in [%s]", strings.Join(emails, ","))
+			emailExpressions = append(emailExpressions, cond)
+		}
+
+		if len(common.EmailDomains) > 0 {
+			domains := make([]string, len(common.EmailDomains))
+			for i, domain := range common.EmailDomains {
+				domains[i] = fmt.Sprintf("'%s'", domain)
+			}
+			cond := fmt.Sprintf("![%s].exists(d, actions.ngrok.oauth.identity.email.endsWith(d))", strings.Join(domains, ","))
+			emailExpressions = append(emailExpressions, cond)
+		}
+
+		// If there are email expressions, filtering to only allow certain emails or domains, return a 403 Forbidden
+		// response for any requests that don't match
+		if len(emailExpressions) > 0 {
+			tp.AddRuleOnHTTPRequest(
+				trafficpolicy.Rule{
+					Expressions: []string{
+						strings.Join(emailExpressions, " || "),
+					},
+					Actions: []trafficpolicy.Action{
+						trafficpolicy.NewCustomResponseAction(403, "Forbidden", nil),
+					},
+				},
+			)
+		}
+
 		return nil
 	}
-
-	return errors.NewErrModulesetNotConvertibleToTrafficPolicy("OAuth module is not supported at this time")
 }

--- a/internal/util/traffic_policy_test.go
+++ b/internal/util/traffic_policy_test.go
@@ -740,12 +740,32 @@ func TestNewTrafficPolicyFromModuleset(t *testing.T) {
 				ObjectMeta: msObjectMeta,
 				Modules: ingressv1alpha1.NgrokModuleSetModules{
 					OIDC: &ingressv1alpha1.EndpointOIDC{
-						CookiePrefix: "something",
+						Issuer:   "https://acme.com/oauth/v2/oauth-anonymous",
+						ClientID: "12345",
+						ClientSecret: ingressv1alpha1.SecretKeyRef{
+							Name: secretName,
+							Key:  secretKey,
+						},
 					},
 				},
 			},
-			tp:  nil,
-			err: errors.NewErrModulesetNotConvertibleToTrafficPolicy("OIDC module is not supported at this time"),
+			tp: &trafficpolicy.TrafficPolicy{
+				OnHTTPRequest: []trafficpolicy.Rule{
+					{
+						Actions: []trafficpolicy.Action{
+							{
+								Type: trafficpolicy.ActionType_OIDC,
+								Config: map[string]string{
+									"issuer_url":    "https://acme.com/oauth/v2/oauth-anonymous",
+									"client_id":     "12345",
+									"client_secret": secretValue,
+								},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
 		},
 		{
 			name: "moduleset with webhook verification",

--- a/internal/util/traffic_policy_test.go
+++ b/internal/util/traffic_policy_test.go
@@ -628,21 +628,98 @@ func TestNewTrafficPolicyFromModuleset(t *testing.T) {
 			err:       nil,
 		},
 		{
-			name: "moduleset with oauth",
+			name: "moduleset with ngrok managed OAuth",
 			moduleset: &ingressv1alpha1.NgrokModuleSet{
 				ObjectMeta: msObjectMeta,
 				Modules: ingressv1alpha1.NgrokModuleSetModules{
 					OAuth: &ingressv1alpha1.EndpointOAuth{
 						Google: &ingressv1alpha1.EndpointOAuthGoogle{
 							OAuthProviderCommon: ingressv1alpha1.OAuthProviderCommon{
-								EmailDomains: []string{"ngrok.com"},
+								EmailAddresses: []string{"testuser@example.com"},
+								EmailDomains:   []string{"ngrok.com"},
 							},
 						},
 					},
 				},
 			},
-			tp:  nil,
-			err: errors.NewErrModulesetNotConvertibleToTrafficPolicy("OAuth module is not supported at this time"),
+			tp: &trafficpolicy.TrafficPolicy{
+				OnHTTPRequest: []trafficpolicy.Rule{
+					{
+						Actions: []trafficpolicy.Action{
+							{
+								Type: trafficpolicy.ActionType_OAuth,
+								Config: map[string]string{
+									"provider": "google",
+								},
+							},
+						},
+					},
+					{
+						Expressions: []string{
+							"!actions.ngrok.oauth.identity.email in ['testuser@example.com'] || !['ngrok.com'].exists(d, actions.ngrok.oauth.identity.email.endsWith(d))",
+						},
+						Actions: []trafficpolicy.Action{
+							{
+								Type: trafficpolicy.ActionType_CustomResponse,
+								Config: map[string]interface{}{
+									"status_code": 403,
+									"content":     "Forbidden",
+								},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "moduleset with custom OAuth",
+			moduleset: &ingressv1alpha1.NgrokModuleSet{
+				ObjectMeta: msObjectMeta,
+				Modules: ingressv1alpha1.NgrokModuleSetModules{
+					OAuth: &ingressv1alpha1.EndpointOAuth{
+						Google: &ingressv1alpha1.EndpointOAuthGoogle{
+							OAuthProviderCommon: ingressv1alpha1.OAuthProviderCommon{
+								ClientID:       ptr.To("my-client-id"),
+								ClientSecret:   &ingressv1alpha1.SecretKeyRef{Name: secretName, Key: secretKey},
+								EmailAddresses: []string{"testuser@example.com"},
+								EmailDomains:   []string{"ngrok.com"},
+							},
+						},
+					},
+				},
+			},
+			tp: &trafficpolicy.TrafficPolicy{
+				OnHTTPRequest: []trafficpolicy.Rule{
+					{
+						Actions: []trafficpolicy.Action{
+							{
+								Type: trafficpolicy.ActionType_OAuth,
+								Config: map[string]string{
+									"provider":      "google",
+									"client_id":     "my-client-id",
+									"client_secret": secretValue,
+								},
+							},
+						},
+					},
+					{
+						Expressions: []string{
+							"!actions.ngrok.oauth.identity.email in ['testuser@example.com'] || !['ngrok.com'].exists(d, actions.ngrok.oauth.identity.email.endsWith(d))",
+						},
+						Actions: []trafficpolicy.Action{
+							{
+								Type: trafficpolicy.ActionType_CustomResponse,
+								Config: map[string]interface{}{
+									"status_code": 403,
+									"content":     "Forbidden",
+								},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
 		},
 		{
 			name: "moduleset with saml",
@@ -782,6 +859,13 @@ func TestNewTrafficPolicyFromModuleset(t *testing.T) {
 					IPRestriction: &ingressv1alpha1.EndpointIPPolicy{
 						IPPolicies: []string{"my-ip-policy", "ipp_123456789012345678901234568"},
 					},
+					OAuth: &ingressv1alpha1.EndpointOAuth{
+						Google: &ingressv1alpha1.EndpointOAuthGoogle{
+							OAuthProviderCommon: ingressv1alpha1.OAuthProviderCommon{
+								EmailDomains: []string{"ngrok.com"},
+							},
+						},
+					},
 					TLSTermination: &ingressv1alpha1.EndpointTLSTermination{
 						TerminateAt: "edge",
 						MinVersion:  ptr.To("1.2"),
@@ -816,6 +900,30 @@ func TestNewTrafficPolicyFromModuleset(t *testing.T) {
 					},
 				},
 				OnHTTPRequest: []trafficpolicy.Rule{
+					{
+						Actions: []trafficpolicy.Action{
+							{
+								Type: trafficpolicy.ActionType_OAuth,
+								Config: map[string]interface{}{
+									"provider": "google",
+								},
+							},
+						},
+					},
+					{
+						Expressions: []string{
+							"!['ngrok.com'].exists(d, actions.ngrok.oauth.identity.email.endsWith(d))",
+						},
+						Actions: []trafficpolicy.Action{
+							{
+								Type: trafficpolicy.ActionType_CustomResponse,
+								Config: map[string]interface{}{
+									"status_code": 403,
+									"content":     "Forbidden",
+								},
+							},
+						},
+					},
 					{
 						Actions: []trafficpolicy.Action{
 							{


### PR DESCRIPTION
## What

We now have traffic policy actions for OAuth and OIDC. This PR adds typed actions for these and updates the ModuleSet -> TrafficPolicy utility conversion function.

## How
* Add more actions to the trafficpolicy package.
* Updates the conversion function to convert OAuth and OIDC Modulesets -> TrafficPolicy
* Adds more tests

## Breaking Changes
No