### PR TITLE
unconditionally create operator with ngrok api

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -282,11 +282,9 @@ func runNormalMode(ctx context.Context, opts managerOpts, k8sClient client.Clien
 		return fmt.Errorf("Unable to load ngrokClientSet: %w", err)
 	}
 
-	if opts.enableFeatureBindings {
-		// register the k8sop in the ngrok API
-		if err := createKubernetesOperator(ctx, k8sClient, opts); err != nil {
-			return fmt.Errorf("unable to create KubernetesOperator: %w", err)
-		}
+	// register the k8sop in the ngrok API
+	if err := createKubernetesOperator(ctx, k8sClient, opts); err != nil {
+		return fmt.Errorf("unable to create KubernetesOperator: %w", err)
 	}
 
 	// k8sResourceDriver is the driver that will be used to interact with the k8s resources for all controllers


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
While we were ironing out bindings and the operator api we only created an ngrok operator w/ the ngrok api if bindings was enabled.

Now that the api has settled significantly and we've worked through the most common failure cases when creating the operator, let's always create the operator in the API.

## How
Remove the guard around creating the operator.

## Breaking Changes
Shouldn't be any!
