### PR TITLE
set operator description from values.yaml description

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -720,6 +720,10 @@ func createKubernetesOperator(ctx context.Context, client client.Client, opts ma
 			Region: opts.region,
 		}
 
+		// Set the description to whatever the user input
+		// in values.yaml
+		k8sOperator.Spec.Description = opts.description
+
 		features := []string{}
 		if opts.enableFeatureIngress {
 			features = append(features, ngrokv1alpha1.KubernetesOperatorFeatureIngress)


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
Currently the KubernetesOperator resource always sets its `Description` field based on the default value for the crd. Since we're asking users for description in values.yaml, we should set it based on that instead.

## How
Set description from Values.description.

## Breaking Changes
Nope!
