### PR TITLE
chore(deps): Upgrade go to 1.24.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
     types: [checks_requested]
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24'
   DOCKER_BUILDX_PLATFORMS: linux/amd64,linux/arm64
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.1 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.4.1
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.60.3
+GOLANGCI_LINT_VERSION ?= v1.64.6
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731531548,
-        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
+        "lastModified": 1741310760,
+        "narHash": "sha256-aizILFrPgq/W53Jw8i0a1h1GZAAKtlYOrG/A5r46gVM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
+        "rev": "de0fe301211c267807afd11b12613f5511ff7433",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     {
       devShells.default = pkgs.mkShell {
         buildInputs = with pkgs; [
-          go_1_23
+          go_1_24
           gotools
           go-tools
           golangci-lint

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -4,8 +4,8 @@ set -eu -o pipefail
 
 GOVERSION="$(go env GOVERSION || echo "not installed")"
 
-if ! [[ "$GOVERSION" == "go1.23" ||  "$GOVERSION" = "go1.23."* ]]; then
-  echo "Detected go version $GOVERSION, but 1.23 is required"
+if ! [[ "$GOVERSION" == "go1.24" ||  "$GOVERSION" = "go1.24."* ]]; then
+  echo "Detected go version $GOVERSION, but 1.24 is required"
   exit 1
 else
   echo "Preflight passed ✅"


### PR DESCRIPTION
## What

Upgrade to go 1.24.1. Looks like there might be some free perf improvements.

## How

* Change references from 1.23 -> 1.24
* Also update golangci-lint to a version that supports 1.24

## Breaking Changes
No