### PR TITLE
add bindings annotation

### DIFF
--- a/api/ngrok/v1alpha1/agentendpoint_types.go
+++ b/api/ngrok/v1alpha1/agentendpoint_types.go
@@ -133,10 +133,10 @@ type AgentEndpointSpec struct {
 	Metadata string `json:"metadata,omitempty"`
 
 	// List of Binding IDs to associate with the endpoint
-	// Accepted values are "public", "internal", or strings matching the pattern "k8s/*"
+	// Accepted values are "public", "internal", or "kubernetes"
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Items=pattern=`^(public|internal|k8s/.*)$`
+	// +kubebuilder:validation:Items=pattern=`^(public|internal|kubernetes)$`
 	Bindings []string `json:"bindings,omitempty"`
 }
 

--- a/api/ngrok/v1alpha1/cloudendpoint_types.go
+++ b/api/ngrok/v1alpha1/cloudendpoint_types.go
@@ -76,10 +76,10 @@ type CloudEndpointSpec struct {
 	Metadata string `json:"metadata,omitempty"`
 
 	// Bindings is the list of Binding IDs to associate with the endpoint
-	// Accepted values are "public", "internal", or strings matching the pattern "k8s/*"
+	// Accepted values are "public", "internal", or "kubernetes"
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Items=pattern=`^(public|internal|k8s/.*)$`
+	// +kubebuilder:validation:Items=pattern=`^(public|internal|kubernetes)$`
 	Bindings []string `json:"bindings,omitempty"`
 }
 

--- a/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_agentendpoints.yaml
+++ b/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_agentendpoints.yaml
@@ -60,7 +60,7 @@ spec:
               bindings:
                 description: |-
                   List of Binding IDs to associate with the endpoint
-                  Accepted values are "public", "internal", or strings matching the pattern "k8s/*"
+                  Accepted values are "public", "internal", or "kubernetes"
                 items:
                   type: string
                 type: array

--- a/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_cloudendpoints.yaml
+++ b/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_cloudendpoints.yaml
@@ -57,7 +57,7 @@ spec:
               bindings:
                 description: |-
                   Bindings is the list of Binding IDs to associate with the endpoint
-                  Accepted values are "public", "internal", or strings matching the pattern "k8s/*"
+                  Accepted values are "public", "internal", or "kubernetes"
                 items:
                   type: string
                 type: array

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -165,3 +165,25 @@ func ExtractUseEndpointPooling(obj client.Object) (bool, error) {
 
 	return strings.EqualFold(val, "true"), nil
 }
+
+// Determines which traffic is allowed to reach an endpoint
+// from the annotation "k8s.ngrok.com/bindings" if it is present. Otherwise, it defaults to public
+func ExtractUseBindings(obj client.Object) ([]string, error) {
+	bindings, err := parser.GetStringSliceAnnotation("bindings", obj)
+	if err != nil {
+		if errors.IsMissingAnnotations(err) {
+			return []string{"public"}, nil
+		}
+		return nil, err
+	}
+
+	n := len(bindings)
+	switch {
+	case n > 1:
+		return nil, fmt.Errorf("multiple bindings are not supported: %v", bindings)
+	case n == 1:
+		return bindings, nil
+	default:
+		return []string{"public"}, nil
+	}
+}

--- a/internal/controller/ingress/service_controller.go
+++ b/internal/controller/ingress/service_controller.go
@@ -412,6 +412,12 @@ func (r *ServiceReconciler) buildEndpoints(ctx context.Context, svc *corev1.Serv
 		return objects, err
 	}
 
+	useBindings, err := annotations.ExtractUseBindings(svc)
+	if err != nil {
+		log.Error(err, "failed to get bindings annotation for service")
+		return objects, err
+	}
+
 	// The final traffic policy that will be applied to the CloudEndpoint
 	tp := trafficpolicy.NewTrafficPolicy()
 
