### PR TITLE
fix: HTTP/2 upstreams for edges & endpoints

### DIFF
--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	common "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/trafficpolicy"
 )
 
@@ -188,6 +189,7 @@ type IRService struct {
 	Port           int32
 	ClientCertRefs []IRObjectRef
 	Scheme         IRScheme
+	Protocol       *common.ApplicationProtocol
 }
 
 type IRScheme string
@@ -201,6 +203,9 @@ type IRServiceKey string
 
 func (s IRService) Key() IRServiceKey {
 	key := fmt.Sprintf("%s/%s/%s/%d", s.UID, s.Namespace, s.Name, s.Port)
+	if s.Protocol != nil {
+		key += fmt.Sprintf("/%s", *s.Protocol)
+	}
 	for _, clientCertRef := range s.ClientCertRefs {
 		key += fmt.Sprintf("/%s.%s", clientCertRef.Name, clientCertRef.Namespace)
 	}

--- a/pkg/managerdriver/testdata/translator/ingress-app-protocols.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-app-protocols.yaml
@@ -1,0 +1,215 @@
+# Ingresses without the mapping-strategy annotation should create endpoints instead of edges
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ngrok-operator
+        app.kubernetes.io/name: ngrok-operator
+        app.kubernetes.io/part-of: ngrok-operator
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: test-ingress-1
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-1
+                    port:
+                      number: 80
+              - path: /unknown
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-1
+                    port:
+                      number: 8080
+              - path: /http2-1
+                pathType: Exact
+                backend:
+                  service:
+                    name: test-service-2
+                    port:
+                      number: 443
+              - path: /http2-2
+                pathType: Exact
+                backend:
+                  service:
+                    name: test-service-3
+                    port:
+                      number: 443
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: web
+        port: 80
+        protocol: TCP
+        appProtocol: http
+        targetPort: http
+      - name: http
+        port: 8080
+        protocol: TCP
+        appProtocol: unknown
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 443
+        protocol: TCP
+        appProtocol: kubernetes.io/h2c
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-3
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 443
+        protocol: TCP
+        appProtocol: k8s.ngrok.com/http2
+        targetPort: http
+      type: ClusterIP
+
+expected:
+  # Generated cloud endpoint should have the first traffic policy, but the second ingress will not be processed due to the
+  # traffic policy conflict
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-ingresses.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      url: https://test-ingresses.ngrok.io
+      trafficPolicy:
+        policy:
+          on_http_request:
+          - name: Generated-Route
+            expressions:
+            - "req.url.path == '/http2-1'"
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-2-default-443.internal
+          - name: Generated-Route
+            expressions:
+            - "req.url.path == '/http2-2'"
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-3-default-443.internal
+          - name: Generated-Route
+            expressions:
+            - "req.url.path.startsWith('/unknown')"
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-1-default-8080.internal
+          - name: Generated-Route
+            expressions:
+            - "req.url.path.startsWith('/')"
+            actions:
+            - type: forward-internal
+              config:
+                url: https://e3b0c-test-service-1-default-80.internal
+          - name: Fallback-404
+            actions:
+            - type: custom-response
+              config:
+                status_code: 404
+                content: "No route was found for this ngrok Cloud Endpoint"
+                headers:
+                  content-type: text/plain
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-80
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-80.internal"
+      upstream:
+        url: "http://test-service-1.default:80"
+        protocol: http1
+      bindings:
+      - "internal"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-8080.internal"
+      upstream:
+        url: "http://test-service-1.default:8080"
+      bindings:
+      - "internal"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-2-default-443
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-2-default-443.internal"
+      upstream:
+        url: "http://test-service-2.default:443"
+        protocol: http2
+      bindings:
+      - "internal"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-3-default-443
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-3-default-443.internal"
+      upstream:
+        url: "http://test-service-3.default:443"
+        protocol: http2
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/translate_ingresses.go
+++ b/pkg/managerdriver/translate_ingresses.go
@@ -326,12 +326,15 @@ func (t *translator) ingressBackendToIR(ingress *netv1.Ingress, backend *netv1.I
 		)
 	}
 
+	appProtocol := getPortAppProtocol(t.log, service, servicePort)
+
 	irService := ir.IRService{
 		UID:       string(service.UID),
 		Name:      serviceName,
 		Namespace: ingress.Namespace,
 		Port:      servicePort.Port,
 		Scheme:    irScheme,
+		Protocol:  appProtocol,
 	}
 	owningResource := ir.OwningResource{
 		Kind:      "Ingress",

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	common "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/ir"
 	"github.com/ngrok/ngrok-operator/internal/store"
@@ -373,6 +374,7 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, routes []*ir.
 						irVHost.AnnotationsToAdd,
 						irVHost.Metadata,
 						service.ClientCertRefs,
+						service.Protocol,
 					)
 					childEndpointCache[service.Key()] = childEndpoint
 				}
