### PR TITLE
fix: traffic-policy annotation not working when using mapping-strategy of edges

### DIFF
--- a/api/ingress/v1alpha1/ngrokmoduleset_types.go
+++ b/api/ingress/v1alpha1/ngrokmoduleset_types.go
@@ -64,8 +64,27 @@ type NgrokModuleSet struct {
 	Modules NgrokModuleSetModules `json:"modules,omitempty"`
 }
 
+func (ms *NgrokModuleSet) IsEmpty() bool {
+	if ms == nil {
+		return true
+	}
+
+	modules := ms.Modules
+	return modules.CircuitBreaker == nil &&
+		modules.Compression == nil &&
+		modules.Headers == nil &&
+		modules.IPRestriction == nil &&
+		modules.OAuth == nil &&
+		modules.Policy == nil &&
+		modules.OIDC == nil &&
+		modules.SAML == nil &&
+		modules.TLSTermination == nil &&
+		modules.MutualTLS == nil &&
+		modules.WebhookVerification == nil
+}
+
 func (ms *NgrokModuleSet) Merge(o *NgrokModuleSet) {
-	if o == nil {
+	if o.IsEmpty() { // Empty, nothing to merge
 		return
 	}
 

--- a/api/ingress/v1alpha1/ngrokmoduleset_types_test.go
+++ b/api/ingress/v1alpha1/ngrokmoduleset_types_test.go
@@ -1,0 +1,116 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNgrokModuleSetIsEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		ms   *NgrokModuleSet
+		want bool
+	}{
+		{
+			name: "nil",
+			ms:   nil,
+			want: true,
+		},
+		{
+			name: "empty",
+			ms:   &NgrokModuleSet{},
+			want: true,
+		},
+		{
+			name: "non-empty",
+			ms: &NgrokModuleSet{
+				Modules: NgrokModuleSetModules{
+					Headers: &EndpointHeaders{
+						Request: &EndpointRequestHeaders{
+							Add: map[string]string{
+								"key": "value",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ms.IsEmpty(); got != tt.want {
+				t.Errorf("NgrokModuleSet.IsEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNgrokModuleSetMerge(t *testing.T) {
+	addHeaders := &EndpointHeaders{
+		Request: &EndpointRequestHeaders{
+			Add: map[string]string{
+				"key": "value",
+			},
+		},
+	}
+	compression := &EndpointCompression{
+		Enabled: true,
+	}
+
+	tests := []struct {
+		name  string
+		m     *NgrokModuleSet
+		other *NgrokModuleSet
+		want  *NgrokModuleSet
+	}{
+		{
+			name:  "both_nil",
+			m:     nil,
+			other: nil,
+			want:  nil,
+		},
+		{
+			name: "b_nil",
+			m: &NgrokModuleSet{
+				Modules: NgrokModuleSetModules{
+					Headers: addHeaders,
+				},
+			},
+			other: nil,
+			want: &NgrokModuleSet{
+				Modules: NgrokModuleSetModules{
+					Headers: addHeaders,
+				},
+			},
+		},
+		{
+			name: "neither_nil",
+			m: &NgrokModuleSet{
+				Modules: NgrokModuleSetModules{
+					Compression: compression,
+				},
+			},
+			other: &NgrokModuleSet{
+				Modules: NgrokModuleSetModules{
+					Headers: addHeaders,
+				},
+			},
+			want: &NgrokModuleSet{
+				Modules: NgrokModuleSetModules{
+					Headers:     addHeaders,
+					Compression: compression,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.m.Merge(tt.other)
+
+			assert.Equal(t, tt.m, tt.want)
+		})
+	}
+}

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
           yq
           kyverno-chainsaw
         ];
+        CGO_ENABLED = "0";
       };
     }));
 }

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -43,3 +43,20 @@ func RemoveAndSyncFinalizer(ctx context.Context, c client.Writer, o client.Objec
 	RemoveFinalizer(o)
 	return c.Update(ctx, o)
 }
+
+func AddAnnotations(o client.Object, annotations map[string]string) {
+	if o == nil || annotations == nil {
+		return
+	}
+
+	existing := o.GetAnnotations()
+	if existing == nil {
+		existing = make(map[string]string)
+	}
+
+	for k, v := range annotations {
+		existing[k] = v
+	}
+
+	o.SetAnnotations(existing)
+}

--- a/pkg/managerdriver/driver.go
+++ b/pkg/managerdriver/driver.go
@@ -606,7 +606,7 @@ func (d *Driver) getTrafficPolicyJSON(ingress *netv1.Ingress, modSet *ingressv1a
 		return nil, err
 	}
 
-	if modSet == nil {
+	if modSet.IsEmpty() {
 		if trafficPolicy != nil {
 			return trafficPolicy.Spec.Policy, nil
 		}

--- a/pkg/managerdriver/translate_ingresses.go
+++ b/pkg/managerdriver/translate_ingresses.go
@@ -409,22 +409,13 @@ func trafficPolicyFromModSetAnnotation(log logr.Logger, store store.Storer, obj 
 	}
 
 	// We always get back a moduleset from the above function, check if it is empty or not
-	if modules := ingressModuleSet.Modules; modules.CircuitBreaker != nil ||
-		modules.Compression != nil ||
-		modules.Headers != nil ||
-		modules.IPRestriction != nil ||
-		modules.OAuth != nil ||
-		modules.Policy != nil ||
-		modules.OIDC != nil ||
-		modules.SAML != nil ||
-		modules.TLSTermination != nil ||
-		modules.MutualTLS != nil ||
-		modules.WebhookVerification != nil {
+	if ingressModuleSet.IsEmpty() {
 		if useEndpoints {
 			log.Error(fmt.Errorf("ngrok moduleset supplied to %s with annotation to use endpoints instead of edges", obj.GetObjectKind().GroupVersionKind().Kind), "ngrok moduleset are not supported on endpoints. prefer using a traffic policy directly. any fields other than supplying a traffic policy using the module set will be ignored",
 				"ingress", fmt.Sprintf("%s.%s", obj.GetName(), obj.GetNamespace()),
 			)
 		}
+		return nil, nil, nil
 	}
 
 	if ingressModuleSet.Modules.Policy == nil {


### PR DESCRIPTION
## What

When using the `edges` mapping-strategy, the `traffic-policy` annotation on ingresses was not getting correctly copied over to the edge routes.

## How

* Added a test to exercise the bug
* Slight refactor to fix the bug

## Breaking Changes
No
