### PR TITLE
default to using endpoints instead of edges for ingress/gateway API

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -139,9 +139,9 @@ func ExtractNgrokTrafficPolicyFromAnnotations(obj client.Object) (string, error)
 	return "", nil
 }
 
-// Whether or not we should use endpoints in building the ngrok model for resources. Extracts the value
+// Whether or not we should use edges in building the ngrok model for resources. Extracts the value
 // from the annotation "k8s.ngrok.com/mapping-strategy" if it is present. Otherwise, it defaults to false
-func ExtractUseEndpoints(obj client.Object) (bool, error) {
+func ExtractUseEdges(obj client.Object) (bool, error) {
 	val, err := parser.GetStringAnnotation(MappingStrategyAnnotationKey, obj)
 	if err != nil {
 		if errors.IsMissingAnnotations(err) {
@@ -149,7 +149,7 @@ func ExtractUseEndpoints(obj client.Object) (bool, error) {
 		}
 		return false, err
 	}
-	return strings.EqualFold(val, MappingStrategy_Endpoints), nil
+	return strings.EqualFold(val, MappingStrategy_Edges), nil
 }
 
 // Whether or not we should use endpoint pooling

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -82,7 +82,7 @@ func TestExtractNgrokTrafficPolicyFromAnnotations(t *testing.T) {
 	}
 }
 
-func TestExtractUseEndpoints(t *testing.T) {
+func TestExtractUseEdges(t *testing.T) {
 	tests := []struct {
 		name        string
 		annotations map[string]string
@@ -90,11 +90,19 @@ func TestExtractUseEndpoints(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name: "Valid mapping strategy",
+			name: "Valid mapping strategy: edges",
+			annotations: map[string]string{
+				"k8s.ngrok.com/mapping-strategy": "edges",
+			},
+			expected:    true,
+			expectedErr: nil,
+		},
+		{
+			name: "Valid mapping strategy: endpoints",
 			annotations: map[string]string{
 				"k8s.ngrok.com/mapping-strategy": "endpoints",
 			},
-			expected:    true,
+			expected:    false,
 			expectedErr: nil,
 		},
 		{
@@ -123,13 +131,13 @@ func TestExtractUseEndpoints(t *testing.T) {
 				},
 			}
 
-			useEndpoints, err := annotations.ExtractUseEndpoints(obj)
+			useEdges, err := annotations.ExtractUseEdges(obj)
 			if tc.expectedErr != nil {
 				require.Error(t, err)
 				assert.Equal(t, tc.expectedErr, err)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tc.expected, useEndpoints)
+				assert.Equal(t, tc.expected, useEdges)
 			}
 		})
 	}

--- a/internal/controller/ingress/service_controller.go
+++ b/internal/controller/ingress/service_controller.go
@@ -278,7 +278,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	var desired []client.Object
-	useEndpoints, err := annotations.ExtractUseEndpoints(svc)
+	useEdges, err := annotations.ExtractUseEdges(svc)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Failed to get %q annotation", annotations.MappingStrategyAnnotation))
 		// TODO: Add an event to the service
@@ -289,7 +289,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// If the conversion of modulesets -> trafficpolicy fails or there is some other error such that we can't
 	// build the desired endpoints correctly, we will fall back to using tunnels and edges
 	// and just bubble up the error as an event on the service