@@ -539,6 +541,7 @@ func (t *translator) buildDefaultDestinationPolicy(irVHost *ir.IRVirtualHost, ch
 				irVHost.AnnotationsToAdd,
 				t.defaultIngressMetadata,
 				service.ClientCertRefs,
+				service.Protocol,
 			)
 			childEndpointCache[service.Key()] = childEndpoint
 		}
@@ -610,6 +613,7 @@ func buildInternalAgentEndpoint(
 	annotations map[string]string,
 	metadata string,
 	upstreamClientCertRefs []ir.IRObjectRef,
+	upstreamProtocol *common.ApplicationProtocol,
 ) *ngrokv1alpha1.AgentEndpoint {
 	ret := &ngrokv1alpha1.AgentEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
@@ -622,7 +626,8 @@ func buildInternalAgentEndpoint(
 			URL:      internalAgentEndpointURL(serviceUID, serviceName, namespace, clusterDomain, port, upstreamClientCertRefs),
 			Metadata: metadata,
 			Upstream: ngrokv1alpha1.EndpointUpstream{
-				URL: internalAgentEndpointUpstreamURL(serviceName, namespace, clusterDomain, port, scheme),
+				URL:      internalAgentEndpointUpstreamURL(serviceName, namespace, clusterDomain, port, scheme),
+				Protocol: upstreamProtocol,
 			},
 			Bindings: []string{"internal"},
 		},

--- a/pkg/managerdriver/tunnels.go
+++ b/pkg/managerdriver/tunnels.go
@@ -10,6 +10,7 @@ import (
 	common "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"golang.org/x/exp/slices"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -116,20 +117,13 @@ func (d *Driver) calculateTunnelsFromIngress(tunnels map[tunnelKey]ingressv1alph
 							Labels:          d.tunnelLabels(serviceName, servicePort),
 						},
 						Spec: ingressv1alpha1.TunnelSpec{
-							ForwardsTo: targetAddr,
-							Labels:     ngrokLabels(ingress.Namespace, serviceUID, serviceName, servicePort),
+							AppProtocol: appProtocol,
+							ForwardsTo:  targetAddr,
+							Labels:      ngrokLabels(ingress.Namespace, serviceUID, serviceName, servicePort),
 							BackendConfig: &ingressv1alpha1.BackendConfig{
 								Protocol: protocol,
 							},
 						},
-					}
-					switch appProtocol {
-					case "http2":
-						proto := common.ApplicationProtocol_HTTP2
-						tunnel.Spec.AppProtocol = &proto
-					case "http1":
-						proto := common.ApplicationProtocol_HTTP1
-						tunnel.Spec.AppProtocol = &proto
 					}
 				}
 
@@ -189,20 +183,13 @@ func (d *Driver) calculateTunnelsFromGateway(tunnels map[tunnelKey]ingressv1alph
 							Labels:          d.tunnelLabels(serviceName, servicePort),
 						},
 						Spec: ingressv1alpha1.TunnelSpec{
-							ForwardsTo: targetAddr,
-							Labels:     ngrokLabels(httproute.Namespace, serviceUID, serviceName, servicePort),
+							AppProtocol: appProtocol,
+							ForwardsTo:  targetAddr,
+							Labels:      ngrokLabels(httproute.Namespace, serviceUID, serviceName, servicePort),
 							BackendConfig: &ingressv1alpha1.BackendConfig{
 								Protocol: protocol,
 							},
 						},
-					}
-					switch appProtocol {
-					case "http2":
-						proto := common.ApplicationProtocol_HTTP2
-						tunnel.Spec.AppProtocol = &proto
-					case "http1":
-						proto := common.ApplicationProtocol_HTTP1
-						tunnel.Spec.AppProtocol = &proto
 					}
 				}
 
@@ -231,42 +218,31 @@ func (d *Driver) calculateTunnelsFromGateway(tunnels map[tunnelKey]ingressv1alph
 	}
 }
 
