### PR TITLE
support bindings annotation on ingress/gateway

### DIFF
--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
@@ -104,6 +104,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
@@ -94,6 +94,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
@@ -74,6 +74,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
@@ -84,6 +84,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-valid-kinds.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-valid-kinds.yaml
@@ -74,6 +74,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation-invalid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation-invalid.yaml
@@ -1,4 +1,4 @@
-# Request mirror filters are not currently supported and should be ignored
+# Tests that the bindings annotation set on a Gateway will be configured on generated CloudEndpoint resources
 input:
   gatewayClasses:
   - apiVersion: gateway.networking.k8s.io/v1
@@ -15,6 +15,7 @@ input:
       namespace: default
       annotations:
         k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/bindings: "foo-binding"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -47,17 +48,6 @@ input:
             name: test-service-1
             port: 8080
             weight: 1
-        filters:
-        - type: ExtensionRef # Bad Group
-          group: "foo.com"
-          kind: NgrokTrafficPolicy
-        - type: ExtensionRef # Bad Kind
-          group: "ngrok.k8s.ngrok.com"
-          kind: SomeResource
-        - type: ExtensionRef # Missing traffic policy
-          group: ""
-          kind: "NgrokTrafficPolicy"
-          name: missing-trafficpolicy
   services:
   - apiVersion: v1
     kind: Service
@@ -83,7 +73,7 @@ expected:
       namespace: default
     spec:
       bindings:
-      - public
+      - foo-binding
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation.yaml
@@ -1,0 +1,66 @@
+# Tests that a Gateway with an invalid bindings configuration will not be processed
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/bindings: "foo-binding,bar-binding" # multiple bindings are not currently supported
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints: []

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-infrastructure.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-infrastructure.yaml
@@ -79,6 +79,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
@@ -122,6 +122,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid.yaml
@@ -102,6 +102,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-glob-hostname.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-glob-hostname.yaml
@@ -71,6 +71,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-no-hostnames.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-no-hostnames.yaml
@@ -69,6 +69,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-weighted-routes-with-rewrite.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-weighted-routes-with-rewrite.yaml
@@ -100,6 +100,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-invalid-backendrefs.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-invalid-backendrefs.yaml
@@ -110,6 +110,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-listener-port-and-protocol.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-listener-port-and-protocol.yaml
@@ -71,6 +71,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-matching-rules.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-matching-rules.yaml
@@ -86,6 +86,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-missing-filter-configs.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-missing-filter-configs.yaml
@@ -78,6 +78,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
@@ -102,6 +102,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-redirects.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-redirects.yaml
@@ -105,6 +105,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
           on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-request-headers.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-request-headers.yaml
@@ -93,6 +93,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-request-mirror-not-supported.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-request-mirror-not-supported.yaml
@@ -79,6 +79,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-response-headers.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-response-headers.yaml
@@ -93,6 +93,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-rewrites.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-rewrites.yaml
@@ -89,6 +89,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
           on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-annotation.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-annotation.yaml
@@ -91,6 +91,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-filter-tcp-error.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-filter-tcp-error.yaml
@@ -90,6 +90,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
@@ -109,6 +109,8 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       trafficPolicy:
         policy:
             on_http_request:

--- a/pkg/managerdriver/testdata/translator/ingress-default-backend-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-default-backend-conflict.yaml
@@ -102,6 +102,8 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:

--- a/pkg/managerdriver/testdata/translator/ingress-namespace-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-namespace-conflict.yaml
@@ -92,6 +92,8 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: aaa
     spec:
+      bindings:
+      - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:

--- a/pkg/managerdriver/testdata/translator/ingress-pooling-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-pooling-conflict.yaml
@@ -94,6 +94,8 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       url: https://test-ingresses.ngrok.io
       poolingEnabled: true
       trafficPolicy:

--- a/pkg/managerdriver/testdata/translator/ingress-trafficpolicy-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-trafficpolicy-conflict.yaml
@@ -130,6 +130,8 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:

--- a/pkg/managerdriver/testdata/translator/ingress-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid.yaml
@@ -122,6 +122,8 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
+      bindings:
+      - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:

--- a/pkg/managerdriver/translate_gatewayapi.go
+++ b/pkg/managerdriver/translate_gatewayapi.go
@@ -153,6 +153,14 @@ func (t *translator) HTTPRouteToIR(
 			}
 		}
 
+		bindings, err := annotations.ExtractUseBindings(gateway)
+		if err != nil {
+			t.log.Error(err, "failed to check bindings annotation for gateway",
+				"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+			)
+			continue
+		}
+
 		matchingListeners := t.matchingGatewayListenersForHTTPRoute(gateway, httpRoute)
 		for _, matchingListener := range matchingListeners {
 			tlsTermCfg := matchingListener.TLS
@@ -213,6 +221,7 @@ func (t *translator) HTTPRouteToIR(
 					TrafficPolicy:          annotationTrafficPolicy,
 					TrafficPolicyObj:       tpObjRef,
 					Metadata:               t.defaultGatewayMetadata,
+					Bindings:               bindings,
 				}
 			}
 			irVHost.AddOwningResource(ir.OwningResource{

--- a/pkg/managerdriver/translate_ingresses.go
+++ b/pkg/managerdriver/translate_ingresses.go
@@ -79,6 +79,14 @@ func (t *translator) ingressesToIR() []*ir.IRVirtualHost {
 			}
 		}
 
+		bindings, err := annotations.ExtractUseBindings(ingress)
+		if err != nil {
+			t.log.Error(err, "failed to check bindings annotation for ingress",
+				"ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
+			)
+			continue
+		}
+
 		t.ingressToIR(
 			ingress,
 			defaultDestination,
@@ -87,6 +95,7 @@ func (t *translator) ingressesToIR() []*ir.IRVirtualHost {
 			useEndpointPooling,
 			annotationTrafficPolicy,
 			tpObjRef,
+			bindings,
 		)
 	}
 
@@ -109,6 +118,7 @@ func (t *translator) ingressToIR(
 	endpointPoolingEnabled bool,
 	annotationTrafficPolicy *trafficpolicy.TrafficPolicy,
 	annotationTrafficPolicyRef *ir.OwningResource,
+	bindings []string,
 ) {
 	for _, rule := range ingress.Spec.Rules {
 		ruleHostname := rule.Host
@@ -198,6 +208,7 @@ func (t *translator) ingressToIR(
 				DefaultDestination:     defaultDestination,
 				EndpointPoolingEnabled: endpointPoolingEnabled,
 				Metadata:               t.defaultIngressMetadata,
+				Bindings:               bindings,
 			}
 			hostCache[ir.IRHostname(ruleHostname)] = irVHost
 		}


### PR DESCRIPTION
Adds support for the bindings annotation to translated Ingress/Gateway resources. Currently defaults to `[]string{"public"}`. This is set on generated `CloudEndpoint` resources. Currently the generated `AgentEndpoint` resources are always `.internal` with a bindings configuration of `[]string{"internal"}` so this annotation does not affect generated `AgentEndpoint` resources.