### PR TITLE
Consume IngressEndpoint from status

### DIFF
--- a/internal/controller/bindings/forwarder_controller.go
+++ b/internal/controller/bindings/forwarder_controller.go
@@ -181,6 +181,11 @@ func (r *ForwarderReconciler) update(ctx context.Context, epb *bindingsv1alpha1.
 		return err
 	}
 
+	ingressEndpoint, err := getIngressEndpointWithFallback(op.Status.BindingsIngressEndpoint, log)
+	if err != nil {
+		log.Error(err, "failed to determine bindings ingress endpoint")
+	}
+
 	cnxnHandler := func(conn net.Conn) error {
 		defer conn.Close()
 
@@ -196,11 +201,6 @@ func (r *ForwarderReconciler) update(ctx context.Context, epb *bindingsv1alpha1.
 		)
 
 		log.Info("Handling connnection")
-
-		ingressEndpoint, err := getIngressEndpointWithFallback(op.Status.BindingsIngressEndpoint, log)
-		if err != nil {
-			log.Error(err, "failed to determine bindings ingress endpoint")
-		}
 
 		ngrokConn, err := tlsDialer.Dial("tcp", ingressEndpoint)
 		if err != nil {

--- a/internal/controller/bindings/forwarder_controller.go
+++ b/internal/controller/bindings/forwarder_controller.go
@@ -138,7 +138,7 @@ func (r *ForwarderReconciler) update(ctx context.Context, epb *bindingsv1alpha1.
 		return fmt.Errorf("operator does not have binding configuration")
 	}
 
-	if op.Spec.Binding.IngressEndpoint == nil {
+	if op.Status.BindingsIngressEndpoint == "" {
 		return fmt.Errorf("operator binding configuration does not have an ingress endpoint")
 	}
 
@@ -196,7 +196,7 @@ func (r *ForwarderReconciler) update(ctx context.Context, epb *bindingsv1alpha1.
 
 		log.Info("Handling connnection")
 
-		ngrokConn, err := tlsDialer.Dial("tcp", *op.Spec.Binding.IngressEndpoint)
+		ngrokConn, err := tlsDialer.Dial("tcp", op.Status.BindingsIngressEndpoint)
 		if err != nil {
 			log.Error(err, "failed to dial ingress endpoint")
 			return err

--- a/internal/controller/bindings/forwarder_controller_test.go
+++ b/internal/controller/bindings/forwarder_controller_test.go
@@ -1,0 +1,47 @@
+package bindings
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetIngressEndpointWithFallback(t *testing.T) {
+	cases := []struct {
+		input            string
+		expectedEndpoint string
+		shouldErr        bool
+	}{
+		{
+			"",
+			"",
+			true,
+		},
+		{
+			"foo.example.com",
+			"foo.example.com:443",
+			false,
+		},
+		{
+			"foo.example.com:443",
+			"foo.example.com:443",
+			false,
+		},
+		{
+			"foo.example.com:443:1234",
+			"",
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		ingressEndpoint, err := getIngressEndpointWithFallback(c.input, logr.Discard())
+		assert.Equal(t, c.expectedEndpoint, ingressEndpoint)
+		if c.shouldErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
We're moving ingress endpoints to be something that's always provided by the ngrok api instead of something configurable by the user. This change starts using the ingress endpoint that's set on the KubernetesOperator status instead of the one on the spec.

We'll (eventually) remove it from the spec and chart.

## How
Get the ingress url off the status instead of spec.

## Breaking Changes
If you have a very old operator that hasn't ever gotten the ingress endpoint from the API it may stop working, but any update from the controller should fill it in.
