### PR TITLE
fix: Empty TLS cert on creation when bindings are enabled

### DIFF
--- a/internal/controller/ngrok/kubernetesoperator_controller.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller.go
@@ -150,7 +150,7 @@ func (r *KubernetesOperatorReconciler) create(ctx context.Context, ko *ngrokv1al
 	var tlsSecret *v1.Secret
 
 	if bindingsEnabled {
-		tlsSecret, err := r.findOrCreateTLSSecret(ctx, ko)
+		tlsSecret, err = r.findOrCreateTLSSecret(ctx, ko)
 		if err != nil {
 			return ngrokapi.NewNgrokError(err, ngrokapi.NgrokOpErrFailedToCreateCSR, "failed to create TLS secret for CSR")
 		}

--- a/tests/chainsaw/operator-registration/chainsaw-test.yaml
+++ b/tests/chainsaw/operator-registration/chainsaw-test.yaml
@@ -39,9 +39,9 @@ spec:
             namespace: ngrok-operator
           type: kubernetes.io/tls
           data:
-            ("tls.crt" != null): true
-            ("tls.csr" != null): true
-            ("tls.key" != null): true
+            ("tls.crt" != null && "tls.crt" != ""): true
+            ("tls.csr" != null && "tls.csr" != ""): true
+            ("tls.key" != null && "tls.key" != ""): true
 
   - name: assert Configmap/ngrok-intermediate-ca exists (tunnels/forwarders will work)
     try:


### PR DESCRIPTION
## What

Fixes an empty TLS cert on operator creation. The `:=` assignment was shadowing and creating a new `tlsSecret` variable scoped to the if statement.

## How
* Unshadow it to fix
* Modify the test to make sure that its not empty.

## Breaking Changes
No