@@ -486,6 +492,7 @@ func (r *ServiceReconciler) buildEndpoints(ctx context.Context, svc *corev1.Serv
 		},
 		Spec: ngrokv1alpha1.CloudEndpointSpec{
 			URL:            cloudEndpointURL,
+			Bindings:       useBindings,
 			PoolingEnabled: useEndpointPooling,
 			TrafficPolicy: &ngrokv1alpha1.NgrokTrafficPolicySpec{
 				Policy: rawPolicy,

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -25,6 +25,7 @@ type IRVirtualHost struct {
 	// Currently only used for debug/error logs, but can be added to generated resource statuses
 	OwningResources        []OwningResource
 	Hostname               string
+	Bindings               []string
 	EndpointPoolingEnabled bool
 
 	// Keeps track of the namespace for this hostname. Since we do not allow multiple endpoints with the same hostname, we cannot support multiple ingresses

--- a/pkg/managerdriver/testdata/translator/endpoint-ingress-default-backend-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/endpoint-ingress-default-backend-conflict.yaml
@@ -102,6 +102,8 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
+      bindings:
+        - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:
@@ -132,4 +134,6 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
+      bindings:
+        - internal
 

--- a/pkg/managerdriver/testdata/translator/endpoint-ingress-namespace-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/endpoint-ingress-namespace-conflict.yaml
@@ -92,6 +92,8 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: aaa
     spec:
+      bindings:
+        - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:
@@ -116,4 +118,6 @@ expected:
       url: "https://e3b0c-test-service-1-aaa-8080.internal"
       upstream:
         url: "http://test-service-1.aaa:8080"
+      bindings:
+        - internal
 

--- a/pkg/managerdriver/testdata/translator/endpoint-ingress-pooling-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/endpoint-ingress-pooling-conflict.yaml
@@ -94,6 +94,8 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
+      bindings:
+        - public
       url: https://test-ingresses.ngrok.io
       poolingEnabled: true
       trafficPolicy:
@@ -119,4 +121,6 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
+      bindings:
+        - internal
 

--- a/pkg/managerdriver/testdata/translator/endpoint-ingress-trafficpolicy-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/endpoint-ingress-trafficpolicy-conflict.yaml
@@ -130,6 +130,8 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
+      bindings:
+        - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:
@@ -164,4 +166,6 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
+      bindings:
+        - internal
 

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -81,6 +81,7 @@ func (t *translator) IRToEndpoints(irVHosts []*ir.IRVirtualHost) (parents map[ty
 			t.managedResourceLabels,
 			irVHost.EndpointPoolingEnabled,
 			t.defaultIngressMetadata,
+			irVHost.Bindings,
 		)
 
 		// If the resource does not have a user-supplied traffic policy, then create a new one as the base
@@ -245,7 +246,7 @@ func (t *translator) injectEndpointDefaultDestinationTPConfig(parentPolicy *traf
 }
 
 // buildCloudEndpoint initializes a new CloudEndpoint
-func buildCloudEndpoint(namespace, hostname string, labels map[string]string, endpointPoolingEnabled bool, metadata string) *ngrokv1alpha1.CloudEndpoint {
+func buildCloudEndpoint(namespace, hostname string, labels map[string]string, endpointPoolingEnabled bool, metadata string, bindings []string) *ngrokv1alpha1.CloudEndpoint {
 	return &ngrokv1alpha1.CloudEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sanitizeStringForK8sName(hostname),
@@ -256,6 +257,7 @@ func buildCloudEndpoint(namespace, hostname string, labels map[string]string, en
 			URL:            "https://" + hostname,
 			PoolingEnabled: endpointPoolingEnabled,
 			Metadata:       metadata,
+			Bindings:       bindings,
 		},
 	}
 }
@@ -274,6 +276,7 @@ func buildInternalAgentEndpoint(serviceUID, serviceName, namespace, clusterDomai
 			Upstream: ngrokv1alpha1.EndpointUpstream{
 				URL: internalAgentEndpointUpstreamURL(serviceName, namespace, clusterDomain, port),
 			},
+			Bindings: []string{"internal"},
 		},
 	}
 }


### PR DESCRIPTION
Add an additional annotation to support bindings on ingress
Update Cloud and Agent Endpoints Bindings to Kubernetes from k8s/*
Update Internal Agent Endpoints to be created with internal bindings
Update Cloud Endpoints to be created with whatever binding is being sent with annotation