### PR TITLE
for the k8s operator resource, remove binding name printcolumn and add endpoint selectors

### DIFF
--- a/api/ngrok/v1alpha1/kubernetesoperator_types.go
+++ b/api/ngrok/v1alpha1/kubernetesoperator_types.go
@@ -135,7 +135,7 @@ type KubernetesOperatorSpec struct {
 // +kubebuilder:printcolumn:name="ID",type=string,JSONPath=`.status.id`,description="Kubernetes Operator ID"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.registrationStatus"
 // +kubebuilder:printcolumn:name="Enabled Features",type="string",JSONPath=".status.enabledFeatures"
-// +kubebuilder:printcolumn:name="Binding Name", type="string", JSONPath=".spec.binding.name",priority=2
+// +kubebuilder:printcolumn:name="Endpoint Selectors",type="string",JSONPath=".spec.binding.endpointSelectors"
 // +kubebuilder:printcolumn:name="Binding Ingress Endpoint", type="string", JSONPath=".spec.binding.ingressEndpoint",priority=2
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 

--- a/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
+++ b/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
@@ -25,9 +25,8 @@ spec:
     - jsonPath: .status.enabledFeatures
       name: Enabled Features
       type: string
-    - jsonPath: .spec.binding.name
-      name: Binding Name
-      priority: 2
+    - jsonPath: .spec.binding.endpointSelectors
+      name: Endpoint Selectors
       type: string
     - jsonPath: .spec.binding.ingressEndpoint
       name: Binding Ingress Endpoint


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
The printed columns for the kubernetes operator resource was referencing the deleted Name field and didn't include endpoint selectors, so this changes that!

## How
Modify kubebuilder annotations to update the printed columns for the kubernetes operator resource.
## Breaking Changes
Does change the "additionalPrinterColumns" field on the kubernetes operator spec but I don't _think_ that should break anything?
