### PR TITLE
add new mapping strategy

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -41,11 +41,21 @@ const (
 	// This annotation can be used on ingress/gateway resources to control which ngrok resources (endpoints/edges) get created from it
 	MappingStrategyAnnotation    = "k8s.ngrok.com/mapping-strategy"
 	MappingStrategyAnnotationKey = "mapping-strategy"
-	MappingStrategy_Endpoints    = "endpoints"
-	MappingStrategy_Edges        = "edges"
 
 	EndpointPoolingAnnotation    = "k8s.ngrok.com/pooling-enabled"
 	EndpointPoolingAnnotationKey = "pooling-enabled"
+)
+
+type MappingStrategy string
+
+const (
+	MappingStrategy_Edges MappingStrategy = "edges"
+
+	// The default strategy when translating resources into AgentEndpoint / CloudEndpoint that prioritizes collapsing into a single public AgentEndpoint when possible
+	MappingStrategy_EndpointsDefault MappingStrategy = "endpoints"
+
+	// Alternative strategy when translating resources into AgentEndpoint / CloudEndpoint that always creates CloudEndpoints for hostnames and only internal AgentEndpoints for each unique upstream
+	MappingStrategy_EndpointsVerbose MappingStrategy = "endpoints-verbose"
 )
 
 type RouteModules struct {
@@ -149,7 +159,7 @@ func ExtractUseEdges(obj client.Object) (bool, error) {
 		}
 		return false, err
 	}
-	return strings.EqualFold(val, MappingStrategy_Edges), nil
+	return strings.EqualFold(val, string(MappingStrategy_Edges)), nil
 }
 
 // Whether or not we should use endpoint pooling

