### PR TITLE
feat: gwapi ReferenceGrant support

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -79,9 +79,10 @@ type managerOpts struct {
 	zapOpts     *zap.Options
 
 	// feature flags
-	enableFeatureIngress  bool
-	enableFeatureGateway  bool
-	enableFeatureBindings bool
+	enableFeatureIngress          bool
+	enableFeatureGateway          bool
+	enableFeatureBindings         bool
+	disableGatewayReferenceGrants bool
 
 	// agent(tunnel driver) flags
 	region  string
@@ -111,6 +112,7 @@ func cmd() *cobra.Command {
 	// feature flags
 	c.Flags().BoolVar(&opts.enableFeatureIngress, "enable-feature-ingress", true, "Enables the Ingress controller")
 	c.Flags().BoolVar(&opts.enableFeatureGateway, "enable-feature-gateway", false, "Enables the Gateway controller")
+	c.Flags().BoolVar(&opts.disableGatewayReferenceGrants, "disable-reference-grants", false, "Opts-out of requiring ReferenceGrants for cross namespace references in Gateway API config")
 	c.Flags().BoolVar(&opts.enableFeatureBindings, "enable-feature-bindings", false, "Enables the Endpoint Bindings controller")
 
 	opts.zapOpts = &zap.Options{}

--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -143,10 +143,11 @@ To uninstall the chart:
 
 ### Kubernetes Gateway feature configuration
 
-| Name                        | Description                              | Value   |
-| --------------------------- | ---------------------------------------- | ------- |
-| `useExperimentalGatewayApi` | DEPRECATED: Use gateway.enabled instead  |         |
-| `gateway.enabled`           | When true, enable the Gateway controller | `false` |
+| Name                             | Description                                                                                                             | Value   |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------- |
+| `useExperimentalGatewayApi`      | DEPRECATED: Use gateway.enabled instead                                                                                 |         |
+| `gateway.enabled`                | When true, enable the Gateway controller                                                                                | `false` |
+| `gateway.disableReferenceGrants` | When true, disables required ReferenceGrants for cross-namespace references. Does nothing when gateway.enabled is false | `false` |
 
 ### Kubernetes Bindings feature configuration
 

--- a/helm/ngrok-operator/templates/_helpers.tpl
+++ b/helm/ngrok-operator/templates/_helpers.tpl
@@ -77,6 +77,11 @@ Ngrok Operator manager cli feature flags
 {{- else }}
 - --enable-feature-gateway=false
 {{- end }}
+{{- if .Values.gateway.disableReferenceGrants }}
+- --disable-reference-grants=true
+{{- else }}
+- --disable-reference-grants=false
+{{- end }}
 {{- if .Values.bindings.enabled }}
 - --enable-feature-bindings={{ .Values.bindings.enabled }}
 {{- end }}

--- a/helm/ngrok-operator/templates/rbac/role.yaml
+++ b/helm/ngrok-operator/templates/rbac/role.yaml
@@ -159,6 +159,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ingress.k8s.ngrok.com
   resources:
   - domains

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -4,7 +4,7 @@ Should match all-options snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/controller-role: e01d6e2a1e8f620e7b681b880a2904fc308b240de4eb5d66a5ed1b5b45a11ded
+        checksum/controller-role: bf32d6fa0abada9bb5046ee53c7c6ee7f6e79694115d2377dff6c002c0f6f06e
         checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
       labels:
         app.kubernetes.io/component: controller
@@ -26,7 +26,7 @@ Should match all-options snapshot:
       template:
         metadata:
           annotations:
-            checksum/controller-role: e01d6e2a1e8f620e7b681b880a2904fc308b240de4eb5d66a5ed1b5b45a11ded
+            checksum/controller-role: bf32d6fa0abada9bb5046ee53c7c6ee7f6e79694115d2377dff6c002c0f6f06e
             checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
             prometheus.io/path: /metrics
@@ -55,6 +55,7 @@ Should match all-options snapshot:
                 - --release-name=RELEASE-NAME
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=false
+                - --disable-reference-grants=false
                 - --description="The official ngrok Kubernetes Operator."
                 - --ingress-controller-name=k8s.ngrok.com/ingress-controller
                 - --zap-log-level=info
@@ -370,6 +371,14 @@ Should match all-options snapshot:
           - update
           - watch
       - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - referencegrants
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
           - ingress.k8s.ngrok.com
         resources:
           - domains
@@ -669,7 +678,7 @@ Should match default snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/controller-role: e01d6e2a1e8f620e7b681b880a2904fc308b240de4eb5d66a5ed1b5b45a11ded
+        checksum/controller-role: bf32d6fa0abada9bb5046ee53c7c6ee7f6e79694115d2377dff6c002c0f6f06e
         checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
       labels:
         app.kubernetes.io/component: controller
@@ -691,7 +700,7 @@ Should match default snapshot:
       template:
         metadata:
           annotations:
-            checksum/controller-role: e01d6e2a1e8f620e7b681b880a2904fc308b240de4eb5d66a5ed1b5b45a11ded
+            checksum/controller-role: bf32d6fa0abada9bb5046ee53c7c6ee7f6e79694115d2377dff6c002c0f6f06e
             checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
             prometheus.io/path: /metrics
@@ -720,6 +729,7 @@ Should match default snapshot:
                 - --release-name=RELEASE-NAME
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=false
+                - --disable-reference-grants=false
                 - --description="The official ngrok Kubernetes Operator."
                 - --ingress-controller-name=k8s.ngrok.com/ingress-controller
                 - --zap-log-level=info
@@ -1020,6 +1030,14 @@ Should match default snapshot:
           - get
           - list
           - update
+          - watch
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - referencegrants
+        verbs:
+          - get
+          - list
           - watch
       - apiGroups:
           - ingress.k8s.ngrok.com

--- a/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
@@ -51,6 +51,7 @@ Should match snapshot:
             - args:
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=false
+                - --disable-reference-grants=false
                 - --description="The official ngrok Kubernetes Operator."
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error

--- a/helm/ngrok-operator/tests/controller-deployment_test.yaml
+++ b/helm/ngrok-operator/tests/controller-deployment_test.yaml
@@ -38,6 +38,19 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: --enable-feature-gateway=true
+- it: Disables ReferenceGrants with GatewayAPI
+  set:
+    gateway.enabled: true
+    gateway.disableReferenceGrants: true
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --enable-feature-gateway=true
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --disable-reference-grants=true
 - it: Uses the new gateway.enabled value when the old one is disabled
   set:
     useExperimentalGatewayApi: false

--- a/helm/ngrok-operator/values.schema.json
+++ b/helm/ngrok-operator/values.schema.json
@@ -387,6 +387,11 @@
                     "type": "boolean",
                     "description": "When true, enable the Gateway controller",
                     "default": false
+                },
+                "disableReferenceGrants": {
+                    "type": "boolean",
+                    "description": "When true, disables required ReferenceGrants for cross-namespace references. Does nothing when gateway.enabled is false",
+                    "default": false
                 }
             }
         },

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -282,6 +282,7 @@ agent:
 ##
 gateway:
   enabled: false
