### PR TITLE
auto enable gateway api support

### DIFF
--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -143,11 +143,11 @@ To uninstall the chart:
 
 ### Kubernetes Gateway feature configuration
 
-| Name                             | Description                                                                                                             | Value   |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------- |
-| `useExperimentalGatewayApi`      | DEPRECATED: Use gateway.enabled instead                                                                                 |         |
-| `gateway.enabled`                | When true, enable the Gateway controller                                                                                | `false` |
-| `gateway.disableReferenceGrants` | When true, disables required ReferenceGrants for cross-namespace references. Does nothing when gateway.enabled is false | `false` |
+| Name                             | Description                                                                                                                    | Value   |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `useExperimentalGatewayApi`      | DEPRECATED: Use gateway.enabled instead                                                                                        |         |
+| `gateway.enabled`                | When true, Gateway API support will be enabled if the CRDs are detected. When false, Gateway API support will never be enabled | `true`  |
+| `gateway.disableReferenceGrants` | When true, disables required ReferenceGrants for cross-namespace references. Does nothing when gateway.enabled is false        | `false` |
 
 ### Kubernetes Bindings feature configuration
 

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -54,7 +54,7 @@ Should match all-options snapshot:
             - args:
                 - --release-name=RELEASE-NAME
                 - --enable-feature-ingress=true
-                - --enable-feature-gateway=false
+                - --enable-feature-gateway=true
                 - --disable-reference-grants=false
                 - --description="The official ngrok Kubernetes Operator."
                 - --ingress-controller-name=k8s.ngrok.com/ingress-controller
@@ -728,7 +728,7 @@ Should match default snapshot:
             - args:
                 - --release-name=RELEASE-NAME
                 - --enable-feature-ingress=true
-                - --enable-feature-gateway=false
+                - --enable-feature-gateway=true
                 - --disable-reference-grants=false
                 - --description="The official ngrok Kubernetes Operator."
                 - --ingress-controller-name=k8s.ngrok.com/ingress-controller

--- a/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
@@ -50,7 +50,7 @@ Should match snapshot:
           containers:
             - args:
                 - --enable-feature-ingress=true
-                - --enable-feature-gateway=false
+                - --enable-feature-gateway=true
                 - --disable-reference-grants=false
                 - --description="The official ngrok Kubernetes Operator."
                 - --zap-log-level=info

--- a/helm/ngrok-operator/values.schema.json
+++ b/helm/ngrok-operator/values.schema.json
@@ -385,8 +385,8 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "description": "When true, enable the Gateway controller",
-                    "default": false
+                    "description": "When true, Gateway API support will be enabled if the CRDs are detected. When false, Gateway API support will never be enabled",
+                    "default": true
                 },
                 "disableReferenceGrants": {
                     "type": "boolean",

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -278,11 +278,11 @@ agent:
 ## @section Kubernetes Gateway feature configuration
 ##
 ## @extra useExperimentalGatewayApi DEPRECATED: Use gateway.enabled instead
-## @param gateway.enabled When true, enable the Gateway controller
+## @param gateway.enabled When true, Gateway API support will be enabled if the CRDs are detected. When false, Gateway API support will never be enabled
 ## @param gateway.disableReferenceGrants When true, disables required ReferenceGrants for cross-namespace references. Does nothing when gateway.enabled is false
 ##
 gateway:
-  enabled: false
+  enabled: true # Enabled by default if the Gateway API CRDs are detected
   disableReferenceGrants: false
 
 ##


### PR DESCRIPTION
This PR aims to auto enable support for Gateway API when possible:
- Gateway API support flag changed from disabled by default to enabled by default
- When flag is omitted, default is enabled instead of disabled
- When enabled, we check if the Gateway API CRDs are installed first
  - If they are, we enable the Gateway API feature set
  - If they are not, we log that the Gateway API CRDs were not detected and the feature set will be disabled


I didn't want to remove the flag itself and rely solely on the CRD check for two reasons:
- Users may have the Gateway API CRDs installed in the cluster but not want to use them with the ngrok operator, so they should be able to disable that feature set and not waste resources running controllers for something they don't intend to use
- Users upgrading from one version to the next by just changing the image tag and not doing a `helm upgrade` would get a crash since they would be trying to set a flag that no longer exists