--- a/internal/trafficpolicy/policy.go
+++ b/internal/trafficpolicy/policy.go
@@ -21,6 +21,7 @@ const (
 	ActionType_ForwardInternal  ActionType = "forward-internal"
 	ActionType_JWTValidation    ActionType = "jwt-validation"
 	ActionType_Log              ActionType = "log"
+	ActionType_SetVars          ActionType = "set-vars"
 	ActionType_OAuth            ActionType = "oauth"
 	ActionType_OIDC             ActionType = "openid-connect"
 	ActionType_RateLimit        ActionType = "rate-limit"
@@ -43,6 +44,7 @@ func ActionTypes() []ActionType {
 		ActionType_ForwardInternal,
 		ActionType_JWTValidation,
 		ActionType_Log,
+		ActionType_SetVars,
 		ActionType_OAuth,
 		ActionType_OIDC,
 		ActionType_RateLimit,

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -121,7 +121,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
             on_tcp_connect:

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -118,7 +118,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -91,7 +91,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-invalid-kinds.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-invalid-kinds.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-same-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-same-namespace.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -101,7 +101,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-valid-kinds.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-valid-kinds.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -91,7 +91,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation-invalid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation-invalid.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
         k8s.ngrok.com/bindings: "foo-binding"
     spec:
       gatewayClassName: ngrok
@@ -89,7 +89,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
         k8s.ngrok.com/bindings: "foo-binding,bar-binding" # multiple bindings are not currently supported
     spec:
       gatewayClassName: ngrok

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-collapse-endpoints-multiple.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-collapse-endpoints-multiple.yaml
@@ -1,0 +1,183 @@
+# Gateways without the mapping-strategy annotation should default to endpoints instead of edges
+# The default mapping strategy should collapse it into AgentEndpoints
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route-2
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /service1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /service2
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-2
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://test-hostname.ngrok.io"
+      upstream:
+        url: "http://test-service-1.default:8080"
+      bindings:
+      - "public"
+      trafficPolicy:
+        inline:
+            on_http_request:
+              - name: Initialize-Local-Service-Match
+                actions:
+                - type: set-vars
+                  config:
+                    vars:
+                    - request_matched_local_svc: false
+              - name: Generated-Local-Service-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-1')"
+                  - vars.request_matched_local_svc == false
+                actions:
+                  - type: set-vars
+                    config:
+                      vars: 
+                      - request_matched_local_svc: true
+              - name: Generated-Local-Service-Route
+                expressions:
+                  - "req.url.path.startsWith('/service1')"
+                  - vars.request_matched_local_svc == false
+                actions:
+                  - type: set-vars
+                    config:
+                      vars: 
+                      - request_matched_local_svc: true
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/service2')"
+                  - vars.request_matched_local_svc == false
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: https://e3b0c-test-service-2-default-8080.internal                      
+              - name: Fallback-404
+                expressions:
+                - vars.request_matched_local_svc == false
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Endpoint"
+                    headers:
+                      content-type: text/plain
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-2-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-2-default-8080.internal"
+      upstream:
+        url: "http://test-service-2.default:8080"
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-default-to-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-default-to-endpoints.yaml
@@ -1,4 +1,5 @@
 # Gateways without the mapping-strategy annotation should default to endpoints instead of edges
+# The default mapping strategy should collapse it into a single AgentEndpoint
 input:
   gatewayClasses:
   - apiVersion: gateway.networking.k8s.io/v1
@@ -59,37 +60,7 @@ input:
         targetPort: http
       type: ClusterIP
 expected:
-  cloudEndpoints:
-  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
-    kind: CloudEndpoint
-    metadata:
-      labels:
-        k8s.ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
-      name: test-gateway.default-test-hostname.ngrok.io
-      namespace: default
-    spec:
-      bindings:
-      - public
-      trafficPolicy:
-        policy:
-            on_http_request:
-              - name: Generated-Route
-                expressions:
-                  - "req.url.path.startsWith('/test-service-1')"
-                actions:
-                  - type: forward-internal
-                    config:
-                      url: "https://e3b0c-test-service-1-default-8080.internal"
-              - name: Fallback-404
-                actions:
-                - type: custom-response
-                  config:
-                    status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
-                    headers:
-                      content-type: text/plain
-      url: https://test-hostname.ngrok.io
+  cloudEndpoints: []
   agentEndpoints:
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
@@ -100,8 +71,36 @@ expected:
       name: e3b0c-test-service-1-default-8080
       namespace: default
     spec:
-      url: "https://e3b0c-test-service-1-default-8080.internal"
+      url: "https://test-hostname.ngrok.io"
       upstream:
         url: "http://test-service-1.default:8080"
       bindings:
-      - "internal"
+      - "public"
+      trafficPolicy:
+        inline:
+            on_http_request:
+              - name: Initialize-Local-Service-Match
+                actions:
+                - type: set-vars
+                  config:
+                    vars:
+                    - request_matched_local_svc: false
+              - name: Generated-Local-Service-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-1')"
+                  - vars.request_matched_local_svc == false
+                actions:
+                  - type: set-vars
+                    config:
+                      vars: 
+                      - request_matched_local_svc: true
+              - name: Fallback-404
+                expressions:
+                - vars.request_matched_local_svc == false
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Endpoint"
+                    headers:
+                      content-type: text/plain

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-endpoints-non-collapsable.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-endpoints-non-collapsable.yaml
@@ -1,0 +1,194 @@
+# Gateways without the mapping-strategy annotation should default to endpoints instead of edges
+# The default mapping strategy should collapse it into AgentEndpoints, but this configuration is not collapsable because each service is used on more than one hostname
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+        - name: test-hostname-2
+          hostname: "test-hostname-2.ngrok.io"
+          port: 443
+          protocol: HTTPS
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      - test-hostname-2.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-2
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-2
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default-test-hostname-2.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+            on_http_request:
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-1')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-test-service-1-default-8080.internal"
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-2')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-test-service-2-default-8080.internal"
+              - name: Fallback-404
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Endpoint"
+                    headers:
+                      content-type: text/plain
+      url: https://test-hostname-2.ngrok.io
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+            on_http_request:
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-1')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-test-service-1-default-8080.internal"
+              - name: Generated-Route
+                expressions:
+                  - "req.url.path.startsWith('/test-service-2')"
+                actions:
+                  - type: forward-internal
+                    config:
+                      url: "https://e3b0c-test-service-2-default-8080.internal"
+              - name: Fallback-404
+                actions:
+                - type: custom-response
+                  config:
+                    status_code: 404
+                    content: "No route was found for this ngrok Endpoint"
+                    headers:
+                      content-type: text/plain
+      url: https://test-hostname.ngrok.io
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-8080.internal"
+      upstream:
+        url: "http://test-service-1.default:8080"
+      bindings:
+      - "internal"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-2-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-2-default-8080.internal"
+      upstream:
+        url: "http://test-service-2.default:8080"
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-infrastructure.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-infrastructure.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       infrastructure:
@@ -96,7 +96,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-invalid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-invalid.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-no-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-no-valid-referencegrants.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       infrastructure:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -139,7 +139,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
             on_tcp_connect:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -119,7 +119,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
             on_tcp_connect:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-no-refgrant.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-no-refgrant.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       backendTLS:
         clientCertificateRef:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-multi-gateway.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-multi-gateway.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway-1
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       backendTLS:
         clientCertificateRef:
@@ -31,7 +31,7 @@ input:
       name: test-gateway-2
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       backendTLS:
         clientCertificateRef:
@@ -133,7 +133,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname-1.ngrok.io
@@ -163,7 +163,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname-2.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-refgrant.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-refgrant.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       backendTLS:
         clientCertificateRef:
@@ -148,7 +148,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       backendTLS:
         clientCertificateRef:
@@ -132,7 +132,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-glob-hostname.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-glob-hostname.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -88,7 +88,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-no-hostnames.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-no-hostnames.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -86,7 +86,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-no-parents.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-no-parents.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-no-routes.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-no-routes.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-weighted-routes-with-rewrite.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-weighted-routes-with-rewrite.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -105,33 +105,26 @@ expected:
       trafficPolicy:
         policy:
             on_http_request:
-            - name: Log-Request-Data
+            - name: Capture-Original-Request-Data
               actions:
-              - type: log
+              - type: set-vars
                 config:
-                  metadata:
-                    "endpoint_id": "${endpoint.id}"
-                    "message": "Capturing original request data with logs before it is modified"
-                    "original_headers": "${req.headers.encodeJson()}"
-                    "original_path": "${req.url.path}"
-                    "original_query_params": "${req.url.query_params.encodeJson()}"
-            - name: Log-Random-Number
+                  vars:
+                  - "original_path": "${req.url.path}"
+                  - "original_headers": "${req.headers.encodeJson()}"
+                  - "original_query_params": "${req.url.query_params.encodeJson()}"
+            - name: Gen-Random-Number
               expressions:
-              - "actions.ngrok.log.metadata['original_path'].startsWith('/weighted-routes')"
+              - "vars.original_path.startsWith('/weighted-routes')"
               actions:
-              - type: log
+              - type: set-vars
                 config:
-                  metadata:
-                    "endpoint_id": "${endpoint.id}"
-                    "message": "Logging random number to select weighted route and preserving captured request data"
-                    "original_headers": "${req.headers.encodeJson()}"
-                    "original_path": "${req.url.path}"
-                    "original_query_params": "${req.url.query_params.encodeJson()}"
-                    "weighted_route_random_num": "${rand.int(0,11)}"
+                  vars:
+                  - "weighted_route_random_num": "${rand.int(0,11)}"
             - name: GatewayAPI-URL-Rewrite-Filter
               expressions:
-                - "actions.ngrok.log.metadata['original_path'].startsWith('/weighted-routes')"
-                - "int(actions.ngrok.log.metadata['weighted_route_random_num']) <= 2"
+                - "vars.original_path.startsWith('/weighted-routes')"
+                - "int(vars.weighted_route_random_num) <= 2"
               actions:
                 - type: url-rewrite
                   config:
@@ -139,16 +132,16 @@ expected:
                     to: "$1://$2$3/rewrite-svc-1$5"
             - name: Generated-Route
               expressions:
-                - "actions.ngrok.log.metadata['original_path'].startsWith('/weighted-routes')"
-                - "int(actions.ngrok.log.metadata['weighted_route_random_num']) <= 2"
+                - "vars.original_path.startsWith('/weighted-routes')"
+                - "int(vars.weighted_route_random_num) <= 2"
               actions:
                 - type: forward-internal
                   config:
                     url: "https://e3b0c-test-service-1-default-8080.internal"
             - name: GatewayAPI-URL-Rewrite-Filter
               expressions:
-                - "actions.ngrok.log.metadata['original_path'].startsWith('/weighted-routes')"
-                - "int(actions.ngrok.log.metadata['weighted_route_random_num']) >= 3 && int(actions.ngrok.log.metadata['weighted_route_random_num']) <= 11"
+                - "vars.original_path.startsWith('/weighted-routes')"
+                - "int(vars.weighted_route_random_num) >= 3 && int(vars.weighted_route_random_num) <= 11"
               actions:
                 - type: url-rewrite
                   config:
@@ -156,8 +149,8 @@ expected:
                     to: "$1://$2$3/rewrite-svc-2$5"
             - name: Generated-Route
               expressions:
-              - "actions.ngrok.log.metadata['original_path'].startsWith('/weighted-routes')"
-              - "int(actions.ngrok.log.metadata['weighted_route_random_num']) >= 3 && int(actions.ngrok.log.metadata['weighted_route_random_num']) <= 11"
+              - "vars.original_path.startsWith('/weighted-routes')"
+              - "int(vars.weighted_route_random_num) >= 3 && int(vars.weighted_route_random_num) <= 11"
               actions:
                 - type: forward-internal
                   config:
@@ -167,7 +160,7 @@ expected:
               - type: custom-response
                 config:
                   status_code: 404
-                  content: "No route was found for this ngrok Cloud Endpoint"
+                  content: "No route was found for this ngrok Endpoint"
                   headers:
                     content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-invalid-backendrefs.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-invalid-backendrefs.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -127,7 +127,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-invalid-externalref-filters.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-invalid-externalref-filters.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -99,7 +99,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-invalid-listeners.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-invalid-listeners.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:

--- a/pkg/managerdriver/testdata/translator/gwapi-listener-port-and-protocol.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-listener-port-and-protocol.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -88,7 +88,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: http://test-hostname.ngrok.io:8080

--- a/pkg/managerdriver/testdata/translator/gwapi-matching-rules.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-matching-rules.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -108,7 +108,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-missing-filter-configs.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-missing-filter-configs.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -95,7 +95,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       infrastructure:
@@ -119,7 +119,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-redirects.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-redirects.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -160,7 +160,7 @@ expected:
               - type: custom-response
                 config:
                   status_code: 404
-                  content: "No route was found for this ngrok Cloud Endpoint"
+                  content: "No route was found for this ngrok Endpoint"
                   headers:
                     content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-request-headers.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-request-headers.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -138,7 +138,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-request-mirror-not-supported.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-request-mirror-not-supported.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -96,7 +96,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-response-headers.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-response-headers.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -110,7 +110,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
             on_http_response:

--- a/pkg/managerdriver/testdata/translator/gwapi-rewrites.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-rewrites.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -94,19 +94,17 @@ expected:
       trafficPolicy:
         policy:
           on_http_request:
-            - name: Log-Request-Data
+            - name: Capture-Original-Request-Data
               actions:
-              - type: log
+              - type: set-vars
                 config:
-                  metadata:
-                    "endpoint_id": "${endpoint.id}"
-                    "message": "Capturing original request data with logs before it is modified"
-                    "original_headers": "${req.headers.encodeJson()}"
-                    "original_path": "${req.url.path}"
-                    "original_query_params": "${req.url.query_params.encodeJson()}"
+                  vars:
+                    - "original_path": "${req.url.path}"
+                    - "original_headers": "${req.headers.encodeJson()}"
+                    - "original_query_params": "${req.url.query_params.encodeJson()}"
             - name: GatewayAPI-URL-Rewrite-Filter
               expressions:
-                - actions.ngrok.log.metadata['original_path'].startsWith('/rewrite-fullpath')
+                - vars.original_path.startsWith('/rewrite-fullpath')
               actions:
                 - type: url-rewrite
                   config:
@@ -114,7 +112,7 @@ expected:
                     to: "$1://$2$3/rewrite"
             - name: GatewayAPI-URL-Rewrite-Filter
               expressions:
-                - actions.ngrok.log.metadata['original_path'].startsWith('/rewrite-hostname')
+                - vars.original_path.startsWith('/rewrite-hostname')
               actions:
                 - type: url-rewrite
                   config:
@@ -122,7 +120,7 @@ expected:
                     to: "$1://rewrite-hostname.com$3$4$5"
             - name: GatewayAPI-URL-Rewrite-Filter
               expressions:
-                - actions.ngrok.log.metadata['original_path'].startsWith('/rewrite-prefix')
+                - vars.original_path.startsWith('/rewrite-prefix')
               actions:
                 - type: url-rewrite
                   config:
@@ -133,7 +131,7 @@ expected:
               - type: custom-response
                 config:
                   status_code: 404
-                  content: "No route was found for this ngrok Cloud Endpoint"
+                  content: "No route was found for this ngrok Endpoint"
                   headers:
                     content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-tls-passthrough-not-supported.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tls-passthrough-not-supported.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:

--- a/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-annotation.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-annotation.yaml
@@ -15,7 +15,7 @@ input:
       namespace: default
       annotations:
         k8s.ngrok.com/traffic-policy: response-404
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -118,7 +118,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-filter-tcp-error.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-filter-tcp-error.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -107,7 +107,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
@@ -14,7 +14,7 @@ input:
       name: test-gateway
       namespace: default
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       gatewayClassName: ngrok
       listeners:
@@ -133,7 +133,7 @@ expected:
                 - type: custom-response
                   config:
                     status_code: 404
-                    content: "No route was found for this ngrok Cloud Endpoint"
+                    content: "No route was found for this ngrok Endpoint"
                     headers:
                       content-type: text/plain
       url: https://test-hostname.ngrok.io

--- a/pkg/managerdriver/testdata/translator/ingress-app-protocols.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-app-protocols.yaml
@@ -1,4 +1,4 @@
-# Ingresses without the mapping-strategy annotation should create endpoints instead of edges
+# Ingresses with service that has app protocols
 input:
   ingressClasses:
   - apiVersion: networking.k8s.io/v1
@@ -18,6 +18,8 @@ input:
     metadata:
       name: test-ingress-1
       namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
     spec:
       ingressClassName: ngrok
       rules:
@@ -150,7 +152,7 @@ expected:
             - type: custom-response
               config:
                 status_code: 404
-                content: "No route was found for this ngrok Cloud Endpoint"
+                content: "No route was found for this ngrok Endpoint"
                 headers:
                   content-type: text/plain
   agentEndpoints:

--- a/pkg/managerdriver/testdata/translator/ingress-default-backend-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-default-backend-conflict.yaml
@@ -17,7 +17,7 @@ input:
     kind: Ingress
     metadata:
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
       name: test-ingress-1
       namespace: default
     spec:
@@ -42,7 +42,7 @@ input:
     kind: Ingress
     metadata:
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
       name: test-ingress-2
       namespace: default
     spec:
@@ -125,7 +125,7 @@ expected:
             - type: custom-response
               config:
                 status_code: 404
-                content: "No route was found for this ngrok Cloud Endpoint"
+                content: "No route was found for this ngrok Endpoint"
                 headers:
                   content-type: text/plain
   agentEndpoints:

--- a/pkg/managerdriver/testdata/translator/ingress-namespace-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-namespace-conflict.yaml
@@ -17,7 +17,7 @@ input:
     kind: Ingress
     metadata:
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
       name: test-ingress-1
       namespace: aaa
     spec:
@@ -37,7 +37,7 @@ input:
     kind: Ingress
     metadata:
       annotations:
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
       name: test-ingress-2
       namespace: zzz
     spec:
@@ -110,7 +110,7 @@ expected:
             - type: custom-response
               config:
                 status_code: 404
-                content: "No route was found for this ngrok Cloud Endpoint"
+                content: "No route was found for this ngrok Endpoint"
                 headers:
                   content-type: text/plain
   agentEndpoints:

--- a/pkg/managerdriver/testdata/translator/ingress-pooling-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-pooling-conflict.yaml
@@ -18,7 +18,7 @@ input:
     metadata:
       annotations:
         k8s.ngrok.com/pooling-enabled: "true"
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
       name: test-ingress-1
       namespace: default
     spec:
@@ -39,7 +39,7 @@ input:
     metadata:
       annotations:
         k8s.ngrok.com/pooling-enabled: "false"
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
       name: test-ingress-2
       namespace: default
     spec:
@@ -113,7 +113,7 @@ expected:
             - type: custom-response
               config:
                 status_code: 404
-                content: "No route was found for this ngrok Cloud Endpoint"
+                content: "No route was found for this ngrok Endpoint"
                 headers:
                   content-type: text/plain
   agentEndpoints:

--- a/pkg/managerdriver/testdata/translator/ingress-trafficpolicy-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-trafficpolicy-conflict.yaml
@@ -18,7 +18,7 @@ input:
     metadata:
       annotations:
         k8s.ngrok.com/traffic-policy: response-503
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
       name: test-ingress-1
       namespace: default
     spec:
@@ -39,7 +39,7 @@ input:
     metadata:
       annotations:
         k8s.ngrok.com/traffic-policy: response-404
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
       name: test-ingress-2
       namespace: default
     spec:
@@ -158,7 +158,7 @@ expected:
             - type: custom-response
               config:
                 status_code: 404
-                content: "No route was found for this ngrok Cloud Endpoint"
+                content: "No route was found for this ngrok Endpoint"
                 headers:
                   content-type: text/plain
   agentEndpoints:

--- a/pkg/managerdriver/testdata/translator/ingress-valid-collapse-default-backend.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid-collapse-default-backend.yaml
@@ -1,0 +1,124 @@
+# Ingresses without the mapping-strategy annotation should create endpoints instead of edges
+# The default mapping-strategy when not specified should collapse them into an AgentEndpoint, but the unique service is on the default backend
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ngrok-operator
+        app.kubernetes.io/name: ngrok-operator
+        app.kubernetes.io/part-of: ngrok-operator
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: test-ingress
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      defaultBackend:
+        service:
+          name: test-service-1
+          port:
+            number: 8080
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test
+                pathType: Prefix
+                backend:
+                  resource:
+                    name: response-503
+                    apiGroup: "ngrok.k8s.ngrok.com"
+                    kind: "NgrokTrafficPolicy"
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies: 
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: NgrokTrafficPolicy
+    metadata:
+      name: response-503
+      namespace: default
+    spec:
+      policy:
+        on_http_request:
+          - name: response-503
+            actions:
+              - type: custom-response
+                config:
+                  status_code: 503
+                  content: "Service is temporarily unavailable"
+                  headers:
+                    content-type: text/plain
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://test-ingresses.ngrok.io"
+      upstream:
+        url: "http://test-service-1.default:8080"
+      bindings:
+      - "public"
+      trafficPolicy:
+        inline:
+          on_http_request:
+          - name: Initialize-Local-Service-Match
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: false
+          - name: response-503
+            expressions:
+            - req.url.path.startsWith('/test')
+            - vars.request_matched_local_svc == false
+            actions:
+            - type: custom-response
+              config:
+                status_code: 503
+                content: "Service is temporarily unavailable"
+                headers:
+                  content-type: text/plain
+          - name: Generated-Route-Default-Backend
+            expressions:
+            - vars.request_matched_local_svc == false
+            actions:
+            - type: set-vars
+              config:
+                vars: 
+                - request_matched_local_svc: true
+          - name: Fallback-404
+            expressions:
+            - vars.request_matched_local_svc == false
+            actions:
+            - type: custom-response
+              config:
+                status_code: 404
+                content: "No route was found for this ngrok Endpoint"
+                headers:
+                  content-type: text/plain

--- a/pkg/managerdriver/testdata/translator/ingress-valid-collapse-simple.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid-collapse-simple.yaml
@@ -1,0 +1,94 @@
+# Ingresses without the mapping-strategy annotation should create endpoints instead of edges
+# The default mapping-strategy when not specified should collapse them into an AgentEndpoint.
+# This is the most simple case where there is a single hostname with a single upstream, nothing fancy.
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ngrok-operator
+        app.kubernetes.io/name: ngrok-operator
+        app.kubernetes.io/part-of: ngrok-operator
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: test-ingress
+      namespace: default
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: test-ingresses.ngrok.io
+          http:
+            paths:
+              - path: /test
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-1
+                    port:
+                      number: 8080
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies: 
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://test-ingresses.ngrok.io"
+      upstream:
+        url: "http://test-service-1.default:8080"
+      bindings:
+      - "public"
+      trafficPolicy:
+        inline:
+          on_http_request:
+          - name: Initialize-Local-Service-Match
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: false
+          - name: Generated-Local-Service-Route
+            expressions:
+            - req.url.path.startsWith('/test')
+            - vars.request_matched_local_svc == false
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: true
+          - name: Fallback-404
+            expressions:
+            - vars.request_matched_local_svc == false
+            actions:
+            - type: custom-response
+              config:
+                status_code: 404
+                content: "No route was found for this ngrok Endpoint"
+                headers:
+                  content-type: text/plain

--- a/pkg/managerdriver/testdata/translator/ingress-valid-default-to-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid-default-to-endpoints.yaml
@@ -1,4 +1,5 @@
 # Ingresses without the mapping-strategy annotation should create endpoints instead of edges
+# The default mapping-strategy when not specified should collapse them into an AgentEndpoint
 input:
   ingressClasses:
   - apiVersion: networking.k8s.io/v1
@@ -110,21 +111,24 @@ input:
 expected:
   # Generated cloud endpoint should have the first traffic policy, but the second ingress will not be processed due to the
   # traffic policy conflict
-  cloudEndpoints:
+  cloudEndpoints: []
+  agentEndpoints:
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
-    kind: CloudEndpoint
+    kind: AgentEndpoint
     metadata:
       labels:
         k8s.ngrok.com/controller-name: test-manager-name
         k8s.ngrok.com/controller-namespace: test-manager-namespace
-      name: test-ingresses.ngrok.io
+      name: e3b0c-test-service-1-default-8080
       namespace: default
     spec:
+      url: "https://test-ingresses.ngrok.io"
+      upstream:
+        url: "http://test-service-1.default:8080"
       bindings:
-      - public
-      url: https://test-ingresses.ngrok.io
+      - "public"
       trafficPolicy:
-        policy:
+        inline:
           on_http_request:
           - name: response-503
             expressions:
@@ -136,48 +140,47 @@ expected:
                   content: "Service is temporarily unavailable"
                   headers:
                     content-type: text/plain
-          - name: Generated-Route
+          - name: Initialize-Local-Service-Match
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: false
+          - name: Generated-Local-Service-Route
             expressions:
             - req.url.path.startsWith('/test-1')
+            - vars.request_matched_local_svc == false
             actions:
-            - type: forward-internal
+            - type: set-vars
               config:
-                url: https://e3b0c-test-service-1-default-8080.internal
+                vars:
+                - request_matched_local_svc: true
           - name: Generated-Route
             expressions:
             - req.url.path.startsWith('/test-2')
+            - vars.request_matched_local_svc == false
             actions:
             - type: forward-internal
               config:
                 url: https://e3b0c-test-service-2-default-8080.internal
           - name: Generated-Route-Default-Backend
+            expressions:
+            - vars.request_matched_local_svc == false
             actions:
-            - type: forward-internal
+            - type: set-vars
               config:
-                url: https://e3b0c-test-service-1-default-8080.internal
+                vars:
+                - request_matched_local_svc: true
           - name: Fallback-404
+            expressions:
+            - vars.request_matched_local_svc == false
             actions:
             - type: custom-response
               config:
                 status_code: 404
-                content: "No route was found for this ngrok Cloud Endpoint"
+                content: "No route was found for this ngrok Endpoint"
                 headers:
                   content-type: text/plain
-  agentEndpoints:
-  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
-    kind: AgentEndpoint
-    metadata:
-      labels:
-        k8s.ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
-      name: e3b0c-test-service-1-default-8080
-      namespace: default
-    spec:
-      url: "https://e3b0c-test-service-1-default-8080.internal"
-      upstream:
-        url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:

--- a/pkg/managerdriver/testdata/translator/ingress-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid.yaml
@@ -18,7 +18,7 @@ input:
     metadata:
       annotations:
         k8s.ngrok.com/traffic-policy: response-503
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
       name: test-ingress-1
       namespace: default
     spec:
@@ -44,7 +44,7 @@ input:
     metadata:
       annotations:
         k8s.ngrok.com/traffic-policy: response-503
-        k8s.ngrok.com/mapping-strategy: "endpoints"
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
       name: test-ingress-2
       namespace: default
     spec:
@@ -162,7 +162,7 @@ expected:
             - type: custom-response
               config:
                 status_code: 404
-                content: "No route was found for this ngrok Cloud Endpoint"
+                content: "No route was found for this ngrok Endpoint"
                 headers:
                   content-type: text/plain
   agentEndpoints:

--- a/pkg/managerdriver/translate_gatewayapi.go
+++ b/pkg/managerdriver/translate_gatewayapi.go
@@ -113,11 +113,11 @@ func (t *translator) HTTPRouteToIR(
 		// We currently require this annotation to be present for an Ingress to be translated into CloudEndpoints/AgentEndpoints, otherwise the default behaviour is to
 		// translate it into HTTPSEdges (legacy). A future version will remove support for HTTPSEdges and translation into CloudEndpoints/AgentEndpoints will become the new
 		// default behaviour.
-		useEdges, err := annotations.ExtractUseEdges(gateway)
+		mappingStrategy, err := MappingStrategyAnnotationToIR(gateway)
 		if err != nil {
 			t.log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using endpoints", annotations.MappingStrategyAnnotation))
 		}
-		if useEdges {
+		if mappingStrategy == ir.IRMappingStrategy_Edges {
 			t.log.Info(fmt.Sprintf("the Gateway and its HTTPRoutes will be provided by ngrok edges instead of endpoints because of the %q annotation",
 				annotations.MappingStrategyAnnotation),
 				"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
@@ -243,6 +243,7 @@ func (t *translator) HTTPRouteToIR(
 					Metadata:               t.defaultGatewayMetadata,
 					Bindings:               bindings,
 					ClientCertRefs:         upstreamClientCertRefs,
+					MappingStrategy:        mappingStrategy,
 				}
 			}
 			irVHost.AddOwningResource(ir.OwningResource{

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -805,11 +805,11 @@ func MappingStrategyAnnotationToIR(obj client.Object) (ir.IRMappingStrategy, err
 	}
 
 	switch val {
-	case string(ir.IRMappingStrategy_Edges):
+	case string(annotations.MappingStrategy_Edges):
 		return ir.IRMappingStrategy_Edges, nil
-	case string(ir.IRMappingStrategy_EndpointsDefault):
+	case string(annotations.MappingStrategy_EndpointsDefault), string(ir.IRMappingStrategy_EndpointsCollapsed):
 		return ir.IRMappingStrategy_EndpointsDefault, nil
-	case string(ir.IRMappingStrategy_EndpointsVerbose):
+	case string(annotations.MappingStrategy_EndpointsVerbose):
 		return ir.IRMappingStrategy_EndpointsVerbose, nil
 	}
 

--- a/pkg/managerdriver/translator_test.go
+++ b/pkg/managerdriver/translator_test.go
@@ -527,8 +527,8 @@ func TestTranslate(t *testing.T) {
 
 			// Finally, run translate and check the contents
 			result := translator.Translate()
-			assert.Equal(t, len(tc.Expected.CloudEndpoints), len(result.CloudEndpoints), "mismatch in actual vs expected number of cloud endpoints from translation")
-			assert.Equal(t, len(tc.Expected.AgentEndpoints), len(result.AgentEndpoints), "mismatch in actual vs expected number of agent endpoints from translation")
+			assert.Equal(t, len(tc.Expected.CloudEndpoints), len(result.CloudEndpoints), fmt.Sprintf("mismatch in actual vs expected number of cloud endpoints from translation, expected: %v, actual: %v", tc.Expected.CloudEndpoints, result.CloudEndpoints))
+			assert.Equal(t, len(tc.Expected.AgentEndpoints), len(result.AgentEndpoints), fmt.Sprintf("mismatch in actual vs expected number of agent endpoints from translation, expected: %v, actual: %v", tc.Expected.AgentEndpoints, result.AgentEndpoints))
 
 			for _, expectedCLEP := range tc.Expected.CloudEndpoints {
 				actualCLEP, exists := result.CloudEndpoints[types.NamespacedName{

--- a/pkg/managerdriver/translator_test.go
+++ b/pkg/managerdriver/translator_test.go
@@ -557,8 +557,6 @@ func TestTranslate(t *testing.T) {
 				assert.Equal(t, expectedCLEP.Spec.Bindings, actualCLEP.Spec.Bindings)
 			}
 
-			//assert.ElementsMatch(t, tc.Expected.AgentEndpoints, slices.Collect(maps.Values(result.AgentEndpoints)))
-
 			for _, expectedAE := range tc.Expected.AgentEndpoints {
 				actualAE, exists := result.AgentEndpoints[types.NamespacedName{
 					Name:      expectedAE.Name,

--- a/pkg/managerdriver/utils.go
+++ b/pkg/managerdriver/utils.go
@@ -83,8 +83,8 @@ func internalAgentEndpointName(serviceUID, serviceName, namespace, clusterDomain
 	return sanitizeStringForK8sName(ret)
 }
 
-// internalAgentEndpointURL builds a URL string for an internal endpoint
-func internalAgentEndpointURL(serviceUID, serviceName, namespace, clusterDomain string, port int32, clientCertRefs []ir.IRObjectRef) string {
+// buildInternalEndpointURL builds a URL string for an internal endpoint
+func buildInternalEndpointURL(serviceUID, serviceName, namespace, clusterDomain string, port int32, clientCertRefs []ir.IRObjectRef) string {
 	uidHash := sha256.Sum256([]byte(serviceUID))
 	hashHex := hex.EncodeToString(uidHash[:])
 
@@ -127,8 +127,8 @@ func internalAgentEndpointURL(serviceUID, serviceName, namespace, clusterDomain 
 	return ret
 }
 
-// internalAgentEndpointUpstreamURL builds a URL string for an internal AgentEndpoint's upstream url
-func internalAgentEndpointUpstreamURL(serviceName, namespace, clusterDomain string, port int32, scheme ir.IRScheme) string {
+// agentEndpointUpstreamURL builds a URL string for an AgentEndpoint's upstream url
+func agentEndpointUpstreamURL(serviceName, namespace, clusterDomain string, port int32, scheme ir.IRScheme) string {
 	ret := fmt.Sprintf("%s%s.%s",
 		string(scheme),
 		sanitizeStringForURL(serviceName),

--- a/pkg/managerdriver/utils_test.go
+++ b/pkg/managerdriver/utils_test.go
@@ -145,7 +145,7 @@ func TestSanitizeStringForURL(t *testing.T) {
 	}
 }
 
-func TestInternalAgentEndpointURL(t *testing.T) {
+func TestBuildInternalEndpointURL(t *testing.T) {
 	testCases := []struct {
 		name                   string
 		serviceName            string
@@ -210,7 +210,7 @@ func TestInternalAgentEndpointURL(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			result := internalAgentEndpointURL(tc.serviceUID, tc.serviceName, tc.namespace, tc.clusterDomain, tc.port, tc.upstreamClientCertRefs)
+			result := buildInternalEndpointURL(tc.serviceUID, tc.serviceName, tc.namespace, tc.clusterDomain, tc.port, tc.upstreamClientCertRefs)
 			if result != tc.expectedResult {
 				t.Errorf("expected %s, got %s", tc.expectedResult, result)
 			}


### PR DESCRIPTION
This PR adds support for the new mapping strategy which attempts to save users money when translating Ingress and Gateway API resources into endpoints.

The current mapping strategy always creates a `CloudEndpoint` that listens on the provided hostname (or multiple `CloudEndpoint` resources for multiple hostnames) and an internal `AgentEndpoint` resource for each unique upstream. It would then configure traffic policy actions within the `CloudEndpoint` to route to the internal `AgentEndpoint`. This works fine but since you are billed per-endpoint, it doesn't make much sense cost-wise why we would do this if you have a hostname that only routes to a single upstream. In cases like that, we could instead collapse everything into a single `AgentEndpoint` resource, saving you the cost of the additional endpoint.

The old mapping strategy still works and is available when using the `k8s.ngrok.com/mapping-strategy: "endpoints-verbose"` annotation. There are no plans to remove it.

I will outline this in documentation updates, but depending on the scale at which you run the ngrok-operator-agent pods, one mapping strategy or the other becomes more cost effective. 

When running the operator-agent deployment at a replica count higher than 1, each `AgentEndpoint` resource results in n ngrok agent endpoint resources in the API (where n = the number of operator-agent pods). This is necessary to support balancing between the pods. You would typically do this if you want high availability on the agent endpoints created by the operator, but as you increase the replicacount, the cost of the `AgentEndpoint` resources increases, whereas the `CloudEndpoint` resources have a static cost since they are handled entirely within the ngrok cloud. With the default installation, this new mapping strategy should help save users money, but if you do decide to increase the replica count on the operator-agent deployment, the old mapping strategy actually becomes the more cost effective one because it prioritizes `CloudEndpoint` resources and efficiently re-uses `AgentEndpoint` resources, limiting the total number of them. 


TL;DR: With the default install, this change makes the default translation from Ingress/Gateway API more cost effective. If you want to run the operator-agent pods at a higher replica count, you can still manually specify the old translation strategy which prefers `CloudEndpoint` resources. The old strategy is more cost effective for those users, but most people probably leave the defaults alone which is why the default mapping strategy is changing.

While you might notice a change in how your Ingress/Gateway API resources are represented by ngrok infrastructure with these changes, there should be no noticeable change in behaviour.


Note for reviewers: I split the commits apart to offer more detailed commit messages that explain why changes were made to each set of testdata files. 