+  disableReferenceGrants: false
 
 ##
 ## @section Kubernetes Bindings feature configuration

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -279,6 +279,7 @@ agent:
 ##
 ## @extra useExperimentalGatewayApi DEPRECATED: Use gateway.enabled instead
 ## @param gateway.enabled When true, enable the Gateway controller
+## @param gateway.disableReferenceGrants When true, disables required ReferenceGrants for cross-namespace references. Does nothing when gateway.enabled is false
 ##
 gateway:
   enabled: false

--- a/internal/controller/gateway/namespace_controller.go
+++ b/internal/controller/gateway/namespace_controller.go
@@ -1,0 +1,108 @@
+/*
+MIT License
+
+Copyright (c) 2025 ngrok, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package gateway
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/go-logr/logr"
+	"github.com/ngrok/ngrok-operator/pkg/managerdriver"
+)
+
+// NamespaceReconciler reconciles Namespaces
+type NamespaceReconciler struct {
+	client.Client
+
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	Driver   *managerdriver.Driver
+}
+
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+
+func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx).WithValues("Namespace", req.Name)
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	var namespace corev1.Namespace
+	err := r.Get(ctx, req.NamespacedName, &namespace)
+
+	switch {
+	case err == nil:
+		_, err := r.Driver.UpdateNamespace(&namespace)
+		if err != nil {
+			log.Error(err, "failed to update Namespace in store")
+			return ctrl.Result{}, err
+		}
+	case client.IgnoreNotFound(err) == nil:
+		if err := r.Driver.DeleteNamespace(req.NamespacedName.Name); err != nil {
+			log.Error(err, "failed to delete Namespace from store")
+			return ctrl.Result{}, err
+		}
+	default:
+		return ctrl.Result{}, err
+	}
+
+	err = r.Driver.Sync(ctx, r.Client)
+	if err != nil {
+		log.Error(err, "failed to sync after reconciling Namespace",
+			"Namespace", namespace.Name,
+		)
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager
+func (r *NamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	storedResources := []client.Object{
+		&corev1.Namespace{},
+	}
+
+	builder := ctrl.NewControllerManagedBy(mgr).For(&corev1.Namespace{})
+	for _, obj := range storedResources {
+		builder = builder.Watches(
+			obj,
+			managerdriver.NewControllerEventHandler(
+				obj.GetObjectKind().GroupVersionKind().Kind,
+				r.Driver,
+				r.Client,
+			),
+		).WithEventFilter(
+			predicate.Or(
+				predicate.GenerationChangedPredicate{},
+			),
+		)
+	}
+	return builder.Complete(r)
+}

--- a/internal/controller/gateway/referencegrant_controller.go
+++ b/internal/controller/gateway/referencegrant_controller.go
@@ -1,0 +1,109 @@
+/*
+MIT License
+
+Copyright (c) 2025 ngrok, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/go-logr/logr"
+	"github.com/ngrok/ngrok-operator/pkg/managerdriver"
+)
+
+// ReferenceGrantReconciler reconciles ReferenceGrants
+type ReferenceGrantReconciler struct {
+	client.Client
+
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	Driver   *managerdriver.Driver
+}
+
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=get;list;watch
+
+func (r *ReferenceGrantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx).WithValues("ReferenceGrant", req.Name)
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	var referenceGrant gatewayv1beta1.ReferenceGrant
+	err := r.Get(ctx, req.NamespacedName, &referenceGrant)
+
+	switch {
+	case err == nil:
+		_, err := r.Driver.UpdateReferenceGrant(&referenceGrant)
+		if err != nil {
+			log.Error(err, "failed to update ReferenceGrant in store")
+			return ctrl.Result{}, err
+		}
+	case client.IgnoreNotFound(err) == nil:
+		if err := r.Driver.DeleteReferenceGrant(req.NamespacedName); err != nil {
+			log.Error(err, "failed to delete ReferenceGrant from store")
+			return ctrl.Result{}, err
+		}
+	default:
+		return ctrl.Result{}, err
+	}
+
+	err = r.Driver.Sync(ctx, r.Client)
+	if err != nil {
+		log.Error(err, "failed to sync after reconciling ReferenceGrant",
+			"ReferenceGrant", fmt.Sprintf("%s.%s", req.Name, req.Namespace),
+		)
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ReferenceGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	storedResources := []client.Object{
+		&gatewayv1beta1.ReferenceGrant{},
+	}
+
+	builder := ctrl.NewControllerManagedBy(mgr).For(&gatewayv1beta1.ReferenceGrant{})
+	for _, obj := range storedResources {
+		builder = builder.Watches(
+			obj,
+			managerdriver.NewControllerEventHandler(
+				obj.GetObjectKind().GroupVersionKind().Kind,
+				r.Driver,
+				r.Client,
+			),
+		).WithEventFilter(
+			predicate.Or(
+				predicate.GenerationChangedPredicate{},
+			),
+		)
+	}
+	return builder.Complete(r)
+}

--- a/internal/store/cachestores.go
+++ b/internal/store/cachestores.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // CacheStores stores cache.Store for all Kinds of k8s objects that
@@ -37,11 +38,13 @@ type CacheStores struct {
 	ServiceV1      cache.Store
 	SecretV1       cache.Store
 	ConfigMapV1    cache.Store
+	NamespaceV1    cache.Store
 
 	// Gateway API Stores
-	Gateway      cache.Store
-	GatewayClass cache.Store
-	HTTPRoute    cache.Store
+	Gateway        cache.Store
+	GatewayClass   cache.Store
+	HTTPRoute      cache.Store
+	ReferenceGrant cache.Store
 
 	// Ngrok Stores
 	DomainV1             cache.Store
@@ -64,11 +67,13 @@ func NewCacheStores(logger logr.Logger) CacheStores {
 		IngressClassV1: cache.NewStore(clusterResourceKeyFunc),
 		ServiceV1:      cache.NewStore(keyFunc),
 		SecretV1:       cache.NewStore(keyFunc),
+		NamespaceV1:    cache.NewStore(clusterResourceKeyFunc),
 		ConfigMapV1:    cache.NewStore(keyFunc),
 		// Gateway API Stores
-		Gateway:      cache.NewStore(keyFunc),
-		GatewayClass: cache.NewStore(keyFunc),
-		HTTPRoute:    cache.NewStore(keyFunc),
+		Gateway:        cache.NewStore(keyFunc),
+		GatewayClass:   cache.NewStore(keyFunc),
+		HTTPRoute:      cache.NewStore(keyFunc),
+		ReferenceGrant: cache.NewStore(keyFunc),
 		// Ngrok Stores
 		DomainV1:             cache.NewStore(keyFunc),
 		TunnelV1:             cache.NewStore(keyFunc),
@@ -116,6 +121,8 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 		return c.ServiceV1.Get(obj)
 	case *corev1.Secret:
 		return c.SecretV1.Get(obj)
+	case *corev1.Namespace:
+		return c.NamespaceV1.Get(obj)
 	case *corev1.ConfigMap:
 		return c.ConfigMapV1.Get(obj)
 
@@ -128,6 +135,8 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 		return c.Gateway.Get(obj)
 	case *gatewayv1.GatewayClass:
 		return c.GatewayClass.Get(obj)
+	case *gatewayv1beta1.ReferenceGrant:
+		return c.ReferenceGrant.Get(obj)
 
 	// ----------------------------------------------------------------------------
 	// Ngrok API Support
@@ -169,6 +178,8 @@ func (c CacheStores) Add(obj runtime.Object) error {
 		return c.ServiceV1.Add(obj)
 	case *corev1.Secret:
 		return c.SecretV1.Add(obj)
+	case *corev1.Namespace:
+		return c.NamespaceV1.Add(obj)
 	case *corev1.ConfigMap:
 		return c.ConfigMapV1.Add(obj)
 
@@ -181,6 +192,8 @@ func (c CacheStores) Add(obj runtime.Object) error {
 		return c.Gateway.Add(obj)
 	case *gatewayv1.GatewayClass:
 		return c.GatewayClass.Add(obj)
+	case *gatewayv1beta1.ReferenceGrant:
+		return c.ReferenceGrant.Add(obj)
 
 	// ----------------------------------------------------------------------------
 	// Ngrok API Support
@@ -223,6 +236,8 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 		return c.ServiceV1.Delete(obj)
 	case *corev1.Secret:
 		return c.SecretV1.Delete(obj)
+	case *corev1.Namespace:
+		return c.NamespaceV1.Delete(obj)
 	case *corev1.ConfigMap:
 		return c.ConfigMapV1.Delete(obj)
 
@@ -235,6 +250,8 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 		return c.Gateway.Delete(obj)
 	case *gatewayv1.GatewayClass:
 		return c.GatewayClass.Delete(obj)
+	case *gatewayv1beta1.ReferenceGrant:
+		return c.ReferenceGrant.Delete(obj)
 
 	// ----------------------------------------------------------------------------
 	// Ngrok API Support

--- a/pkg/managerdriver/endpoints.go
+++ b/pkg/managerdriver/endpoints.go
@@ -27,6 +27,7 @@ func (d *Driver) SyncEndpoints(ctx context.Context, c client.Client) error {
 		d.ingressNgrokMetadata,
 		d.gatewayNgrokMetadata,
 		d.clusterDomain,
+		d.disableGatewayReferenceGrants,
 	)
 	translationResult := translator.Translate()
 

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
@@ -148,3 +148,5 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
+      bindings:
+      - internal

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
@@ -1,0 +1,150 @@
+# Tests that Secrets/ConfigMaps within Gateway.TLS require reference grants for cross namespace
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-invalid-1
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+          tls:
+            mode: Terminate
+            certificateRefs:
+            - kind: Secret
+              name: tls-secret
+              namespace: other
+            frontendValidation:
+              caCertificateRefs:
+              - kind: ConfigMap
+                name: ca-configmap
+                namespace: other
+            options:
+              "k8s.ngrok.com/terminate-tls.min_version": "1.2"
+              "k8s.ngrok.com/terminate-tls.max_version": "1.3"
+              "k8s.ngrok.com/terminate-tls.mutual_tls_verification_strategy": "require-and-verify"
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  secrets:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: tls-secret
+      namespace: other
+    type: kubernetes.io/tls
+    data:
+      tls.key: U2VydmVyUHJpdmF0ZUtleQ==
+      tls.crt: U2VydmVyQ2VydA==
+  configMaps:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ca-configmap
+      namespace: other
+    data:
+      ca.crt: CACert
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      trafficPolicy:
+        policy:
+            on_http_request:
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-1')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-test-service-1-default-8080.internal"
+              - name: Fallback-404
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Cloud Endpoint"
+                    headers:
+                      content-type: text/plain
+            on_tcp_connect:
+            - name: Gateway-TLS-Termination
+              actions:
+              - type: terminate-tls
+                config:
+                  "mutual_tls_verification_strategy": "require-and-verify"
+                  "min_version": "1.2"
+                  "max_version": "1.3"
+                  "mutual_tls_certificate_authorities":
+                  - "CACert"
+                  "server_certificate": "ServerCert"
+                  "server_private_key": "ServerPrivateKey"
+      url: https://test-hostname.ngrok.io
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-8080.internal"
+      upstream:
+        url: "http://test-service-1.default:8080"

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
@@ -1,0 +1,147 @@
+# Tests that Services within backendRefs require reference grants for cross namespaceinput:
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /same-namespace-svc
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: same-namespace-svc
+            port: 8080
+            weight: 1
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /cross-namespace-svc # Allowed with a ReferenceGrant
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: cross-namespace-svc
+            namespace: other
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: same-namespace-svc
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: cross-namespace-svc
+      namespace: other
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      trafficPolicy:
+        policy:
+            on_http_request:
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/cross-namespace-svc')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-cross-namespace-svc-other-8080.internal"
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/same-namespace-svc')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-same-namespace-svc-default-8080.internal"
+              - name: Fallback-404
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Cloud Endpoint"
+                    headers:
+                      content-type: text/plain
+      url: https://test-hostname.ngrok.io
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-same-namespace-svc-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-same-namespace-svc-default-8080.internal"
+      upstream:
+        url: "http://same-namespace-svc.default:8080"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-cross-namespace-svc-other-8080
+      namespace: other
+    spec:
+      url: "https://e3b0c-cross-namespace-svc-other-8080.internal"
+      upstream:
+        url: "http://cross-namespace-svc.other:8080"

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
@@ -133,6 +133,8 @@ expected:
       url: "https://e3b0c-same-namespace-svc-default-8080.internal"
       upstream:
         url: "http://same-namespace-svc.default:8080"
+      bindings:
+      - internal
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -145,3 +147,5 @@ expected:
       url: "https://e3b0c-cross-namespace-svc-other-8080.internal"
       upstream:
         url: "http://cross-namespace-svc.other:8080"
+      bindings:
+      - internal

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
@@ -106,3 +106,5 @@ expected:
       url: "https://e3b0c-test-service-1-foo-8080.internal"
       upstream:
         url: "http://test-service-1.foo:8080"
+      bindings:
+      - internal

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
@@ -1,0 +1,108 @@
+# Tests that gateway.spec.infrastructure adds the labels/annotations to generated resources
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+          allowedRoutes:
+            namespaces:
+              from: All # All namespaces
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: foo
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: foo
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      trafficPolicy:
+        policy:
+            on_http_request:
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-1')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-test-service-1-foo-8080.internal"
+              - name: Fallback-404
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Cloud Endpoint"
+                    headers:
+                      content-type: text/plain
+      url: https://test-hostname.ngrok.io
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-foo-8080
+      namespace: foo
+    spec:
+      url: "https://e3b0c-test-service-1-foo-8080.internal"
+      upstream:
+        url: "http://test-service-1.foo:8080"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
@@ -1,0 +1,118 @@
+# Tests that gateway.spec.infrastructure adds the labels/annotations to generated resources
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+          allowedRoutes:
+            namespaces:
+              from: Selector # Select matching namespaces only
+              selector:
+                matchLabels:
+                  selector-key: selector-val
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: foo
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: foo
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  namespaces:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: foo
+      labels:
+        selector-key: selector-val
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      trafficPolicy:
+        policy:
+            on_http_request:
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-1')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-test-service-1-foo-8080.internal"
+              - name: Fallback-404
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Cloud Endpoint"
+                    headers:
+                      content-type: text/plain
+      url: https://test-hostname.ngrok.io
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-foo-8080
+      namespace: foo
+    spec:
+      url: "https://e3b0c-test-service-1-foo-8080.internal"
+      upstream:
+        url: "http://test-service-1.foo:8080"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
@@ -116,3 +116,5 @@ expected:
       url: "https://e3b0c-test-service-1-foo-8080.internal"
       upstream:
         url: "http://test-service-1.foo:8080"
+      bindings:
+      - internal

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-no-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-no-valid-referencegrants.yaml
@@ -1,0 +1,115 @@
+# Tests that Secrets/ConfigMaps within Gateway.TLS require reference grants for cross namespace
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+    spec:
+      gatewayClassName: ngrok
+      infrastructure:
+        annotations:
+          annotation-key: annotation-val
+        labels:
+          label-key: label-val
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+          tls:
+            mode: Terminate
+            certificateRefs:
+            - kind: Secret
+              name: other-namespace-secret
+              namespace: other
+            frontendValidation:
+              caCertificateRefs:
+              - kind: ConfigMap
+                name: other-namespace-configmap
+                namespace: other
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /same-namespace-svc
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: same-namespace-svc
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: same-namespace-svc
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: NgrokTrafficPolicy
+    metadata:
+      name: other-namespace-tp
+      namespace: other
+    spec:
+      policy:
+        on_http_request:
+        - name: Add-Headers
+          actions:
+            - type: add-headers
+              config:
+                headers:
+                  X-Route-Added-Headder: "add"
+  secrets:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: other-namespace-secret
+      namespace: other
+    type: kubernetes.io/tls
+    data:
+      tls.key: U2VydmVyUHJpdmF0ZUtleQ==
+      tls.crt: U2VydmVyQ2VydA==
+  configMaps:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: other-namespace-configmap
+      namespace: other
+    data:
+      ca.crt: CACert
+expected:
+  cloudEndpoints: []
+  agentEndpoints: []
+

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
@@ -1,0 +1,168 @@
+# Tests that Secrets/ConfigMaps within Gateway.TLS require reference grants for cross namespace
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-invalid-1
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+          tls:
+            mode: Terminate
+            certificateRefs:
+            - kind: Secret
+              name: tls-secret
+              namespace: other
+            frontendValidation:
+              caCertificateRefs:
+              - kind: ConfigMap
+                name: ca-configmap
+                namespace: other
+            options:
+              "k8s.ngrok.com/terminate-tls.min_version": "1.2"
+              "k8s.ngrok.com/terminate-tls.max_version": "1.3"
+              "k8s.ngrok.com/terminate-tls.mutual_tls_verification_strategy": "require-and-verify"
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  secrets:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: tls-secret
+      namespace: other
+    type: kubernetes.io/tls
+    data:
+      tls.key: U2VydmVyUHJpdmF0ZUtleQ==
+      tls.crt: U2VydmVyQ2VydA==
+  configMaps:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ca-configmap
+      namespace: other
+    data:
+      ca.crt: CACert
+  referenceGrants:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: ReferenceGrant
+    metadata:
+      name: other-namespace-grant
+      namespace: other
+    spec:
+      from:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          namespace: default
+      to:
+        - group: ""
+          kind: Secret
+          name: "tls-secret"
+        - group: ""
+          kind: ConfigMap
+          name: "ca-configmap"
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      trafficPolicy:
+        policy:
+            on_http_request:
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-1')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-test-service-1-default-8080.internal"
+              - name: Fallback-404
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Cloud Endpoint"
+                    headers:
+                      content-type: text/plain
+            on_tcp_connect:
+            - name: Gateway-TLS-Termination
+              actions:
+              - type: terminate-tls
+                config:
+                  "mutual_tls_verification_strategy": "require-and-verify"
+                  "min_version": "1.2"
+                  "max_version": "1.3"
+                  "mutual_tls_certificate_authorities":
+                  - "CACert"
+                  "server_certificate": "ServerCert"
+                  "server_private_key": "ServerPrivateKey"
+      url: https://test-hostname.ngrok.io
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-8080.internal"
+      upstream:
+        url: "http://test-service-1.default:8080"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
@@ -166,3 +166,5 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
+      bindings:
+      - internal

--- a/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
@@ -1,0 +1,140 @@
+# Tests that Services within backendRefs require reference grants for cross namespace
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+    spec:
+      gatewayClassName: ngrok
+      infrastructure:
+        annotations:
+          annotation-key: annotation-val
+        labels:
+          label-key: label-val
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /same-namespace-svc
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: same-namespace-svc
+            port: 8080
+            weight: 1
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /cross-namespace # Not allowed without a ReferenceGrant
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: cross-namespace-svc
+            namespace: other
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: same-namespace-svc
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: cross-namespace-svc
+      namespace: other
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      annotations:
+        annotation-key: annotation-val
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+        label-key: label-val
+      name: test-gateway.default-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      trafficPolicy:
+        policy:
+            on_http_request:
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/same-namespace-svc')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-same-namespace-svc-default-8080.internal"
+              - name: Fallback-404
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Cloud Endpoint"
+                    headers:
+                      content-type: text/plain
+      url: https://test-hostname.ngrok.io
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      annotations:
+        annotation-key: annotation-val
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+        label-key: label-val
+      name: e3b0c-same-namespace-svc-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-same-namespace-svc-default-8080.internal"
+      upstream:
+        url: "http://same-namespace-svc.default:8080"
+

--- a/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
@@ -137,4 +137,6 @@ expected:
       url: "https://e3b0c-same-namespace-svc-default-8080.internal"
       upstream:
         url: "http://same-namespace-svc.default:8080"
+      bindings:
+      - internal
 

--- a/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
@@ -1,0 +1,162 @@
+# Tests that Services within backendRefs require reference grants for cross namespaceinput:
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /same-namespace-svc
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: same-namespace-svc
+            port: 8080
+            weight: 1
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /cross-namespace-svc # Allowed with a ReferenceGrant
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: cross-namespace-svc
+            namespace: other
+            port: 8080
+            weight: 1
+  referenceGrants:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: ReferenceGrant
+    metadata:
+      name: other-namespace-grant
+      namespace: other
+    spec:
+      from:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          namespace: default
+      to:
+        - group: ""
+          kind: Service
+          name: "cross-namespace-svc"
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: same-namespace-svc
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: cross-namespace-svc
+      namespace: other
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      trafficPolicy:
+        policy:
+            on_http_request:
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/cross-namespace-svc')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-cross-namespace-svc-other-8080.internal"
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/same-namespace-svc')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-same-namespace-svc-default-8080.internal"
+              - name: Fallback-404
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Cloud Endpoint"
+                    headers:
+                      content-type: text/plain
+      url: https://test-hostname.ngrok.io
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-same-namespace-svc-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-same-namespace-svc-default-8080.internal"
+      upstream:
+        url: "http://same-namespace-svc.default:8080"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-cross-namespace-svc-other-8080
+      namespace: other
+    spec:
+      url: "https://e3b0c-cross-namespace-svc-other-8080.internal"
+      upstream:
+        url: "http://cross-namespace-svc.other:8080"

--- a/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
@@ -148,6 +148,8 @@ expected:
       url: "https://e3b0c-same-namespace-svc-default-8080.internal"
       upstream:
         url: "http://same-namespace-svc.default:8080"
+      bindings:
+      - internal
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -160,3 +162,5 @@ expected:
       url: "https://e3b0c-cross-namespace-svc-other-8080.internal"
       upstream:
         url: "http://cross-namespace-svc.other:8080"
+      bindings:
+      - internal

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -29,6 +29,10 @@ type translator struct {
 	defaultIngressMetadata string
 	defaultGatewayMetadata string
 	clusterDomain          string
+
+	// We give users the ability to opt-out of requiring ReferenceGrants for cross namespace
+	// references when using Gateway API
+	disableGatewayReferenceGrants bool
 }
 
 // TranslationResult is the final set of translation output resources
@@ -45,14 +49,16 @@ func NewTranslator(
 	defaultIngressMetadata string,
 	defaultGatewayMetadata string,
 	clusterDomain string,
+	disableGatewayReferenceGrants bool,
 ) Translator {
 	return &translator{
-		log:                    log,
-		store:                  store,
-		managedResourceLabels:  managedResourceLabels,
-		defaultIngressMetadata: defaultIngressMetadata,
-		defaultGatewayMetadata: defaultGatewayMetadata,
-		clusterDomain:          clusterDomain,
+		log:                           log,
+		store:                         store,
+		managedResourceLabels:         managedResourceLabels,
+		defaultIngressMetadata:        defaultIngressMetadata,
+		defaultGatewayMetadata:        defaultGatewayMetadata,
+		clusterDomain:                 clusterDomain,
+		disableGatewayReferenceGrants: disableGatewayReferenceGrants,
 	}
 }
 

--- a/pkg/managerdriver/translator_test.go
+++ b/pkg/managerdriver/translator_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-logr/logr/testr"
+	"github.com/go-logr/logr"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/ir"
@@ -26,6 +26,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func stringPtr(input string) *string {
@@ -392,206 +393,91 @@ func TestGatewayMethodToIR(t *testing.T) {
 	}
 }
 
+// TranslatorRawTestCase facuilitates the initial loading of test input/expected objects, but k8s objects with embedded structs don't parse cleanly
+// with regular yaml marshalling so we need to be a little creative about how we process them.
+type TranslatorRawTestCase struct {
+	Input struct {
+		GatewayClasses  []map[string]interface{} `yaml:"gatewayClasses"`
+		Gateways        []map[string]interface{} `yaml:"gateways"`
+		HTTPRoutes      []map[string]interface{} `yaml:"httpRoutes"`
+		IngressClasses  []map[string]interface{} `yaml:"ingressClasses"`
+		Ingresses       []map[string]interface{} `yaml:"ingresses"`
+		TrafficPolicies []map[string]interface{} `yaml:"trafficPolicies"`
+		Services        []map[string]interface{} `yaml:"services"`
+		Secrets         []map[string]interface{} `yaml:"secrets"`
+		Configmaps      []map[string]interface{} `yaml:"configMaps"`
+		ReferenceGrants []map[string]interface{} `yaml:"referenceGrants"`
+	} `yaml:"input"`
+
+	Expected struct {
+		CloudEndpoints []map[string]interface{} `yaml:"cloudEndpoints"`
+		AgentEndpoints []map[string]interface{} `yaml:"agentEndpoints"`
+	} `yaml:"expected"`
+}
+
+// TranslatorTestCase stores our actual fully parsed inputs/outputs
+type TranslatorTestCase struct {
+	Input struct {
+		GatewayClasses  []*gatewayv1.GatewayClass
+		Gateways        []*gatewayv1.Gateway
+		HTTPRoutes      []*gatewayv1.HTTPRoute
+		IngressClasses  []*netv1.IngressClass
+		Ingresses       []*netv1.Ingress
+		TrafficPolicies []*ngrokv1alpha1.NgrokTrafficPolicy
+		Secrets         []*corev1.Secret
+		ConfigMaps      []*corev1.ConfigMap
+		Services        []*corev1.Service
+		ReferenceGrants []*gatewayv1beta1.ReferenceGrant
+	}
+
+	Expected struct {
+		CloudEndpoints []*ngrokv1alpha1.CloudEndpoint
+		AgentEndpoints []*ngrokv1alpha1.AgentEndpoint
+	}
+}
+
 func TestTranslate(t *testing.T) {
 	testdataDir := "testdata/translator"
-
-	logger := testr.New(t)
-
-	// RawTestCase facuilitates the initial loading of test input/expected objects, but k8s objects with embedded structs don't parse cleanly
-	// with regular yaml marshalling so we need to be a little creative about how we process them.
-	type RawTestCase struct {
-		Input struct {
-			GatewayClasses  []map[string]interface{} `yaml:"gatewayClasses"`
-			Gateways        []map[string]interface{} `yaml:"gateways"`
-			HTTPRoutes      []map[string]interface{} `yaml:"httpRoutes"`
-			IngressClasses  []map[string]interface{} `yaml:"ingressClasses"`
-			Ingresses       []map[string]interface{} `yaml:"ingresses"`
-			TrafficPolicies []map[string]interface{} `yaml:"trafficPolicies"`
-			Services        []map[string]interface{} `yaml:"services"`
-			Secrets         []map[string]interface{} `yaml:"secrets"`
-			Configmaps      []map[string]interface{} `yaml:"configMaps"`
-		} `yaml:"input"`
-
-		Expected struct {
-			CloudEndpoints []map[string]interface{} `yaml:"cloudEndpoints"`
-			AgentEndpoints []map[string]interface{} `yaml:"agentEndpoints"`
-		} `yaml:"expected"`
-	}
-
-	// TestCase stores our actual fully parsed inputs/outputs
-	type TestCase struct {
-		Input struct {
-			GatewayClasses  []*gatewayv1.GatewayClass
-			Gateways        []*gatewayv1.Gateway
-			HTTPRoutes      []*gatewayv1.HTTPRoute
-			IngressClasses  []*netv1.IngressClass
-			Ingresses       []*netv1.Ingress
-			TrafficPolicies []*ngrokv1alpha1.NgrokTrafficPolicy
-			Secrets         []*corev1.Secret
-			ConfigMaps      []*corev1.ConfigMap
-			Services        []*corev1.Service
-		}
-
-		Expected struct {
-			CloudEndpoints []*ngrokv1alpha1.CloudEndpoint
-			AgentEndpoints []*ngrokv1alpha1.AgentEndpoint
-		}
-	}
+	disableRefGrantsDir := "testdata/translator-disable-refgrants"
 
 	// Create a scheme with all supported types
 	sch := runtime.NewScheme()
 
 	utilruntime.Must(gatewayv1.Install(sch))
+	utilruntime.Must(gatewayv1beta1.Install(sch))
 	utilruntime.Must(clientgoscheme.AddToScheme(sch))
 	utilruntime.Must(ingressv1alpha1.AddToScheme(sch))
 	utilruntime.Must(corev1.AddToScheme(sch))
 	utilruntime.Must(ngrokv1alpha1.AddToScheme(sch))
 
 	// Load test files from the testdata directory
-	files, err := filepath.Glob(filepath.Join(testdataDir, "*.yaml"))
+	defaultTranslatorFiles, err := filepath.Glob(filepath.Join(testdataDir, "*.yaml"))
 	require.NoError(t, err, "failed to read test files in %s", testdataDir)
+	disableRefGrantsFiles, err := filepath.Glob(filepath.Join(disableRefGrantsDir, "*.yaml"))
+	require.NoError(t, err, "failed to read test files in %s", disableRefGrantsDir)
 
-	for _, file := range files {
+	for _, file := range defaultTranslatorFiles {
+		logger := logr.New(logr.Discard().GetSink())
+		// If you need to debug tests, uncomment this logger instead to actually see errors printed in the tests.
+		// Otherwise, keep the above logger so that we don't output stuff and make the test output harder to read.
+		// logger = testr.New(t)
+
+		driver := NewDriver(
+			logger,
+			sch,
+			testutils.DefaultControllerName,
+			types.NamespacedName{
+				Name:      "test-manager-name",
+				Namespace: "test-manager-namespace",
+			},
+			WithGatewayEnabled(true),
+			WithSyncAllowConcurrent(true),
+		)
 		t.Run(filepath.Base(file), func(t *testing.T) {
-			data, err := os.ReadFile(file)
-			require.NoError(t, err, "failed to read file: %s", file)
-
-			// Load into the RawTestCase
-			rawTC := new(RawTestCase)
-			require.NoError(t, yaml.UnmarshalStrict(data, rawTC), "failed to unmarshal raw testCase")
-
-			// Use scheme based decoding to properly parse everything into TestCase
-			tc := TestCase{}
-
-			// Decode input objects
-			for _, rawObj := range rawTC.Input.GatewayClasses {
-
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				gatewayClass, ok := obj.(*gatewayv1.GatewayClass)
-				require.True(t, ok, "expected a GatewayClass, got %T", obj)
-				tc.Input.GatewayClasses = append(tc.Input.GatewayClasses, gatewayClass)
-			}
-			for _, rawObj := range rawTC.Input.Gateways {
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				gateway, ok := obj.(*gatewayv1.Gateway)
-				require.True(t, ok, "expected a Gateway, got %T", obj)
-				tc.Input.Gateways = append(tc.Input.Gateways, gateway)
-			}
-			for _, rawObj := range rawTC.Input.HTTPRoutes {
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				httpRoute, ok := obj.(*gatewayv1.HTTPRoute)
-				require.True(t, ok, "expected an HTTPRoute, got %T", obj)
-				tc.Input.HTTPRoutes = append(tc.Input.HTTPRoutes, httpRoute)
-			}
-			for _, rawObj := range rawTC.Input.IngressClasses {
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				ingClass, ok := obj.(*netv1.IngressClass)
-				require.True(t, ok, "expected an IngressClass, got %T", obj)
-				tc.Input.IngressClasses = append(tc.Input.IngressClasses, ingClass)
-			}
-			for _, rawObj := range rawTC.Input.Ingresses {
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				ing, ok := obj.(*netv1.Ingress)
-				require.True(t, ok, "expected an Ingress, got %T", obj)
-				tc.Input.Ingresses = append(tc.Input.Ingresses, ing)
-			}
-			for _, rawObj := range rawTC.Input.Services {
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				svc, ok := obj.(*corev1.Service)
-				require.True(t, ok, "expected a Service, got %T", obj)
-				tc.Input.Services = append(tc.Input.Services, svc)
-			}
-			for _, rawObj := range rawTC.Input.Secrets {
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				secret, ok := obj.(*corev1.Secret)
-				require.True(t, ok, "expected a Secret, got %T", obj)
-				tc.Input.Secrets = append(tc.Input.Secrets, secret)
-			}
-			for _, rawObj := range rawTC.Input.Configmaps {
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				configMap, ok := obj.(*corev1.ConfigMap)
-				require.True(t, ok, "expected a ConfigMap, got %T", obj)
-				tc.Input.ConfigMaps = append(tc.Input.ConfigMaps, configMap)
-			}
-			for _, rawObj := range rawTC.Input.TrafficPolicies {
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				pol, ok := obj.(*ngrokv1alpha1.NgrokTrafficPolicy)
-				require.True(t, ok, "expected an NgrokTrafficPolicy, got %T", obj)
-				tc.Input.TrafficPolicies = append(tc.Input.TrafficPolicies, pol)
-			}
-
-			// Decode expected objects
-			for _, rawObj := range rawTC.Expected.CloudEndpoints {
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				ce, ok := obj.(*ngrokv1alpha1.CloudEndpoint)
-				require.True(t, ok, "expected a CloudEndpoint, got %T", obj)
-				tc.Expected.CloudEndpoints = append(tc.Expected.CloudEndpoints, ce)
-			}
-			for _, rawObj := range rawTC.Expected.AgentEndpoints {
-				obj, err := decodeViaScheme(sch, rawObj)
-				require.NoError(t, err)
-				ae, ok := obj.(*ngrokv1alpha1.AgentEndpoint)
-				require.True(t, ok, "expected an AgentEndpoint, got %T", obj)
-				tc.Expected.AgentEndpoints = append(tc.Expected.AgentEndpoints, ae)
-			}
-
-			// logger := logr.New(logr.Discard().GetSink())
-			// If you need to debug tests, uncomment this logger instead to actually see errors printed in the tests.
-			// Otherwise, keep the above logger so that we don't output stuff and make the test output harder to read.
-			// logger = testr.New(t)
-
-			driver := NewDriver(
-				logger,
-				sch,
-				testutils.DefaultControllerName,
-				types.NamespacedName{
-					Name:      "test-manager-name",
-					Namespace: "test-manager-namespace",
-				},
-				WithGatewayEnabled(true),
-				WithSyncAllowConcurrent(true),
-			)
+			tc := loadTranslatorTestCase(t, file, sch)
 
 			// Load input objects into the driver store
-			inputObjects := []runtime.Object{}
-			for _, obj := range tc.Input.GatewayClasses {
-				inputObjects = append(inputObjects, obj)
-			}
-			for _, obj := range tc.Input.Gateways {
-				inputObjects = append(inputObjects, obj)
-			}
-			for _, obj := range tc.Input.HTTPRoutes {
-				inputObjects = append(inputObjects, obj)
-			}
-			for _, obj := range tc.Input.IngressClasses {
-				inputObjects = append(inputObjects, obj)
-			}
-			for _, obj := range tc.Input.Ingresses {
-				inputObjects = append(inputObjects, obj)
-			}
-			for _, obj := range tc.Input.TrafficPolicies {
-				inputObjects = append(inputObjects, obj)
-			}
-			for _, obj := range tc.Input.Services {
-				inputObjects = append(inputObjects, obj)
-			}
-			for _, obj := range tc.Input.Secrets {
-				inputObjects = append(inputObjects, obj)
-			}
-			for _, obj := range tc.Input.ConfigMaps {
-				inputObjects = append(inputObjects, obj)
-			}
-
+			inputObjects := loadTranslatorInputObjs(t, tc)
 			client := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(inputObjects...).Build()
 
 			require.NoError(t, driver.Seed(context.Background(), client))
@@ -602,6 +488,7 @@ func TestTranslate(t *testing.T) {
 				driver.ingressNgrokMetadata,
 				driver.gatewayNgrokMetadata,
 				"svc.cluster.local",
+				false, // Require reference grants (default)
 			)
 
 			// Finally, run translate and check the contents
@@ -651,6 +538,227 @@ func TestTranslate(t *testing.T) {
 
 		})
 	}
+	for _, file := range disableRefGrantsFiles {
+		logger := logr.New(logr.Discard().GetSink())
+		// If you need to debug tests, uncomment this logger instead to actually see errors printed in the tests.
+		// Otherwise, keep the above logger so that we don't output stuff and make the test output harder to read.
+		// logger = testr.New(t)
+
+		driver := NewDriver(
+			logger,
+			sch,
+			testutils.DefaultControllerName,
+			types.NamespacedName{
+				Name:      "test-manager-name",
+				Namespace: "test-manager-namespace",
+			},
+			WithGatewayEnabled(true),
+			WithSyncAllowConcurrent(true),
+		)
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			tc := loadTranslatorTestCase(t, file, sch)
+
+			// Load input objects into the driver store
+			inputObjects := loadTranslatorInputObjs(t, tc)
+			client := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(inputObjects...).Build()
+
+			require.NoError(t, driver.Seed(context.Background(), client))
+			translator := NewTranslator(
+				driver.log,
+				driver.store,
+				driver.defaultManagedResourceLabels(),
+				driver.ingressNgrokMetadata,
+				driver.gatewayNgrokMetadata,
+				"svc.cluster.local",
+				true, // Disable reference grants
+			)
+
+			// Finally, run translate and check the contents
+			result := translator.Translate()
+			require.Equal(t, len(tc.Expected.AgentEndpoints), len(result.AgentEndpoints))
+			require.Equal(t, len(tc.Expected.CloudEndpoints), len(result.CloudEndpoints))
+
+			for _, expectedCLEP := range tc.Expected.CloudEndpoints {
+				actualCLEP, exists := result.CloudEndpoints[types.NamespacedName{
+					Name:      expectedCLEP.Name,
+					Namespace: expectedCLEP.Namespace,
+				}]
+				require.True(t, exists, "expected CloudEndpoint %s.%s to exist, content: %v", expectedCLEP.Name, expectedCLEP.Namespace, result.CloudEndpoints)
+				assert.Equal(t, expectedCLEP.Name, actualCLEP.Name)
+				assert.Equal(t, expectedCLEP.Namespace, actualCLEP.Namespace)
+				assert.Equal(t, expectedCLEP.Labels, actualCLEP.Labels)
+				assert.Equal(t, expectedCLEP.Annotations, actualCLEP.Annotations)
+				assert.Equal(t, expectedCLEP.Spec.URL, actualCLEP.Spec.URL)
+				assert.Equal(t, expectedCLEP.Spec.TrafficPolicyName, actualCLEP.Spec.TrafficPolicyName)
+				assert.Equal(t, expectedCLEP.Spec.PoolingEnabled, actualCLEP.Spec.PoolingEnabled)
+				if expectedCLEP.Spec.TrafficPolicy != nil {
+
+					expectedTrafficPolicyCfg := &trafficpolicy.TrafficPolicy{}
+					require.NoError(t, json.Unmarshal(expectedCLEP.Spec.TrafficPolicy.Policy, expectedTrafficPolicyCfg))
+
+					actualTrafficPolicyCfg := &trafficpolicy.TrafficPolicy{}
+					require.NoError(t, json.Unmarshal(actualCLEP.Spec.TrafficPolicy.Policy, actualTrafficPolicyCfg))
+					assert.Equal(t, expectedTrafficPolicyCfg, actualTrafficPolicyCfg)
+				}
+				assert.Equal(t, expectedCLEP.Spec.Description, actualCLEP.Spec.Description)
+				assert.Equal(t, expectedCLEP.Spec.Metadata, actualCLEP.Spec.Metadata)
+				assert.Equal(t, expectedCLEP.Spec.Bindings, actualCLEP.Spec.Bindings)
+			}
+
+			for _, expectedAE := range tc.Expected.AgentEndpoints {
+				actualAE, exists := result.AgentEndpoints[types.NamespacedName{
+					Name:      expectedAE.Name,
+					Namespace: expectedAE.Namespace,
+				}]
+				require.True(t, exists, "expected AgentEndpoint %s.%s to exist. actual agent endpoints: %v", expectedAE.Name, expectedAE.Namespace, result.AgentEndpoints)
+				require.Equal(t, expectedAE.Name, actualAE.Name)
+				require.Equal(t, expectedAE.Namespace, actualAE.Namespace)
+				require.Equal(t, expectedAE.Labels, actualAE.Labels)
+				require.Equal(t, expectedAE.Annotations, actualAE.Annotations)
+				require.Equal(t, expectedAE.Spec, actualAE.Spec)
+			}
+
+		})
+	}
+}
+
+func loadTranslatorInputObjs(t *testing.T, tc TranslatorTestCase) []runtime.Object {
+	t.Helper()
+	inputObjects := []runtime.Object{}
+	for _, obj := range tc.Input.GatewayClasses {
+		inputObjects = append(inputObjects, obj)
+	}
+	for _, obj := range tc.Input.Gateways {
+		inputObjects = append(inputObjects, obj)
+	}
+	for _, obj := range tc.Input.HTTPRoutes {
+		inputObjects = append(inputObjects, obj)
+	}
+	for _, obj := range tc.Input.ReferenceGrants {
+		inputObjects = append(inputObjects, obj)
+	}
+	for _, obj := range tc.Input.IngressClasses {
+		inputObjects = append(inputObjects, obj)
+	}
+	for _, obj := range tc.Input.Ingresses {
+		inputObjects = append(inputObjects, obj)
+	}
+	for _, obj := range tc.Input.TrafficPolicies {
+		inputObjects = append(inputObjects, obj)
+	}
+	for _, obj := range tc.Input.Services {
+		inputObjects = append(inputObjects, obj)
+	}
+	for _, obj := range tc.Input.Secrets {
+		inputObjects = append(inputObjects, obj)
+	}
+	for _, obj := range tc.Input.ConfigMaps {
+		inputObjects = append(inputObjects, obj)
+	}
+	return inputObjects
+}
+
+func loadTranslatorTestCase(t *testing.T, file string, sch *runtime.Scheme) TranslatorTestCase {
+	t.Helper()
+	data, err := os.ReadFile(file)
+	require.NoError(t, err, "failed to read file: %s", file)
+
+	// Load into the RawTestCase
+	rawTC := new(TranslatorRawTestCase)
+	require.NoError(t, yaml.UnmarshalStrict(data, rawTC), "failed to unmarshal raw testCase")
+
+	// Use scheme based decoding to properly parse everything into TestCase
+	tc := TranslatorTestCase{}
+
+	// Decode input objects
+	for _, rawObj := range rawTC.Input.GatewayClasses {
+
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		gatewayClass, ok := obj.(*gatewayv1.GatewayClass)
+		require.True(t, ok, "expected a GatewayClass, got %T", obj)
+		tc.Input.GatewayClasses = append(tc.Input.GatewayClasses, gatewayClass)
+	}
+	for _, rawObj := range rawTC.Input.Gateways {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		gateway, ok := obj.(*gatewayv1.Gateway)
+		require.True(t, ok, "expected a Gateway, got %T", obj)
+		tc.Input.Gateways = append(tc.Input.Gateways, gateway)
+	}
+	for _, rawObj := range rawTC.Input.HTTPRoutes {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		httpRoute, ok := obj.(*gatewayv1.HTTPRoute)
+		require.True(t, ok, "expected an HTTPRoute, got %T", obj)
+		tc.Input.HTTPRoutes = append(tc.Input.HTTPRoutes, httpRoute)
+	}
+	for _, rawObj := range rawTC.Input.ReferenceGrants {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		referenceGrant, ok := obj.(*gatewayv1beta1.ReferenceGrant)
+		require.True(t, ok, "expected a ReferenceGrant, got %T", obj)
+		tc.Input.ReferenceGrants = append(tc.Input.ReferenceGrants, referenceGrant)
+	}
+	for _, rawObj := range rawTC.Input.IngressClasses {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		ingClass, ok := obj.(*netv1.IngressClass)
+		require.True(t, ok, "expected an IngressClass, got %T", obj)
+		tc.Input.IngressClasses = append(tc.Input.IngressClasses, ingClass)
+	}
+	for _, rawObj := range rawTC.Input.Ingresses {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		ing, ok := obj.(*netv1.Ingress)
+		require.True(t, ok, "expected an Ingress, got %T", obj)
+		tc.Input.Ingresses = append(tc.Input.Ingresses, ing)
+	}
+	for _, rawObj := range rawTC.Input.Services {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		svc, ok := obj.(*corev1.Service)
+		require.True(t, ok, "expected a Service, got %T", obj)
+		tc.Input.Services = append(tc.Input.Services, svc)
+	}
+	for _, rawObj := range rawTC.Input.Secrets {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		secret, ok := obj.(*corev1.Secret)
+		require.True(t, ok, "expected a Secret, got %T", obj)
+		tc.Input.Secrets = append(tc.Input.Secrets, secret)
+	}
+	for _, rawObj := range rawTC.Input.Configmaps {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		configMap, ok := obj.(*corev1.ConfigMap)
+		require.True(t, ok, "expected a ConfigMap, got %T", obj)
+		tc.Input.ConfigMaps = append(tc.Input.ConfigMaps, configMap)
+	}
+	for _, rawObj := range rawTC.Input.TrafficPolicies {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		pol, ok := obj.(*ngrokv1alpha1.NgrokTrafficPolicy)
+		require.True(t, ok, "expected an NgrokTrafficPolicy, got %T", obj)
+		tc.Input.TrafficPolicies = append(tc.Input.TrafficPolicies, pol)
+	}
+
+	// Decode expected objects
+	for _, rawObj := range rawTC.Expected.CloudEndpoints {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		ce, ok := obj.(*ngrokv1alpha1.CloudEndpoint)
+		require.True(t, ok, "expected a CloudEndpoint, got %T", obj)
+		tc.Expected.CloudEndpoints = append(tc.Expected.CloudEndpoints, ce)
+	}
+	for _, rawObj := range rawTC.Expected.AgentEndpoints {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		ae, ok := obj.(*ngrokv1alpha1.AgentEndpoint)
+		require.True(t, ok, "expected an AgentEndpoint, got %T", obj)
+		tc.Expected.AgentEndpoints = append(tc.Expected.AgentEndpoints, ae)
+	}
+	return tc
 }
 
 // decodeViaScheme helps us decode raw objects loaded from test data yaml files into proper objects that can then be typecast

--- a/pkg/managerdriver/translator_test.go
+++ b/pkg/managerdriver/translator_test.go
@@ -406,6 +406,7 @@ type TranslatorRawTestCase struct {
 		Services        []map[string]interface{} `yaml:"services"`
 		Secrets         []map[string]interface{} `yaml:"secrets"`
 		Configmaps      []map[string]interface{} `yaml:"configMaps"`
+		Namespaces      []map[string]interface{} `yaml:"namespaces"`
 		ReferenceGrants []map[string]interface{} `yaml:"referenceGrants"`
 	} `yaml:"input"`
 
@@ -427,6 +428,7 @@ type TranslatorTestCase struct {
 		Secrets         []*corev1.Secret
 		ConfigMaps      []*corev1.ConfigMap
 		Services        []*corev1.Service
+		Namespaces      []*corev1.Namespace
 		ReferenceGrants []*gatewayv1beta1.ReferenceGrant
 	}
 
@@ -655,6 +657,9 @@ func loadTranslatorInputObjs(t *testing.T, tc TranslatorTestCase) []runtime.Obje
 	for _, obj := range tc.Input.ConfigMaps {
 		inputObjects = append(inputObjects, obj)
 	}
+	for _, obj := range tc.Input.Namespaces {
+		inputObjects = append(inputObjects, obj)
+	}
 	return inputObjects
 }
 
@@ -734,6 +739,13 @@ func loadTranslatorTestCase(t *testing.T, file string, sch *runtime.Scheme) Tran
 		configMap, ok := obj.(*corev1.ConfigMap)
 		require.True(t, ok, "expected a ConfigMap, got %T", obj)
 		tc.Input.ConfigMaps = append(tc.Input.ConfigMaps, configMap)
+	}
+	for _, rawObj := range rawTC.Input.Namespaces {
+		obj, err := decodeViaScheme(sch, rawObj)
+		require.NoError(t, err)
+		namespace, ok := obj.(*corev1.Namespace)
+		require.True(t, ok, "expected a Namespace, got %T", obj)
+		tc.Input.Namespaces = append(tc.Input.Namespaces, namespace)
 	}
 	for _, rawObj := range rawTC.Input.TrafficPolicies {
 		obj, err := decodeViaScheme(sch, rawObj)


### PR DESCRIPTION
**Note: This PR branches off of https://github.com/ngrok/ngrok-operator/pull/588 since it builds upon the GatewayAPI -> Endpoints work. This PR is not worth reviewing until that merges**

Makes ReferenceGrants required by default for:
- Referencing a Service in another namespace from an HTTPRoute
- Referencing a Secret in another namespace from a Gateway
- Referencing a Secret in another namespace from a Gateway

Per Gateway API, references in the same namespace do not require ReferenceGrants.

Added the ability to opt-out of ReferenceGrant support with the `gateway.disableReferenceGrants` helm value (default=false) which configures the `--disable-reference-grants` flag in the deployment.

Somewhat related: also fixes the faulty logic in the `allowedRoutes.Namespaces.Selector` field of `Gateways` which was brought over from the existing Edges code (fix is only brought over for Endpoints support as Edges are being removed soon)