-	if useEndpoints {
+	if !useEdges {
 		desired, err = r.buildEndpoints(ctx, svc)
 		if err != nil {
 			log.Error(err, "Failed to build desired endpoints")

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -370,8 +370,12 @@ var _ = Describe("Store", func() {
 		})
 
 		Context("when ingress has unsupported default backend", func() {
-			It("ignores the ingress with default backend and returns an error", func() {
+			It("ignores the ingress with default backend and returns an error with mapping-strategy: edges", func() {
 				ing := testutils.NewTestIngressV1("ingress-default-backend", "test-namespace")
+				if ing.Annotations == nil {
+					ing.Annotations = map[string]string{}
+				}
+				ing.Annotations["k8s.ngrok.com/mapping-strategy"] = "edges"
 				ing.Spec.DefaultBackend = &netv1.IngressBackend{
 					Service: &netv1.IngressServiceBackend{
 						Name: "default-service",

--- a/pkg/managerdriver/domains.go
+++ b/pkg/managerdriver/domains.go
@@ -42,11 +42,11 @@ func ingressToDomains(log logr.Logger, in *netv1.Ingress, newDomainMetadata stri
 		domain.Spec.Metadata = newDomainMetadata
 
 		// Check the annotation to see if an edge or endpoint is desired from this ingress resource
-		useEndpoints, err := annotations.ExtractUseEndpoints(in)
+		useEdges, err := annotations.ExtractUseEdges(in)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using edges", annotations.MappingStrategyAnnotation))
+			log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using endpoints", annotations.MappingStrategyAnnotation))
 		}
-		if useEndpoints {
+		if !useEdges {
 			endpointDomains[domainName] = domain
 		} else {
 			edgeDomains[domainName] = domain
@@ -86,11 +86,11 @@ func gatewayToDomains(log logr.Logger, in *gatewayv1.Gateway, newDomainMetadata 
 		domain.Spec.Metadata = newDomainMetadata
 
 		// Check the annotation to see if an edge or endpoint is desired from this ingress resource
-		useEndpoints, err := annotations.ExtractUseEndpoints(in)
+		useEdges, err := annotations.ExtractUseEdges(in)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using edges", annotations.MappingStrategyAnnotation))
+			log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using endpoints", annotations.MappingStrategyAnnotation))
 		}
-		if useEndpoints {
+		if !useEdges {
 			endpointDomains[domainName] = domain
 		} else {
 			edgeDomains[domainName] = domain

--- a/pkg/managerdriver/driver_test.go
+++ b/pkg/managerdriver/driver_test.go
@@ -125,10 +125,19 @@ var _ = Describe("Driver", func() {
 				Expect(tunnels.Items).To(HaveLen(0))
 			})
 		})
-		Context("When there are just ingresses and CRDs need to be created", func() {
+		Context("When there are just edge ingresses and edges need to be created", func() {
 			It("Should create the CRDs", func() {
 				i1 := testutils.NewTestIngressV1("test-ingress", "test-namespace")
+				if i1.Annotations == nil {
+					i1.Annotations = map[string]string{}
+				}
+				i1.Annotations["k8s.ngrok.com/mapping-strategy"] = "edges"
 				i2 := testutils.NewTestIngressV1("test-ingress-2", "test-namespace")
+				if i2.Annotations == nil {
+					i2.Annotations = map[string]string{}
+				}
+				i2.Annotations["k8s.ngrok.com/mapping-strategy"] = "edges"
+
 				ic1 := testutils.NewTestIngressClass("test-ingress-class", true, true)
 				ic2 := testutils.NewTestIngressClass("test-ingress-class-2", true, true)
 				s := testutils.NewTestServiceV1("example", "test-namespace")
@@ -664,11 +673,15 @@ var _ = Describe("Driver", func() {
 		})
 	})
 
-	Describe("When no ingresses are opted in to use endpoints", func() {
+	Describe("When ingresses are opted in to use edges", func() {
 		It("Should create edges and not endpoints", func() {
 			ic1 := testutils.NewTestIngressClass("test-ingress-class", true, true)
 
 			i1 := testutils.NewTestIngressV1WithClass("ingress-1", "test-namespace", ic1.Name)
+			if i1.Annotations == nil {
+				i1.Annotations = map[string]string{}
+			}
+			i1.Annotations["k8s.ngrok.com/mapping-strategy"] = "edges"
 			i1.Spec.Rules = []netv1.IngressRule{
 				{
 					Host: "a.customdomain.com",
@@ -723,6 +736,10 @@ var _ = Describe("Driver", func() {
 				},
 			}
 			i2 := testutils.NewTestIngressV1WithClass("ingress-2", "other-namespace", ic1.Name)
+			if i2.Annotations == nil {
+				i2.Annotations = map[string]string{}
+			}
+			i2.Annotations["k8s.ngrok.com/mapping-strategy"] = "edges"
 			i2.Spec.Rules = []netv1.IngressRule{
 				{
 					Host: "c.customdomain.com",

--- a/pkg/managerdriver/edges.go
+++ b/pkg/managerdriver/edges.go
@@ -197,13 +197,12 @@ func (d *Driver) calculateHTTPSEdges(domains *domainSet) map[string]ingressv1alp
 func (d *Driver) calculateHTTPSEdgesFromIngress(edgeMap map[string]ingressv1alpha1.HTTPSEdge) {
 	ingresses := d.store.ListNgrokIngressesV1()
 	for _, ingress := range ingresses {
-		useEndpoints, err := annotations.ExtractUseEndpoints(ingress)
+		useEdges, err := annotations.ExtractUseEdges(ingress)
 		if err != nil {
-			d.log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using edges", annotations.MappingStrategyAnnotation))
+			d.log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using endpoints", annotations.MappingStrategyAnnotation))
 		}
-		if useEndpoints {
-			d.log.Info(fmt.Sprintf("the following ingress will be provided by ngrok endpoints instead of edges because of the %q annotation",
-				annotations.MappingStrategyAnnotation),
+		if !useEdges {
+			d.log.Info("the following ingress will be provided by ngrok endpoints instead of edges",
 				"ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
 			)
 			continue
@@ -305,13 +304,12 @@ func (d *Driver) calculateHTTPSEdgesFromIngress(edgeMap map[string]ingressv1alph
 func (d *Driver) calculateHTTPSEdgesFromGateway(edgeMap map[string]ingressv1alpha1.HTTPSEdge) {
 	gateways := d.store.ListGateways()
 	for _, gtw := range gateways {
-		useEndpoints, err := annotations.ExtractUseEndpoints(gtw)
+		useEdges, err := annotations.ExtractUseEdges(gtw)
 		if err != nil {
-			d.log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using edges", annotations.MappingStrategyAnnotation))
+			d.log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using endpoints", annotations.MappingStrategyAnnotation))
 		}
-		if useEndpoints {
-			d.log.Info(fmt.Sprintf("the following gateway will be provided by ngrok endpoints instead of edges because of the %q annotation",
-				annotations.MappingStrategyAnnotation),
+		if !useEdges {
+			d.log.Info("the following gateway will be provided by ngrok endpoints",
 				"gateway", fmt.Sprintf("%s.%s", gtw.Name, gtw.Namespace),
 			)
 			continue

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-default-to-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-default-to-endpoints.yaml
@@ -1,0 +1,107 @@
+# Gateways without the mapping-strategy annotation should default to endpoints instead of edges
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+            on_http_request:
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-1')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-test-service-1-default-8080.internal"
+              - name: Fallback-404
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Cloud Endpoint"
+                    headers:
+                      content-type: text/plain
+      url: https://test-hostname.ngrok.io
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-8080.internal"
+      upstream:
+        url: "http://test-service-1.default:8080"
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-no-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-no-endpoints.yaml
@@ -1,4 +1,4 @@
-# Gateways that do not have the mapping-strategy: endpoints should not create any endpoint resources
+# Gateways that have the mapping-strategy: edges should not create any endpoint resources
 input:
   gatewayClasses:
   - apiVersion: gateway.networking.k8s.io/v1
@@ -13,6 +13,8 @@ input:
     metadata:
       name: test-gateway
       namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: edges
     spec:
       gatewayClassName: ngrok
       infrastructure:

--- a/pkg/managerdriver/testdata/translator/ingress-no-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-no-endpoints.yaml
@@ -1,4 +1,4 @@
-# Ingresses with traffic policy defaultBackends
+# Ingresses that have the mapping-strategy: edges should not create any endpoint resources
 input:
   ingressClasses:
   - apiVersion: networking.k8s.io/v1
@@ -18,6 +18,7 @@ input:
     metadata:
       annotations:
         k8s.ngrok.com/traffic-policy: response-503
+        k8s.ngrok.com/mapping-strategy: edges
       name: test-ingress-1
       namespace: default
     spec:
@@ -43,6 +44,7 @@ input:
     metadata:
       annotations:
         k8s.ngrok.com/traffic-policy: response-503
+        k8s.ngrok.com/mapping-strategy: edges
       name: test-ingress-2
       namespace: default
     spec:

--- a/pkg/managerdriver/testdata/translator/ingress-valid-default-to-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid-default-to-endpoints.yaml
@@ -1,0 +1,194 @@
+# Ingresses without the mapping-strategy annotation should create endpoints instead of edges
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ngrok-operator
+        app.kubernetes.io/name: ngrok-operator
+        app.kubernetes.io/part-of: ngrok-operator
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        k8s.ngrok.com/traffic-policy: response-503
+      name: test-ingress-1
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      defaultBackend:
+        service:
+          name: test-service-1
+          port:
+            number: 8080
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test-1
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-1
+                    port:
+                      number: 8080
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        k8s.ngrok.com/traffic-policy: response-503
+      name: test-ingress-2
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      defaultBackend:
+        service:
+          name: test-service-1
+          port:
+            number: 8080
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test-2
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-2
+                    port:
+                      number: 8080
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies: 
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: NgrokTrafficPolicy
+    metadata:
+      name: response-503
+      namespace: default
+    spec:
+      policy:
+        on_http_request:
+          - name: response-503
+            expressions:
+              - req.url.path.startsWith('/foo')
+            actions:
+              - type: custom-response
+                config:
+                  status_code: 503
+                  content: "Service is temporarily unavailable"
+                  headers:
+                    content-type: text/plain
+expected:
+  # Generated cloud endpoint should have the first traffic policy, but the second ingress will not be processed due to the
+  # traffic policy conflict
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-ingresses.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      url: https://test-ingresses.ngrok.io
+      trafficPolicy:
+        policy:
+          on_http_request:
+          - name: response-503
+            expressions:
+              - req.url.path.startsWith('/foo')
+            actions:
+              - type: custom-response
+                config:
+                  status_code: 503
+                  content: "Service is temporarily unavailable"
+                  headers:
+                    content-type: text/plain
+          - name: Generated-Route
+            expressions:
+            - req.url.path.startsWith('/test-1')
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-1-default-8080.internal
+          - name: Generated-Route
+            expressions:
+            - req.url.path.startsWith('/test-2')
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-2-default-8080.internal
+          - name: Generated-Route-Default-Backend
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-1-default-8080.internal
+          - name: Fallback-404
+            actions:
+            - type: custom-response
+              config:
+                status_code: 404
+                content: "No route was found for this ngrok Cloud Endpoint"
+                headers:
+                  content-type: text/plain
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-8080.internal"
+      upstream:
+        url: "http://test-service-1.default:8080"
+      bindings:
+      - "internal"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-2-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-2-default-8080.internal"
+      upstream:
+        url: "http://test-service-2.default:8080"
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/translate_gatewayapi.go
+++ b/pkg/managerdriver/translate_gatewayapi.go
@@ -113,11 +113,11 @@ func (t *translator) HTTPRouteToIR(
 		// We currently require this annotation to be present for an Ingress to be translated into CloudEndpoints/AgentEndpoints, otherwise the default behaviour is to
 		// translate it into HTTPSEdges (legacy). A future version will remove support for HTTPSEdges and translation into CloudEndpoints/AgentEndpoints will become the new
 		// default behaviour.
-		useEndpoints, err := annotations.ExtractUseEndpoints(gateway)
+		useEdges, err := annotations.ExtractUseEdges(gateway)
 		if err != nil {
-			t.log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using edges", annotations.MappingStrategyAnnotation))
+			t.log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using endpoints", annotations.MappingStrategyAnnotation))
 		}
-		if !useEndpoints {
+		if useEdges {
 			t.log.Info(fmt.Sprintf("the Gateway and its HTTPRoutes will be provided by ngrok edges instead of endpoints because of the %q annotation",
 				annotations.MappingStrategyAnnotation),
 				"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
@@ -145,7 +145,7 @@ func (t *translator) HTTPRouteToIR(
 
 		// If we don't have a native traffic policy from annotations, see if one was provided from a moduleset annotation
 		if annotationTrafficPolicy == nil {
-			annotationTrafficPolicy, tpObjRef, err = trafficPolicyFromModSetAnnotation(t.log, t.store, gateway, useEndpoints)
+			annotationTrafficPolicy, tpObjRef, err = trafficPolicyFromModSetAnnotation(t.log, t.store, gateway, true)
 			if err != nil {
 				t.log.Error(err, "error getting ngrok traffic policy for gateway",
 					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace))

--- a/pkg/managerdriver/translate_ingresses.go
+++ b/pkg/managerdriver/translate_ingresses.go
@@ -28,11 +28,11 @@ func (t *translator) ingressesToIR() []*ir.IRVirtualHost {
 		// We currently require this annotation to be present for an Ingress to be translated into CloudEndpoints/AgentEndpoints, otherwise the default behaviour is to
 		// translate it into HTTPSEdges (legacy). A future version will remove support for HTTPSEdges and translation into CloudEndpoints/AgentEndpoints will become the new
 		// default behaviour.
-		useEndpoints, err := annotations.ExtractUseEndpoints(ingress)
+		useEdges, err := annotations.ExtractUseEdges(ingress)
 		if err != nil {
-			t.log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using edges", annotations.MappingStrategyAnnotation))
+			t.log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using endpoints", annotations.MappingStrategyAnnotation))
 		}
-		if !useEndpoints {
+		if useEdges {
 			t.log.Info(fmt.Sprintf("the following ingress will be provided by ngrok edges instead of endpoints because of the %q annotation",
 				annotations.MappingStrategyAnnotation),
 				"ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
@@ -60,7 +60,7 @@ func (t *translator) ingressesToIR() []*ir.IRVirtualHost {
 
 		// If we don't have a native traffic policy from annotations, see if one was provided from a moduleset annotation
 		if annotationTrafficPolicy == nil {
-			annotationTrafficPolicy, tpObjRef, err = trafficPolicyFromModSetAnnotation(t.log, t.store, ingress, useEndpoints)
+			annotationTrafficPolicy, tpObjRef, err = trafficPolicyFromModSetAnnotation(t.log, t.store, ingress, true)
 			if err != nil {
 				t.log.Error(err, "error getting ngrok traffic policy for ingress",
 					"ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace))


### PR DESCRIPTION
For the last few builds, we've required the `k8s.ngrok.com/mapping-strategy: endpoints` annotation on `Ingress` and `Gateway` resources in order for them to generate `AgentEndpoint` and `CloudEndpoint` resources instead of Edges. This makes endpoints the new default when the annotation is not supplied. Supplying `k8s.ngrok.com/mapping-strategy: edges` will still allow you to create Edges instead of Endpoints, but Edges are being removed soon.