-func (d *Driver) getTunnelBackend(backendSvc netv1.IngressServiceBackend, namespace string) (string, int32, string, string, error) {
+func (d *Driver) getTunnelBackend(backendSvc netv1.IngressServiceBackend, namespace string) (string, int32, string, *common.ApplicationProtocol, error) {
 	service, servicePort, err := d.findBackendServicePort(backendSvc, namespace)
 	if err != nil {
-		return "", 0, "", "", err
+		return "", 0, "", nil, err
 	}
-
-	protocol, err := getProtoForServicePort(d.log, service, servicePort.Name)
-	if err != nil {
-		return "", 0, "", "", err
-	}
-
-	appProtocol, err := getPortAppProtocol(service, servicePort)
-	if err != nil {
-		return "", 0, "", "", err
-	}
-
-	return string(service.UID), servicePort.Port, protocol, appProtocol, nil
+	return d.getTunnelBackendCommon(service, servicePort)
 }
 
-func (d *Driver) getTunnelBackendFromGateway(backendRef gatewayv1.BackendRef, namespace string) (string, int32, string, string, error) {
+func (d *Driver) getTunnelBackendFromGateway(backendRef gatewayv1.BackendRef, namespace string) (string, int32, string, *common.ApplicationProtocol, error) {
 	service, servicePort, err := d.findBackendRefServicePort(backendRef, namespace)
 	if err != nil {
-		return "", 0, "", "", err
+		return "", 0, "", nil, err
 	}
 
-	protocol, err := getProtoForServicePort(d.log, service, servicePort.Name)
+	return d.getTunnelBackendCommon(service, servicePort)
+}
+
+func (d *Driver) getTunnelBackendCommon(svc *corev1.Service, port *corev1.ServicePort) (string, int32, string, *common.ApplicationProtocol, error) {
+	protocol, err := getProtoForServicePort(d.log, svc, port.Name)
 	if err != nil {
-		return "", 0, "", "", err
+		return "", 0, "", nil, err
 	}
 
-	appProtocol, err := getPortAppProtocol(service, servicePort)
-	if err != nil {
-		return "", 0, "", "", err
-	}
-
-	return string(service.UID), servicePort.Port, protocol, appProtocol, nil
+	appProtocol := getPortAppProtocol(d.log, svc, port)
+	return string(svc.UID), port.Port, protocol, appProtocol, nil
 }
 
 func (d *Driver) tunnelLabels(serviceName string, port int32) map[string]string {


### PR DESCRIPTION
Fixes #572 

## What

This is a fix for 2 issues:
* If the `appProtocol` on a service was unknown, we were throwing an error instead of ignoring it. According to the [docs](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol), valid values are any of the [IANA standard service names](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml). If we don't have a specific protocol mapped, we should probably ignore it.
* We weren't setting the upstream protocol on AgentEndpoints when converting from ingresses. This was breaking support for HTTP/2 upstreams when using endpoints.


## How
* For the first part, try to map the `appProtocol` to one of our known protocols. If the `Tunnel.protocol` isn't able to be determined, just leave it empty and log a message instead of returning an error.
* Plumb through `Protocol` to our internal representation so that `appProtocol` setting takes effect for `AgentEndpoints`. 
* Add tests for both cases

## Breaking Changes
No

## Validation

I tested this with against an argoCD install(email & IP redacted). I was able to hit both the UI and login to the CLI:

```sh
argocd login grpc.argocd.mydomain.xyz
<login>
argocd app list
```

```yaml
---
kind: NgrokTrafficPolicy
apiVersion: ngrok.k8s.ngrok.com/v1alpha1
metadata:
  name: google-oauth
  namespace: argocd
spec:
  policy:
    on_http_request:
    - actions: # Phase 1 : Authenticate
      - type: oauth
        config:
          provider: google
    - expressions: # Phase 2 : Deny if not me
      - "!(actions.ngrok.oauth.identity.email in ['my.email@gmail.com'])"
      actions:
      - type: custom-response
        config:
          status_code: 403
          content: "Forbidden"
---
kind: NgrokTrafficPolicy
apiVersion: ngrok.k8s.ngrok.com/v1alpha1
metadata:
  name: argocd-grpc-access
  namespace: argocd
spec:
  policy:
    on_tcp_connect:
    - actions:
      - type: restrict-ips
        config:
          enforce: true
          allow:
          - '0.0.0.0/32'        # My IPv4
---
apiVersion: v1
kind: Service
metadata:
  name: argocd-server
  namespace: argocd
  annotations:
    k8s.ngrok.com/app-protocols: '{"https": "HTTPS", "grpc": "HTTPS"}'
spec:
  type: ClusterIP
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: 8080
  - name: https
    port: 443
    protocol: TCP
    targetPort: 8080
  - name: grpc
    port: 444
    protocol: TCP
    appProtocol: k8s.ngrok.com/http2
    targetPort: 8080
  selector:
    app.kubernetes.io/name: argocd-server
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: argocd-ingress
  namespace: argocd
  annotations:
    external-dns.alpha.kubernetes.io/hostname: argocd.mydomain.xyz
    external-dns.alpha.kubernetes.io/ttl: 1m
    k8s.ngrok.com/traffic-policy: google-oauth
    k8s.ngrok.com/mapping-strategy: endpoints
spec:
  ingressClassName: ngrok
  rules:
  - host: argocd.mydomain.xyz
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: argocd-server
            port:
              name: https
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: argocd-grpc-ingress
  namespace: argocd
  annotations:
    external-dns.alpha.kubernetes.io/hostname: grpc.argocd.mydomain.xyz
    external-dns.alpha.kubernetes.io/ttl: 1m
    k8s.ngrok.com/traffic-policy: argocd-grpc-access
spec:
  ingressClassName: ngrok
  rules:
  - host: grpc.argocd.mydomain.xyz
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: argocd-server
            port:
              name: grpc
```