### PR TITLE
Add IngressEndpoint to KubernetesOperatorStatus

### DIFF
--- a/api/ngrok/v1alpha1/kubernetesoperator_types.go
+++ b/api/ngrok/v1alpha1/kubernetesoperator_types.go
@@ -92,6 +92,10 @@ type KubernetesOperatorStatus struct {
 	// EnabledFeatures is the string representation of the features enabled for this Kubernetes Operator
 	// +kubebuilder:validation:Optional
 	EnabledFeatures string `json:"enabledFeatures,omitempty"`
+
+	// BindingsIngressEndpoint is the URL that the operator will use to talk
+	// to the ngrok edge when forwarding traffic for k8s-bound endpoints
+	BindingsIngressEndpoint string `json:"bindingsIngressEndpoint,omitempty"`
 }
 
 const (

--- a/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
+++ b/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
@@ -122,6 +122,11 @@ spec:
           status:
             description: KubernetesOperatorStatus defines the observed state of KubernetesOperator
             properties:
+              bindingsIngressEndpoint:
+                description: |-
+                  BindingsIngressEndpoint is the URL that the operator will use to talk
+                  to the ngrok edge when forwarding traffic for k8s-bound endpoints
+                type: string
               enabledFeatures:
                 description: EnabledFeatures is the string representation of the features
                   enabled for this Kubernetes Operator

--- a/internal/controller/ngrok/kubernetesoperator_controller.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller.go
@@ -206,6 +206,9 @@ func (r *KubernetesOperatorReconciler) updateStatus(ctx context.Context, ko *ngr
 		if ngrokKo.EnabledFeatures != nil {
 			ko.Status.EnabledFeatures = strings.Join(ngrokKo.EnabledFeatures, ",")
 		}
+		if ngrokKo.Binding != nil {
+			ko.Status.BindingsIngressEndpoint = ngrokKo.Binding.IngressEndpoint
+		}
 
 		ko.Status.RegistrationStatus = ngrokv1alpha1.KubernetesOperatorRegistrationStatusSuccess
 	} else {


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
Adds a new field to `KuebrnetesOperatorStatus` that will be filled in with the `.Bindings.IngressEndpoint` url returned by the ngrok API response to a create/update.

We'll consume that status field in the next PR to use that url when forwarding traffic to ngrok instead of using the field that's set from `values.yaml` (and remove that option from `values.yaml`).

## How
Check the ngrok API response and set the new field appropriately any time `updateStatus` is called on the KubernetesOperator resource.

## Breaking Changes
Does add a new field on our KubernetesOperator resource so that resource will have to be updated when updating the operator.
