### PR TITLE
add support for TCPRoute & TLSRoute

### DIFF
--- a/helm/ngrok-operator/templates/rbac/role.yaml
+++ b/helm/ngrok-operator/templates/rbac/role.yaml
@@ -167,6 +167,42 @@ rules:
   - list
   - watch
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tcproutes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tcproutes/status
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes/status
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - ingress.k8s.ngrok.com
   resources:
   - domains

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -4,7 +4,7 @@ Should match all-options snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/controller-role: bf32d6fa0abada9bb5046ee53c7c6ee7f6e79694115d2377dff6c002c0f6f06e
+        checksum/controller-role: 7a9dd902b42a29f69ffbd6c3b6dddda72b68e4f0ee3af37b60dc4dfd103d4ac4
         checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
       labels:
         app.kubernetes.io/component: controller
@@ -26,7 +26,7 @@ Should match all-options snapshot:
       template:
         metadata:
           annotations:
-            checksum/controller-role: bf32d6fa0abada9bb5046ee53c7c6ee7f6e79694115d2377dff6c002c0f6f06e
+            checksum/controller-role: 7a9dd902b42a29f69ffbd6c3b6dddda72b68e4f0ee3af37b60dc4dfd103d4ac4
             checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
             prometheus.io/path: /metrics
@@ -379,6 +379,42 @@ Should match all-options snapshot:
           - list
           - watch
       - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - tcproutes
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - tcproutes/status
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - tlsroutes
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - tlsroutes/status
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
           - ingress.k8s.ngrok.com
         resources:
           - domains
@@ -678,7 +714,7 @@ Should match default snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/controller-role: bf32d6fa0abada9bb5046ee53c7c6ee7f6e79694115d2377dff6c002c0f6f06e
+        checksum/controller-role: 7a9dd902b42a29f69ffbd6c3b6dddda72b68e4f0ee3af37b60dc4dfd103d4ac4
         checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
       labels:
         app.kubernetes.io/component: controller
@@ -700,7 +736,7 @@ Should match default snapshot:
       template:
         metadata:
           annotations:
-            checksum/controller-role: bf32d6fa0abada9bb5046ee53c7c6ee7f6e79694115d2377dff6c002c0f6f06e
+            checksum/controller-role: 7a9dd902b42a29f69ffbd6c3b6dddda72b68e4f0ee3af37b60dc4dfd103d4ac4
             checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
             prometheus.io/path: /metrics
@@ -1038,6 +1074,42 @@ Should match default snapshot:
         verbs:
           - get
           - list
+          - watch
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - tcproutes
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - tcproutes/status
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - tlsroutes
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - tlsroutes/status
+        verbs:
+          - get
+          - list
+          - update
           - watch
       - apiGroups:
           - ingress.k8s.ngrok.com

--- a/internal/controller/gateway/suite_test.go
+++ b/internal/controller/gateway/suite_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -84,6 +85,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	err = gatewayv1.Install(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+	err = gatewayv1alpha2.Install(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme
 
@@ -105,6 +108,20 @@ var _ = BeforeSuite(func() {
 		Client:   k8sManager.GetClient(),
 		Log:      logf.Log.WithName("controllers").WithName("GatewayClass"),
 		Recorder: k8sManager.GetEventRecorderFor("gatewayclass-controller"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&TCPRouteReconciler{
+		Client:   k8sManager.GetClient(),
+		Log:      logf.Log.WithName("controllers").WithName("TCPRoute"),
+		Recorder: k8sManager.GetEventRecorderFor("tcproute-controller"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&TLSRouteReconciler{
+		Client:   k8sManager.GetClient(),
+		Log:      logf.Log.WithName("controllers").WithName("TLSRoute"),
+		Recorder: k8sManager.GetEventRecorderFor("tlsroute-controller"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/gateway/tcproute_controller.go
+++ b/internal/controller/gateway/tcproute_controller.go
@@ -1,0 +1,117 @@
+/*
+MIT License
+
+Copyright (c) 2022 ngrok, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package gateway
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/go-logr/logr"
+	"github.com/ngrok/ngrok-operator/internal/controller"
+	"github.com/ngrok/ngrok-operator/pkg/managerdriver"
+)
+
+// TCPRouteReconciler reconciles a TCPRoute object
+type TCPRouteReconciler struct {
+	client.Client
+
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	Driver   *managerdriver.Driver
+}
+
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=tcproutes,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=tcproutes/status,verbs=get;list;watch;update
+
+func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx).WithValues("TCPRoute", req.NamespacedName)
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	tcpRoute := new(gatewayv1alpha2.TCPRoute)
+	err := r.Client.Get(ctx, req.NamespacedName, tcpRoute)
+	switch {
+	case err == nil:
+		// all good, continue
+	case client.IgnoreNotFound(err) == nil:
+		if err := r.Driver.DeleteNamedTCPRoute(req.NamespacedName); err != nil {
+			log.Error(err, "failed to delete TCPRoute from store")
+			return ctrl.Result{}, err
+		}
+
+		err = r.Driver.Sync(ctx, r.Client)
+		if err != nil {
+			log.Error(err, "failed to sync after removing TCPRoute from store")
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, nil
+	default:
+		return ctrl.Result{}, err
+	}
+
+	tcpRoute, err = r.Driver.UpdateTCPRoute(tcpRoute)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if controller.IsUpsert(tcpRoute) {
+		// The object is not being deleted, so register and sync finalizer
+		if err := controller.RegisterAndSyncFinalizer(ctx, r.Client, tcpRoute); err != nil {
+			log.Error(err, "Failed to register finalizer")
+			return ctrl.Result{}, err
+		}
+	} else {
+		log.Info("deleting TCPRoute from store")
+		if controller.HasFinalizer(tcpRoute) {
+			if err := controller.RemoveAndSyncFinalizer(ctx, r.Client, tcpRoute); err != nil {
+				log.Error(err, "Failed to remove finalizer")
+				return ctrl.Result{}, err
+			}
+		}
+
+		// Remove it from the store
+		if err := r.Driver.DeleteTCPRoute(tcpRoute); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	if err := r.Driver.Sync(ctx, r.Client); err != nil {
+		log.Error(err, "failed to sync after reconciling TCPRoutes")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&gatewayv1alpha2.TCPRoute{}).Complete(r)
+}

--- a/internal/controller/gateway/tcproute_controller_test.go
+++ b/internal/controller/gateway/tcproute_controller_test.go
@@ -26,6 +26,7 @@ package gateway
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -71,6 +72,18 @@ var _ = Describe("TCPRoute controller", func() {
 
 	AfterEach(func() {
 		ctx := context.Background()
+		hasTCPRoute := false
+		tcpRoutes := driver.GetStore().ListTCPRoutes()
+		for _, tcpRoute := range tcpRoutes {
+			if tcpRoute.Name == "test-tcproute" {
+				hasTCPRoute = true
+			}
+		}
+		Expect(len(tcpRoutes)).To(Equal(1))
+		Expect(hasTCPRoute).To(Equal(true))
 		Expect(k8sClient.Delete(ctx, testTCProute)).To(Succeed())
+		time.Sleep(time.Second * 3)
+		tcpRoutes = driver.GetStore().ListTCPRoutes()
+		Expect(len(tcpRoutes)).To(Equal(0))
 	})
 })

--- a/internal/controller/gateway/tcproute_controller_test.go
+++ b/internal/controller/gateway/tcproute_controller_test.go
@@ -1,0 +1,76 @@
+/*
+MIT License
+
+Copyright (c) 2025 ngrok, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package gateway
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+var _ = Describe("TCPRoute controller", func() {
+	const (
+		TCPRouteName = "test-tcproute"
+	)
+
+	var (
+		testTCProute *gatewayv1alpha2.TCPRoute
+	)
+
+	BeforeEach(func() {
+		ctx := context.Background()
+		testTCProute = &gatewayv1alpha2.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: TCPRouteName,
+			},
+			Spec: gatewayv1alpha2.TCPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{
+						Kind: ptr.To(gatewayv1.Kind("gateway")),
+						Name: gatewayv1.ObjectName("example-gw"),
+					}},
+				},
+				Rules: []gatewayv1alpha2.TCPRouteRule{{
+					BackendRefs: []gatewayv1alpha2.BackendRef{{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("example-svc"),
+						},
+					}},
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, testTCProute)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		ctx := context.Background()
+		Expect(k8sClient.Delete(ctx, testTCProute)).To(Succeed())
+	})
+})

--- a/internal/controller/gateway/testdata/gatewayapi-crds.yaml
+++ b/internal/controller/gateway/testdata/gatewayapi-crds.yaml
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 #
-# Gateway API Standard channel install
+# Gateway API Experimental channel install
 #
 ---
 #
-# config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+# config/crd/experimental/gateway.networking.k8s.io_backendlbpolicies.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -25,7 +25,1137 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.2.0
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendlbpolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendLBPolicy
+    listKind: BackendLBPolicyList
+    plural: backendlbpolicies
+    shortNames:
+    - blbpolicy
+    singular: backendlbpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackendLBPolicy provides a way to define load balancing rules
+          for a backend.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendLBPolicy.
+            properties:
+              sessionPersistence:
+                description: |-
+                  SessionPersistence defines and configures session persistence
+                  for the backend.
+
+                  Support: Extended
+                properties:
+                  absoluteTimeout:
+                    description: |-
+                      AbsoluteTimeout defines the absolute timeout of the persistent
+                      session. Once the AbsoluteTimeout duration has elapsed, the
+                      session becomes invalid.
+
+                      Support: Extended
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
+                  cookieConfig:
+                    description: |-
+                      CookieConfig provides configuration settings that are specific
+                      to cookie-based session persistence.
+
+                      Support: Core
+                    properties:
+                      lifetimeType:
+                        default: Session
+                        description: |-
+                          LifetimeType specifies whether the cookie has a permanent or
+                          session-based lifetime. A permanent cookie persists until its
+                          specified expiry time, defined by the Expires or Max-Age cookie
+                          attributes, while a session cookie is deleted when the current
+                          session ends.
+
+                          When set to "Permanent", AbsoluteTimeout indicates the
+                          cookie's lifetime via the Expires or Max-Age cookie attributes
+                          and is required.
+
+                          When set to "Session", AbsoluteTimeout indicates the
+                          absolute lifetime of the cookie tracked by the gateway and
+                          is optional.
+
+                          Support: Core for "Session" type
+
+                          Support: Extended for "Permanent" type
+                        enum:
+                        - Permanent
+                        - Session
+                        type: string
+                    type: object
+                  idleTimeout:
+                    description: |-
+                      IdleTimeout defines the idle timeout of the persistent session.
+                      Once the session has been idle for more than the specified
+                      IdleTimeout duration, the session becomes invalid.
+
+                      Support: Extended
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
+                  sessionName:
+                    description: |-
+                      SessionName defines the name of the persistent session token
+                      which may be reflected in the cookie or the header. Users
+                      should avoid reusing session names to prevent unintended
+                      consequences, such as rejection or unpredictable behavior.
+
+                      Support: Implementation-specific
+                    maxLength: 128
+                    type: string
+                  type:
+                    default: Cookie
+                    description: |-
+                      Type defines the type of session persistence such as through
+                      the use a header or cookie. Defaults to cookie based session
+                      persistence.
+
+                      Support: Core for "Cookie" type
+
+                      Support: Extended for "Header" type
+                    enum:
+                    - Cookie
+                    - Header
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                    is Permanent
+                  rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                    || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+              targetRefs:
+                description: |-
+                  TargetRef identifies an API object to apply policy to.
+                  Currently, Backends (i.e. Service, ServiceImport, or any
+                  implementation-specific backendRef) are the only valid API
+                  target references.
+                items:
+                  description: |-
+                    LocalPolicyTargetReference identifies an API object to apply a direct or
+                    inherited policy to. This should be used as part of Policy resources
+                    that can target Gateway API resources. For more information on how this
+                    policy attachment model works, and a sample Policy resource, refer to
+                    the policy attachment documentation for Gateway API.
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - kind
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - targetRefs
+            type: object
+          status:
+            description: Status defines the current state of BackendLBPolicy.
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendtlspolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendTLSPolicy
+    listKind: BackendTLSPolicyList
+    plural: backendtlspolicies
+    shortNames:
+    - btlspolicy
+    singular: backendtlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackendTLSPolicy provides a way to configure how a Gateway
+          connects to a Backend via TLS.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              options:
+                additionalProperties:
+                  description: |-
+                    AnnotationValue is the value of an annotation in Gateway API. This is used
+                    for validation of maps such as TLS options. This roughly matches Kubernetes
+                    annotation validation, although the length validation in that case is based
+                    on the entire size of the annotations struct.
+                  maxLength: 4096
+                  minLength: 0
+                  type: string
+                description: |-
+                  Options are a list of key/value pairs to enable extended TLS
+                  configuration for each implementation. For example, configuring the
+                  minimum TLS version or supported cipher suites.
+
+                  A set of common keys MAY be defined by the API in the future. To avoid
+                  any ambiguity, implementation-specific definitions MUST use
+                  domain-prefixed names, such as `example.com/my-custom-option`.
+                  Un-prefixed names are reserved for key names defined by Gateway API.
+
+                  Support: Implementation-specific
+                maxProperties: 16
+                type: object
+              targetRefs:
+                description: |-
+                  TargetRefs identifies an API object to apply the policy to.
+                  Only Services have Extended support. Implementations MAY support
+                  additional objects, with Implementation Specific support.
+                  Note that this config applies to the entire referenced resource
+                  by default, but this default may change in the future to provide
+                  a more granular application of the policy.
+
+                  Support: Extended for Kubernetes Service
+
+                  Support: Implementation-specific for any other resource
+                items:
+                  description: |-
+                    LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                    direct policy to. This should be used as part of Policy resources that can
+                    target single resources. For more information on how this policy attachment
+                    mode works, and a sample Policy resource, refer to the policy attachment
+                    documentation for Gateway API.
+
+                    Note: This should only be used for direct policy attachment when references
+                    to SectionName are actually needed. In all other cases,
+                    LocalPolicyTargetReference should be used.
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. When
+                        unspecified, this targetRef targets the entire resource. In the following
+                        resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name
+                        * HTTPRoute: HTTPRouteRule name
+                        * Service: Port name
+
+                        If a SectionName is specified, but does not exist on the targeted object,
+                        the Policy must fail to attach, and the policy implementation should record
+                        a `ResolvedRefs` or similar Condition in the Policy's status.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              validation:
+                description: Validation contains backend TLS validation configuration.
+                properties:
+                  caCertificateRefs:
+                    description: |-
+                      CACertificateRefs contains one or more references to Kubernetes objects that
+                      contain a PEM-encoded TLS CA certificate bundle, which is used to
+                      validate a TLS handshake between the Gateway and backend Pod.
+
+                      If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
+                      specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
+                      not both. If CACertifcateRefs is empty or unspecified, the configuration for
+                      WellKnownCACertificates MUST be honored instead if supported by the implementation.
+
+                      References to a resource in a different namespace are invalid for the
+                      moment, although we will revisit this in the future.
+
+                      A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
+                      Implementations MAY choose to support attaching multiple certificates to
+                      a backend, but this behavior is implementation-specific.
+
+                      Support: Core - An optional single reference to a Kubernetes ConfigMap,
+                      with the CA certificate in a key named `ca.crt`.
+
+                      Support: Implementation-specific (More than one reference, or other kinds
+                      of resources).
+                    items:
+                      description: |-
+                        LocalObjectReference identifies an API object within the namespace of the
+                        referrer.
+                        The API object must be valid in the cluster; the Group and Kind must
+                        be registered in the cluster for this reference to be valid.
+
+                        References to objects with invalid Group and Kind are not valid, and must
+                        be rejected by the implementation, with appropriate Conditions set
+                        on the containing object.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                  hostname:
+                    description: |-
+                      Hostname is used for two purposes in the connection between Gateways and
+                      backends:
+
+                      1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
+                      2. If SubjectAltNames is not specified, Hostname MUST be used for
+                         authentication and MUST match the certificate served by the matching
+                         backend.
+
+                      Support: Core
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  subjectAltNames:
+                    description: |-
+                      SubjectAltNames contains one or more Subject Alternative Names.
+                      When specified, the certificate served from the backend MUST have at least one
+                      Subject Alternate Name matching one of the specified SubjectAltNames.
+
+                      Support: Core
+                    items:
+                      description: SubjectAltName represents Subject Alternative Name.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname contains Subject Alternative Name specified in DNS name format.
+                            Required when Type is set to Hostname, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type:
+                          description: |-
+                            Type determines the format of the Subject Alternative Name. Always required.
+
+                            Support: Core
+                          enum:
+                          - Hostname
+                          - URI
+                          type: string
+                        uri:
+                          description: |-
+                            URI contains Subject Alternative Name specified in a full URI format.
+                            It MUST include both a scheme (e.g., "http" or "ftp") and a scheme-specific-part.
+                            Common values include SPIFFE IDs like "spiffe://mycluster.example.com/ns/myns/sa/svc1sa".
+                            Required when Type is set to URI, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: SubjectAltName element must contain Hostname, if
+                          Type is set to Hostname
+                        rule: '!(self.type == "Hostname" && (!has(self.hostname) ||
+                          self.hostname == ""))'
+                      - message: SubjectAltName element must not contain Hostname,
+                          if Type is not set to Hostname
+                        rule: '!(self.type != "Hostname" && has(self.hostname) &&
+                          self.hostname != "")'
+                      - message: SubjectAltName element must contain URI, if Type
+                          is set to URI
+                        rule: '!(self.type == "URI" && (!has(self.uri) || self.uri
+                          == ""))'
+                      - message: SubjectAltName element must not contain URI, if Type
+                          is not set to URI
+                        rule: '!(self.type != "URI" && has(self.uri) && self.uri !=
+                          "")'
+                    maxItems: 5
+                    type: array
+                  wellKnownCACertificates:
+                    description: |-
+                      WellKnownCACertificates specifies whether system CA certificates may be used in
+                      the TLS handshake between the gateway and backend pod.
+
+                      If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
+                      must be specified with at least one entry for a valid configuration. Only one of
+                      CACertificateRefs or WellKnownCACertificates may be specified, not both. If an
+                      implementation does not support the WellKnownCACertificates field or the value
+                      supplied is not supported, the Status Conditions on the Policy MUST be
+                      updated to include an Accepted: False Condition with Reason: Invalid.
+
+                      Support: Implementation-specific
+                    enum:
+                    - System
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                  rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")'
+                - message: must specify either CACertificateRefs or WellKnownCACertificates
+                  rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")
+            required:
+            - targetRefs
+            - validation
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.0
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
@@ -258,6 +1388,25 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              supportedFeatures:
+                description: |
+                  SupportedFeatures is the set of features the GatewayClass support.
+                  It MUST be sorted in ascending alphabetical order by the Name key.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        FeatureName is used to describe distinct features that are covered by
+                        conformance tests.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         required:
         - spec
@@ -483,6 +1632,25 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              supportedFeatures:
+                description: |
+                  SupportedFeatures is the set of features the GatewayClass support.
+                  It MUST be sorted in ascending alphabetical order by the Name key.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        FeatureName is used to describe distinct features that are covered by
+                        conformance tests.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         required:
         - spec
@@ -499,7 +1667,7 @@ status:
   storedVersions: null
 ---
 #
-# config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+# config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -507,7 +1675,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.2.0
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
 spec:
@@ -637,6 +1805,72 @@ spec:
                 - message: Hostname values must be unique
                   rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
                     a2.type == a1.type && a2.value == a1.value) : true )'
+              backendTLS:
+                description: |+
+                  BackendTLS configures TLS settings for when this Gateway is connecting to
+                  backends with TLS.
+
+                  Support: Core
+
+                properties:
+                  clientCertificateRef:
+                    description: |+
+                      ClientCertificateRef is a reference to an object that contains a Client
+                      Certificate and the associated private key.
+
+                      References to a resource in different namespace are invalid UNLESS there
+                      is a ReferenceGrant in the target namespace that allows the certificate
+                      to be attached. If a ReferenceGrant does not allow this reference, the
+                      "ResolvedRefs" condition MUST be set to False for this listener with the
+                      "RefNotPermitted" reason.
+
+                      ClientCertificateRef can reference to standard Kubernetes resources, i.e.
+                      Secret, or implementation-specific custom resources.
+
+                      This setting can be overridden on the service level by use of BackendTLSPolicy.
+
+                      Support: Core
+
+                    properties:
+                      group:
+                        default: ""
+                        description: |-
+                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                          When unspecified or empty string, core API group is inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Secret
+                        description: Kind is kind of the referent. For example "Secret".
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referenced object. When unspecified, the local
+                          namespace is inferred.
+
+                          Note that when a namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
               gatewayClassName:
                 description: |-
                   GatewayClassName used for this Gateway. This is the name of a
@@ -1176,6 +2410,94 @@ spec:
                             type: object
                           maxItems: 64
                           type: array
+                        frontendValidation:
+                          description: |+
+                            FrontendValidation holds configuration information for validating the frontend (client).
+                            Setting this field will require clients to send a client certificate
+                            required for validation during the TLS handshake. In browsers this may result in a dialog appearing
+                            that requests a user to specify the client certificate.
+                            The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                            Support: Extended
+
+                          properties:
+                            caCertificateRefs:
+                              description: |-
+                                CACertificateRefs contains one or more references to
+                                Kubernetes objects that contain TLS certificates of
+                                the Certificate Authorities that can be used
+                                as a trust anchor to validate the certificates presented by the client.
+
+                                A single CA certificate reference to a Kubernetes ConfigMap
+                                has "Core" support.
+                                Implementations MAY choose to support attaching multiple CA certificates to
+                                a Listener, but this behavior is implementation-specific.
+
+                                Support: Core - A single reference to a Kubernetes ConfigMap
+                                with the CA certificate in a key named `ca.crt`.
+
+                                Support: Implementation-specific (More than one reference, or other kinds
+                                of resources).
+
+                                References to a resource in a different namespace are invalid UNLESS there
+                                is a ReferenceGrant in the target namespace that allows the certificate
+                                to be attached. If a ReferenceGrant does not allow this reference, the
+                                "ResolvedRefs" condition MUST be set to False for this listener with the
+                                "RefNotPermitted" reason.
+                              items:
+                                description: |-
+                                  ObjectReference identifies an API object including its namespace.
+
+                                  The API object must be valid in the cluster; the Group and Kind must
+                                  be registered in the cluster for this reference to be valid.
+
+                                  References to objects with invalid Group and Kind are not valid, and must
+                                  be rejected by the implementation, with appropriate Conditions set
+                                  on the containing object.
+                                properties:
+                                  group:
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    description: Kind is kind of the referent. For
+                                      example "ConfigMap" or "Service".
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the referenced object. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - name
+                                type: object
+                              maxItems: 8
+                              minItems: 1
+                              type: array
+                          type: object
                         mode:
                           default: Terminate
                           description: |-
@@ -1675,6 +2997,72 @@ spec:
                 - message: Hostname values must be unique
                   rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
                     a2.type == a1.type && a2.value == a1.value) : true )'
+              backendTLS:
+                description: |+
+                  BackendTLS configures TLS settings for when this Gateway is connecting to
+                  backends with TLS.
+
+                  Support: Core
+
+                properties:
+                  clientCertificateRef:
+                    description: |+
+                      ClientCertificateRef is a reference to an object that contains a Client
+                      Certificate and the associated private key.
+
+                      References to a resource in different namespace are invalid UNLESS there
+                      is a ReferenceGrant in the target namespace that allows the certificate
+                      to be attached. If a ReferenceGrant does not allow this reference, the
+                      "ResolvedRefs" condition MUST be set to False for this listener with the
+                      "RefNotPermitted" reason.
+
+                      ClientCertificateRef can reference to standard Kubernetes resources, i.e.
+                      Secret, or implementation-specific custom resources.
+
+                      This setting can be overridden on the service level by use of BackendTLSPolicy.
+
+                      Support: Core
+
+                    properties:
+                      group:
+                        default: ""
+                        description: |-
+                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                          When unspecified or empty string, core API group is inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Secret
+                        description: Kind is kind of the referent. For example "Secret".
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referenced object. When unspecified, the local
+                          namespace is inferred.
+
+                          Note that when a namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
               gatewayClassName:
                 description: |-
                   GatewayClassName used for this Gateway. This is the name of a
@@ -2214,6 +3602,94 @@ spec:
                             type: object
                           maxItems: 64
                           type: array
+                        frontendValidation:
+                          description: |+
+                            FrontendValidation holds configuration information for validating the frontend (client).
+                            Setting this field will require clients to send a client certificate
+                            required for validation during the TLS handshake. In browsers this may result in a dialog appearing
+                            that requests a user to specify the client certificate.
+                            The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                            Support: Extended
+
+                          properties:
+                            caCertificateRefs:
+                              description: |-
+                                CACertificateRefs contains one or more references to
+                                Kubernetes objects that contain TLS certificates of
+                                the Certificate Authorities that can be used
+                                as a trust anchor to validate the certificates presented by the client.
+
+                                A single CA certificate reference to a Kubernetes ConfigMap
+                                has "Core" support.
+                                Implementations MAY choose to support attaching multiple CA certificates to
+                                a Listener, but this behavior is implementation-specific.
+
+                                Support: Core - A single reference to a Kubernetes ConfigMap
+                                with the CA certificate in a key named `ca.crt`.
+
+                                Support: Implementation-specific (More than one reference, or other kinds
+                                of resources).
+
+                                References to a resource in a different namespace are invalid UNLESS there
+                                is a ReferenceGrant in the target namespace that allows the certificate
+                                to be attached. If a ReferenceGrant does not allow this reference, the
+                                "ResolvedRefs" condition MUST be set to False for this listener with the
+                                "RefNotPermitted" reason.
+                              items:
+                                description: |-
+                                  ObjectReference identifies an API object including its namespace.
+
+                                  The API object must be valid in the cluster; the Group and Kind must
+                                  be registered in the cluster for this reference to be valid.
+
+                                  References to objects with invalid Group and Kind are not valid, and must
+                                  be rejected by the implementation, with appropriate Conditions set
+                                  on the containing object.
+                                properties:
+                                  group:
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    description: Kind is kind of the referent. For
+                                      example "ConfigMap" or "Service".
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the referenced object. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - name
+                                type: object
+                              maxItems: 8
+                              minItems: 1
+                              type: array
+                          type: object
                         mode:
                           default: Terminate
                           description: |-
@@ -2607,7 +4083,7 @@ status:
   storedVersions: null
 ---
 #
-# config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+# config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2615,7 +4091,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.2.0
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: grpcroutes.gateway.networking.k8s.io
 spec:
@@ -2816,6 +4292,16 @@ spec:
                   generic way to enable other kinds of cross-namespace reference.
 
 
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
 
 
 
@@ -2882,6 +4368,16 @@ spec:
                         generic way to enable any other kind of cross-namespace reference.
 
 
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
 
                         Support: Core
                       maxLength: 63
@@ -2901,6 +4397,10 @@ spec:
                         and SectionName are specified, the name and port of the selected listener
                         must match both specified values.
 
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
 
 
                         Implementations MAY choose to support other parent resources.
@@ -2956,25 +4456,28 @@ spec:
                 maxItems: 32
                 type: array
                 x-kubernetes-validations:
-                - message: sectionName must be specified when parentRefs includes
+                - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
                   rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
                     == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
-                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
                     || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
-                    == '''')) : true))'
-                - message: sectionName must be unique when parentRefs includes 2 or
-                    more references to the same parent
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
                   rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
                     == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
                     p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
                     || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
-                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
-                    == p2.sectionName))))
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
               rules:
                 description: |+
                   Rules are a list of GRPC matchers, filters and actions.
@@ -3334,9 +4837,51 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |+
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |+
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
                                   required:
                                   - backendRef
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
                                 responseHeaderModifier:
                                   description: |-
                                     ResponseHeaderModifier defines a schema for a filter that modifies response
@@ -3945,9 +5490,51 @@ spec:
                                 - message: Must have port for Service reference
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
+                              fraction:
+                                description: |+
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |+
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
                             required:
                             - backendRef
                             type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
                           responseHeaderModifier:
                             description: |-
                               ResponseHeaderModifier defines a schema for a filter that modifies response
@@ -4325,6 +5912,103 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                    name:
+                      description: |
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+                        Support: Extended
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+                                Support: Core for "Session" type
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+                            Support: Core for "Cookie" type
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                          || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                   type: object
                 maxItems: 16
                 type: array
@@ -4349,6 +6033,9 @@ spec:
                     : 0) : 0) + (self.size() > 14 ? (has(self[14].matches) ? self[14].matches.size()
                     : 0) : 0) + (self.size() > 15 ? (has(self[15].matches) ? self[15].matches.size()
                     : 0) : 0) <= 128'
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
             type: object
           status:
             description: Status defines the current state of GRPCRoute.
@@ -4527,6 +6214,16 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
 
                             Support: Core
                           maxLength: 63
@@ -4546,6 +6243,10 @@ spec:
                             and SectionName are specified, the name and port of the selected listener
                             must match both specified values.
 
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
 
 
                             Implementations MAY choose to support other parent resources.
@@ -4620,7 +6321,7 @@ status:
   storedVersions: null
 ---
 #
-# config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+# config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4628,7 +6329,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.2.0
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
 spec:
@@ -4809,6 +6510,16 @@ spec:
                   generic way to enable other kinds of cross-namespace reference.
 
 
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
 
 
 
@@ -4875,6 +6586,16 @@ spec:
                         generic way to enable any other kind of cross-namespace reference.
 
 
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
 
                         Support: Core
                       maxLength: 63
@@ -4894,6 +6615,10 @@ spec:
                         and SectionName are specified, the name and port of the selected listener
                         must match both specified values.
 
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
 
 
                         Implementations MAY choose to support other parent resources.
@@ -4949,25 +6674,28 @@ spec:
                 maxItems: 32
                 type: array
                 x-kubernetes-validations:
-                - message: sectionName must be specified when parentRefs includes
+                - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
                   rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
                     == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
-                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
                     || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
-                    == '''')) : true))'
-                - message: sectionName must be unique when parentRefs includes 2 or
-                    more references to the same parent
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
                   rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
                     == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
                     p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
                     || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
-                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
-                    == p2.sectionName))))
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
               rules:
                 default:
                 - matches:
@@ -5339,9 +7067,51 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |+
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |+
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
                                   required:
                                   - backendRef
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
                                 requestRedirect:
                                   description: |-
                                     RequestRedirect defines a schema for a filter that responds to the
@@ -6236,9 +8006,51 @@ spec:
                                 - message: Must have port for Service reference
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
+                              fraction:
+                                description: |+
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |+
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
                             required:
                             - backendRef
                             type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
                           requestRedirect:
                             description: |-
                               RequestRedirect defines a schema for a filter that responds to the
@@ -7008,6 +8820,193 @@ spec:
                         type: object
                       maxItems: 64
                       type: array
+                    name:
+                      description: |
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    retry:
+                      description: |+
+                        Retry defines the configuration for when to retry an HTTP request.
+
+                        Support: Extended
+
+                      properties:
+                        attempts:
+                          description: |-
+                            Attempts specifies the maxmimum number of times an individual request
+                            from the gateway to a backend should be retried.
+
+                            If the maximum number of retries has been attempted without a successful
+                            response from the backend, the Gateway MUST return an error.
+
+                            When this field is unspecified, the number of times to attempt to retry
+                            a backend request is implementation-specific.
+
+                            Support: Extended
+                          type: integer
+                        backoff:
+                          description: |-
+                            Backoff specifies the minimum duration a Gateway should wait between
+                            retry attempts and is represented in Gateway API Duration formatting.
+
+                            For example, setting the `rules[].retry.backoff` field to the value
+                            `100ms` will cause a backend request to first be retried approximately
+                            100 milliseconds after timing out or receiving a response code configured
+                            to be retryable.
+
+                            An implementation MAY use an exponential or alternative backoff strategy
+                            for subsequent retry attempts, MAY cap the maximum backoff duration to
+                            some amount greater than the specified minimum, and MAY add arbitrary
+                            jitter to stagger requests, as long as unsuccessful backend requests are
+                            not retried before the configured minimum duration.
+
+                            If a Request timeout (`rules[].timeouts.request`) is configured on the
+                            route, the entire duration of the initial request and any retry attempts
+                            MUST not exceed the Request timeout duration. If any retry attempts are
+                            still in progress when the Request timeout duration has been reached,
+                            these SHOULD be canceled if possible and the Gateway MUST immediately
+                            return a timeout error.
+
+                            If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
+                            configured on the route, any retry attempts which reach the configured
+                            BackendRequest timeout duration without a response SHOULD be canceled if
+                            possible and the Gateway should wait for at least the specified backoff
+                            duration before attempting to retry the backend request again.
+
+                            If a BackendRequest timeout is _not_ configured on the route, retry
+                            attempts MAY time out after an implementation default duration, or MAY
+                            remain pending until a configured Request timeout or implementation
+                            default duration for total request time is reached.
+
+                            When this field is unspecified, the time to wait between retry attempts
+                            is implementation-specific.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        codes:
+                          description: |-
+                            Codes defines the HTTP response status codes for which a backend request
+                            should be retried.
+
+                            Support: Extended
+                          items:
+                            description: |-
+                              HTTPRouteRetryStatusCode defines an HTTP response status code for
+                              which a backend request should be retried.
+
+                              Implementations MUST support the following status codes as retryable:
+
+                              * 500
+                              * 502
+                              * 503
+                              * 504
+
+                              Implementations MAY support specifying additional discrete values in the
+                              500-599 range.
+
+                              Implementations MAY support specifying discrete values in the 400-499 range,
+                              which are often inadvisable to retry.
+
+                              <gateway:experimental>
+                            maximum: 599
+                            minimum: 400
+                            type: integer
+                          type: array
+                      type: object
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+                        Support: Extended
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+                                Support: Core for "Session" type
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+                            Support: Core for "Cookie" type
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                          || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                     timeouts:
                       description: |-
                         Timeouts defines the timeouts that can be configured for an HTTP request.
@@ -7128,6 +9127,9 @@ spec:
                     : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
                     > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
                     : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
             type: object
           status:
             description: Status defines the current state of HTTPRoute.
@@ -7306,6 +9308,16 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
 
                             Support: Core
                           maxLength: 63
@@ -7325,6 +9337,10 @@ spec:
                             and SectionName are specified, the name and port of the selected listener
                             must match both specified values.
 
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
 
 
                             Implementations MAY choose to support other parent resources.
@@ -7560,6 +9576,16 @@ spec:
                   generic way to enable other kinds of cross-namespace reference.
 
 
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
 
 
 
@@ -7626,6 +9652,16 @@ spec:
                         generic way to enable any other kind of cross-namespace reference.
 
 
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
 
                         Support: Core
                       maxLength: 63
@@ -7645,6 +9681,10 @@ spec:
                         and SectionName are specified, the name and port of the selected listener
                         must match both specified values.
 
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
 
 
                         Implementations MAY choose to support other parent resources.
@@ -7700,25 +9740,28 @@ spec:
                 maxItems: 32
                 type: array
                 x-kubernetes-validations:
-                - message: sectionName must be specified when parentRefs includes
+                - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
                   rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
                     == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
-                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
                     || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
-                    == '''')) : true))'
-                - message: sectionName must be unique when parentRefs includes 2 or
-                    more references to the same parent
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
                   rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
                     == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
                     p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
                     || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
-                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
-                    == p2.sectionName))))
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
               rules:
                 default:
                 - matches:
@@ -8090,9 +10133,51 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |+
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |+
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
                                   required:
                                   - backendRef
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
                                 requestRedirect:
                                   description: |-
                                     RequestRedirect defines a schema for a filter that responds to the
@@ -8987,9 +11072,51 @@ spec:
                                 - message: Must have port for Service reference
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
+                              fraction:
+                                description: |+
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |+
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
                             required:
                             - backendRef
                             type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
                           requestRedirect:
                             description: |-
                               RequestRedirect defines a schema for a filter that responds to the
@@ -9759,6 +11886,193 @@ spec:
                         type: object
                       maxItems: 64
                       type: array
+                    name:
+                      description: |
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    retry:
+                      description: |+
+                        Retry defines the configuration for when to retry an HTTP request.
+
+                        Support: Extended
+
+                      properties:
+                        attempts:
+                          description: |-
+                            Attempts specifies the maxmimum number of times an individual request
+                            from the gateway to a backend should be retried.
+
+                            If the maximum number of retries has been attempted without a successful
+                            response from the backend, the Gateway MUST return an error.
+
+                            When this field is unspecified, the number of times to attempt to retry
+                            a backend request is implementation-specific.
+
+                            Support: Extended
+                          type: integer
+                        backoff:
+                          description: |-
+                            Backoff specifies the minimum duration a Gateway should wait between
+                            retry attempts and is represented in Gateway API Duration formatting.
+
+                            For example, setting the `rules[].retry.backoff` field to the value
+                            `100ms` will cause a backend request to first be retried approximately
+                            100 milliseconds after timing out or receiving a response code configured
+                            to be retryable.
+
+                            An implementation MAY use an exponential or alternative backoff strategy
+                            for subsequent retry attempts, MAY cap the maximum backoff duration to
+                            some amount greater than the specified minimum, and MAY add arbitrary
+                            jitter to stagger requests, as long as unsuccessful backend requests are
+                            not retried before the configured minimum duration.
+
+                            If a Request timeout (`rules[].timeouts.request`) is configured on the
+                            route, the entire duration of the initial request and any retry attempts
+                            MUST not exceed the Request timeout duration. If any retry attempts are
+                            still in progress when the Request timeout duration has been reached,
+                            these SHOULD be canceled if possible and the Gateway MUST immediately
+                            return a timeout error.
+
+                            If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
+                            configured on the route, any retry attempts which reach the configured
+                            BackendRequest timeout duration without a response SHOULD be canceled if
+                            possible and the Gateway should wait for at least the specified backoff
+                            duration before attempting to retry the backend request again.
+
+                            If a BackendRequest timeout is _not_ configured on the route, retry
+                            attempts MAY time out after an implementation default duration, or MAY
+                            remain pending until a configured Request timeout or implementation
+                            default duration for total request time is reached.
+
+                            When this field is unspecified, the time to wait between retry attempts
+                            is implementation-specific.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        codes:
+                          description: |-
+                            Codes defines the HTTP response status codes for which a backend request
+                            should be retried.
+
+                            Support: Extended
+                          items:
+                            description: |-
+                              HTTPRouteRetryStatusCode defines an HTTP response status code for
+                              which a backend request should be retried.
+
+                              Implementations MUST support the following status codes as retryable:
+
+                              * 500
+                              * 502
+                              * 503
+                              * 504
+
+                              Implementations MAY support specifying additional discrete values in the
+                              500-599 range.
+
+                              Implementations MAY support specifying discrete values in the 400-499 range,
+                              which are often inadvisable to retry.
+
+                              <gateway:experimental>
+                            maximum: 599
+                            minimum: 400
+                            type: integer
+                          type: array
+                      type: object
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+                        Support: Extended
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+                                Support: Core for "Session" type
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+                            Support: Core for "Cookie" type
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                          || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                     timeouts:
                       description: |-
                         Timeouts defines the timeouts that can be configured for an HTTP request.
@@ -9879,6 +12193,9 @@ spec:
                     : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
                     > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
                     : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
             type: object
           status:
             description: Status defines the current state of HTTPRoute.
@@ -10057,6 +12374,16 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
 
                             Support: Core
                           maxLength: 63
@@ -10076,6 +12403,10 @@ spec:
                             and SectionName are specified, the name and port of the selected listener
                             must match both specified values.
 
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
 
 
                             Implementations MAY choose to support other parent resources.
@@ -10152,7 +12483,7 @@ status:
   storedVersions: null
 ---
 #
-# config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+# config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -10160,7 +12491,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.2.0
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
 spec:
@@ -10337,6 +12668,2304 @@ spec:
     served: true
     storage: true
     subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: tcproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TCPRoute
+    listKind: TCPRouteList
+    plural: tcproutes
+    singular: tcproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          TCPRoute provides a way to route TCP requests. When combined with a Gateway
+          listener, it can be used to forward connections on the port specified by the
+          listener to a set of backends specified by the TCPRoute.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TCPRoute.
+            properties:
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: |+
+                  Rules are a list of TCP matchers and actions.
+
+                items:
+                  description: TCPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a non-existent resource or a
+                        Service with no endpoints), the underlying implementation MUST actively
+                        reject connection attempts to this backend. Connection rejections must
+                        respect weight; if an invalid backend is requested to have 80% of
+                        connections, then 80% of connections must be rejected instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TCPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: tlsroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility
+          in matching streams for a given TLS listener.
+
+          If you need to forward traffic to a single target for a TLS listener, you
+          could choose to use a TCPRoute with a TLS listener.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of SNI names that should match against the
+                  SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed in SNI names per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+
+                  If a hostname is specified by both the Listener and TLSRoute, there
+                  must be at least one intersecting hostname for the TLSRoute to be
+                  attached to the Listener. For example:
+
+                  * A Listener with `test.example.com` as the hostname matches TLSRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches TLSRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `test.example.com` and `*.example.com` would both match. On the other
+                    hand, `example.com` and `test.example.net` would not match.
+
+                  If both the Listener and TLSRoute have specified hostnames, any
+                  TLSRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  TLSRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match.
+
+                  If both the Listener and TLSRoute have specified hostnames, and none
+                  match with the criteria above, then the TLSRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status of
+                  `False` in the corresponding RouteParentStatus.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: |+
+                  Rules are a list of TLS matchers and actions.
+
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a non-existent resource or
+                        a Service with no endpoints), the rule performs no forwarding; if no
+                        filters are specified that would result in a response being sent, the
+                        underlying implementation must actively reject request attempts to this
+                        backend, by rejecting the connection or returning a 500 status code.
+                        Request rejections must respect weight; if an invalid backend is
+                        requested to have 80% of requests, then 80% of requests must be rejected
+                        instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: udproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: UDPRoute
+    listKind: UDPRouteList
+    plural: udproutes
+    singular: udproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          UDPRoute provides a way to route UDP traffic. When combined with a Gateway
+          listener, it can be used to forward traffic on the port specified by the
+          listener to a set of backends specified by the UDPRoute.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of UDPRoute.
+            properties:
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: |+
+                  Rules are a list of UDP matchers and actions.
+
+                items:
+                  description: UDPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a non-existent resource or a
+                        Service with no endpoints), the underlying implementation MUST actively
+                        reject connection attempts to this backend. Packet drops must
+                        respect weight; if an invalid backend is requested to have 80% of
+                        the packets, then 80% of packets must be dropped instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of UDPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/internal/controller/gateway/tlsroute_controller.go
+++ b/internal/controller/gateway/tlsroute_controller.go
@@ -1,0 +1,117 @@
+/*
+MIT License
+
+Copyright (c) 2022 ngrok, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package gateway
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/go-logr/logr"
+	"github.com/ngrok/ngrok-operator/internal/controller"
+	"github.com/ngrok/ngrok-operator/pkg/managerdriver"
+)
+
+// TLSRouteReconciler reconciles a TLSRoute object
+type TLSRouteReconciler struct {
+	client.Client
+
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	Driver   *managerdriver.Driver
+}
+
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=tlsroutes,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=tlsroutes/status,verbs=get;list;watch;update
+
+func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx).WithValues("TLSRoute", req.NamespacedName)
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	tcpRoute := new(gatewayv1alpha2.TLSRoute)
+	err := r.Client.Get(ctx, req.NamespacedName, tcpRoute)
+	switch {
+	case err == nil:
+		// all good, continue
+	case client.IgnoreNotFound(err) == nil:
+		if err := r.Driver.DeleteNamedTLSRoute(req.NamespacedName); err != nil {
+			log.Error(err, "failed to delete TLSRoute from store")
+			return ctrl.Result{}, err
+		}
+
+		err = r.Driver.Sync(ctx, r.Client)
+		if err != nil {
+			log.Error(err, "failed to sync after removing TLSRoute from store")
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, nil
+	default:
+		return ctrl.Result{}, err
+	}
+
+	tcpRoute, err = r.Driver.UpdateTLSRoute(tcpRoute)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if controller.IsUpsert(tcpRoute) {
+		// The object is not being deleted, so register and sync finalizer
+		if err := controller.RegisterAndSyncFinalizer(ctx, r.Client, tcpRoute); err != nil {
+			log.Error(err, "Failed to register finalizer")
+			return ctrl.Result{}, err
+		}
+	} else {
+		log.Info("deleting TLSRoute from store")
+		if controller.HasFinalizer(tcpRoute) {
+			if err := controller.RemoveAndSyncFinalizer(ctx, r.Client, tcpRoute); err != nil {
+				log.Error(err, "Failed to remove finalizer")
+				return ctrl.Result{}, err
+			}
+		}
+
+		// Remove it from the store
+		if err := r.Driver.DeleteTLSRoute(tcpRoute); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	if err := r.Driver.Sync(ctx, r.Client); err != nil {
+		log.Error(err, "failed to sync after reconciling TLSRoutes")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&gatewayv1alpha2.TLSRoute{}).Complete(r)
+}

--- a/internal/controller/gateway/tlsroute_controller_test.go
+++ b/internal/controller/gateway/tlsroute_controller_test.go
@@ -1,0 +1,76 @@
+/*
+MIT License
+
+Copyright (c) 2025 ngrok, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package gateway
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+var _ = Describe("TLSRoute controller", func() {
+	const (
+		TLSRouteName = "test-tlsroute"
+	)
+
+	var (
+		testTLSroute *gatewayv1alpha2.TLSRoute
+	)
+
+	BeforeEach(func() {
+		ctx := context.Background()
+		testTLSroute = &gatewayv1alpha2.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: TLSRouteName,
+			},
+			Spec: gatewayv1alpha2.TLSRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{
+						Kind: ptr.To(gatewayv1.Kind("gateway")),
+						Name: gatewayv1.ObjectName("example-gw"),
+					}},
+				},
+				Rules: []gatewayv1alpha2.TLSRouteRule{{
+					BackendRefs: []gatewayv1alpha2.BackendRef{{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("example-svc"),
+						},
+					}},
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, testTLSroute)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		ctx := context.Background()
+		Expect(k8sClient.Delete(ctx, testTLSroute)).To(Succeed())
+	})
+})

--- a/internal/controller/gateway/tlsroute_controller_test.go
+++ b/internal/controller/gateway/tlsroute_controller_test.go
@@ -26,6 +26,7 @@ package gateway
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -71,6 +72,18 @@ var _ = Describe("TLSRoute controller", func() {
 
 	AfterEach(func() {
 		ctx := context.Background()
+		hasTLSRoute := false
+		tlsRoutes := driver.GetStore().ListTLSRoutes()
+		for _, tlsRoute := range tlsRoutes {
+			if tlsRoute.Name == "test-tlsroute" {
+				hasTLSRoute = true
+			}
+		}
+		Expect(len(tlsRoutes)).To(Equal(1))
+		Expect(hasTLSRoute).To(Equal(true))
 		Expect(k8sClient.Delete(ctx, testTLSroute)).To(Succeed())
+		time.Sleep(time.Second * 3)
+		tlsRoutes = driver.GetStore().ListTLSRoutes()
+		Expect(len(tlsRoutes)).To(Equal(0))
 	})
 })

--- a/internal/ir/ir_test.go
+++ b/internal/ir/ir_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
 )
 
 // --- Helper functions to create pointers ---
@@ -28,13 +29,13 @@ func TestSortRoutes(t *testing.T) {
 			name: "Path and PathType sorting: Exact vs Prefix",
 			routes: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/foo"),
 						PathType: pathTypePtr(IRPathType_Prefix),
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/bar"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
@@ -42,13 +43,13 @@ func TestSortRoutes(t *testing.T) {
 			},
 			expectedOrder: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/bar"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/foo"),
 						PathType: pathTypePtr(IRPathType_Prefix),
 					},
@@ -59,13 +60,13 @@ func TestSortRoutes(t *testing.T) {
 			name: "Longer paths before shorter paths",
 			routes: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/longer"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/short"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
@@ -73,13 +74,13 @@ func TestSortRoutes(t *testing.T) {
 			},
 			expectedOrder: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/longer"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/short"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
@@ -90,13 +91,13 @@ func TestSortRoutes(t *testing.T) {
 			name: "Lexicographical order for same path length and type",
 			routes: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/b"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/a"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
@@ -104,13 +105,13 @@ func TestSortRoutes(t *testing.T) {
 			},
 			expectedOrder: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/a"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/b"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
@@ -121,26 +122,26 @@ func TestSortRoutes(t *testing.T) {
 			name: "Header specificity: routes with headers come before those without",
 			routes: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Headers: []IRHeaderMatch{
 							{Name: "X-Test", Value: "foo", ValueType: IRStringValueType_Exact},
 						},
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{},
+					HTTPMatchCriteria: &IRHTTPMatch{},
 				},
 			},
 			expectedOrder: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Headers: []IRHeaderMatch{
 							{Name: "X-Test", Value: "foo", ValueType: IRStringValueType_Exact},
 						},
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{},
+					HTTPMatchCriteria: &IRHTTPMatch{},
 				},
 			},
 		},
@@ -148,26 +149,26 @@ func TestSortRoutes(t *testing.T) {
 			name: "Query param specificity: routes with query params come before those without",
 			routes: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						QueryParams: []IRQueryParamMatch{
 							{Name: "id", Value: "123", ValueType: IRStringValueType_Exact},
 						},
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{},
+					HTTPMatchCriteria: &IRHTTPMatch{},
 				},
 			},
 			expectedOrder: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						QueryParams: []IRQueryParamMatch{
 							{Name: "id", Value: "123", ValueType: IRStringValueType_Exact},
 						},
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{},
+					HTTPMatchCriteria: &IRHTTPMatch{},
 				},
 			},
 		},
@@ -175,22 +176,22 @@ func TestSortRoutes(t *testing.T) {
 			name: "Method specificity: routes with method come before those without",
 			routes: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Method: methodPtr(IRMethodMatch_Get),
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{},
+					HTTPMatchCriteria: &IRHTTPMatch{},
 				},
 			},
 			expectedOrder: []*IRRoute{
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Method: methodPtr(IRMethodMatch_Get),
 					},
 				},
 				{
-					MatchCriteria: IRHTTPMatch{},
+					HTTPMatchCriteria: &IRHTTPMatch{},
 				},
 			},
 		},
@@ -199,14 +200,14 @@ func TestSortRoutes(t *testing.T) {
 			routes: []*IRRoute{
 				// Route A: has path "/a", exact, no headers, no query, no method.
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/a"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
 				},
 				// Route B: has path "/a", exact, with headers.
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/a"),
 						PathType: pathTypePtr(IRPathType_Exact),
 						Headers: []IRHeaderMatch{
@@ -216,7 +217,7 @@ func TestSortRoutes(t *testing.T) {
 				},
 				// Route C: no path, with headers.
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Headers: []IRHeaderMatch{
 							{Name: "Y", Value: "2", ValueType: IRStringValueType_Exact},
 						},
@@ -224,13 +225,13 @@ func TestSortRoutes(t *testing.T) {
 				},
 				// Route D: no path, no headers, with method.
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Method: methodPtr(IRMethodMatch_Get),
 					},
 				},
 				// Route E: no path, no headers, no method.
 				{
-					MatchCriteria: IRHTTPMatch{},
+					HTTPMatchCriteria: &IRHTTPMatch{},
 				},
 			},
 			// Expected order:
@@ -241,7 +242,7 @@ func TestSortRoutes(t *testing.T) {
 			expectedOrder: []*IRRoute{
 				// Route B: has path "/a", exact, with headers.
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/a"),
 						PathType: pathTypePtr(IRPathType_Exact),
 						Headers: []IRHeaderMatch{
@@ -251,14 +252,14 @@ func TestSortRoutes(t *testing.T) {
 				},
 				// Route A: has path "/a", exact, no headers.
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Path:     stringPtr("/a"),
 						PathType: pathTypePtr(IRPathType_Exact),
 					},
 				},
 				// Then, among routes with no path, route with headers (C)
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Headers: []IRHeaderMatch{
 							{Name: "Y", Value: "2", ValueType: IRStringValueType_Exact},
 						},
@@ -266,13 +267,39 @@ func TestSortRoutes(t *testing.T) {
 				},
 				// Then, route with method (D)
 				{
-					MatchCriteria: IRHTTPMatch{
+					HTTPMatchCriteria: &IRHTTPMatch{
 						Method: methodPtr(IRMethodMatch_Get),
 					},
 				},
 				// Then, route with nothing (E)
 				{
-					MatchCriteria: IRHTTPMatch{},
+					HTTPMatchCriteria: &IRHTTPMatch{},
+				},
+			},
+		},
+		{
+			name: "Routes with no match criteria come last",
+			routes: []*IRRoute{
+
+				{
+					HTTPMatchCriteria: nil,
+				},
+				{
+					HTTPMatchCriteria: &IRHTTPMatch{
+						Path:     ptr.To("/test"),
+						PathType: ptr.To(IRPathType_Exact),
+					},
+				},
+			},
+			expectedOrder: []*IRRoute{
+				{
+					HTTPMatchCriteria: &IRHTTPMatch{
+						Path:     ptr.To("/test"),
+						PathType: ptr.To(IRPathType_Exact),
+					},
+				},
+				{
+					HTTPMatchCriteria: nil,
 				},
 			},
 		},

--- a/internal/ir/ir_test.go
+++ b/internal/ir/ir_test.go
@@ -303,6 +303,62 @@ func TestSortRoutes(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Routes with no match criteria come last (different initial order)",
+			routes: []*IRRoute{
+				{
+					HTTPMatchCriteria: &IRHTTPMatch{
+						Path:     ptr.To("/test"),
+						PathType: ptr.To(IRPathType_Exact),
+					},
+				},
+				{
+					HTTPMatchCriteria: nil,
+				},
+			},
+			expectedOrder: []*IRRoute{
+				{
+					HTTPMatchCriteria: &IRHTTPMatch{
+						Path:     ptr.To("/test"),
+						PathType: ptr.To(IRPathType_Exact),
+					},
+				},
+				{
+					HTTPMatchCriteria: nil,
+				},
+			},
+		},
+		{
+			name: "Routes with no match criteria come last (multiple with no match criteria)",
+			routes: []*IRRoute{
+				{
+					HTTPMatchCriteria: nil,
+				},
+				{
+					HTTPMatchCriteria: nil,
+				},
+				{
+					HTTPMatchCriteria: &IRHTTPMatch{
+						Path:     ptr.To("/test"),
+						PathType: ptr.To(IRPathType_Exact),
+					},
+				},
+			},
+			expectedOrder: []*IRRoute{
+				{
+					HTTPMatchCriteria: &IRHTTPMatch{
+						Path:     ptr.To("/test"),
+						PathType: ptr.To(IRPathType_Exact),
+					},
+				},
+				{
+					HTTPMatchCriteria: nil,
+				},
+				{
+					HTTPMatchCriteria: nil,
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/store/cachestores.go
+++ b/internal/store/cachestores.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -44,6 +45,8 @@ type CacheStores struct {
 	Gateway        cache.Store
 	GatewayClass   cache.Store
 	HTTPRoute      cache.Store
+	TCPRoute       cache.Store
+	TLSRoute       cache.Store
 	ReferenceGrant cache.Store
 
 	// Ngrok Stores
@@ -73,6 +76,8 @@ func NewCacheStores(logger logr.Logger) CacheStores {
 		Gateway:        cache.NewStore(keyFunc),
 		GatewayClass:   cache.NewStore(keyFunc),
 		HTTPRoute:      cache.NewStore(keyFunc),
+		TCPRoute:       cache.NewStore(keyFunc),
+		TLSRoute:       cache.NewStore(keyFunc),
 		ReferenceGrant: cache.NewStore(keyFunc),
 		// Ngrok Stores
 		DomainV1:             cache.NewStore(keyFunc),
@@ -131,6 +136,10 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 	// ----------------------------------------------------------------------------
 	case *gatewayv1.HTTPRoute:
 		return c.HTTPRoute.Get(obj)
+	case *gatewayv1alpha2.TCPRoute:
+		return c.TCPRoute.Get(obj)
+	case *gatewayv1alpha2.TLSRoute:
+		return c.TLSRoute.Get(obj)
 	case *gatewayv1.Gateway:
 		return c.Gateway.Get(obj)
 	case *gatewayv1.GatewayClass:
@@ -188,6 +197,10 @@ func (c CacheStores) Add(obj runtime.Object) error {
 	// ----------------------------------------------------------------------------
 	case *gatewayv1.HTTPRoute:
 		return c.HTTPRoute.Add(obj)
+	case *gatewayv1alpha2.TCPRoute:
+		return c.TCPRoute.Add(obj)
+	case *gatewayv1alpha2.TLSRoute:
+		return c.TLSRoute.Add(obj)
 	case *gatewayv1.Gateway:
 		return c.Gateway.Add(obj)
 	case *gatewayv1.GatewayClass:
@@ -246,6 +259,10 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 	// ----------------------------------------------------------------------------
 	case *gatewayv1.HTTPRoute:
 		return c.HTTPRoute.Delete(obj)
+	case *gatewayv1alpha2.TCPRoute:
+		return c.TCPRoute.Delete(obj)
+	case *gatewayv1alpha2.TLSRoute:
+		return c.TLSRoute.Delete(obj)
 	case *gatewayv1.Gateway:
 		return c.Gateway.Delete(obj)
 	case *gatewayv1.GatewayClass:

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -93,6 +93,90 @@ var _ = Describe("Store", func() {
 		})
 	})
 
+	var _ = Describe("GetGateway", func() {
+		Context("when the Gateway exists", func() {
+			BeforeEach(func() {
+				gw := testutils.NewGateway("test-gateway", "test-namespace")
+				Expect(store.Add(&gw)).To(BeNil())
+			})
+			It("returns the Gateway", func() {
+				gw, err := store.GetGateway("test-gateway", "test-namespace")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(gw.Name).To(Equal("test-gateway"))
+			})
+		})
+		Context("when the Gateway does not exist", func() {
+			It("returns an error", func() {
+				gw, err := store.GetGateway("does-not-exist", "does-not-exist")
+				Expect(err).To(HaveOccurred())
+				Expect(gw).To(BeNil())
+			})
+		})
+	})
+
+	var _ = Describe("GetHTTPRoute", func() {
+		Context("when the HTTPRoute exists", func() {
+			BeforeEach(func() {
+				r := testutils.NewHTTPRoute("test-httproute", "test-namespace")
+				Expect(store.Add(&r)).To(BeNil())
+			})
+			It("returns the HTTPRoute", func() {
+				r, err := store.GetHTTPRoute("test-httproute", "test-namespace")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(r.Name).To(Equal("test-httproute"))
+			})
+		})
+		Context("when the HTTPRoute does not exist", func() {
+			It("returns an error", func() {
+				r, err := store.GetHTTPRoute("does-not-exist", "does-not-exist")
+				Expect(err).To(HaveOccurred())
+				Expect(r).To(BeNil())
+			})
+		})
+	})
+
+	var _ = Describe("GetTLSRoute", func() {
+		Context("when the TLSRoute exists", func() {
+			BeforeEach(func() {
+				r := testutils.NewTLSRoute("test-tlsroute", "test-namespace")
+				Expect(store.Add(&r)).To(BeNil())
+			})
+			It("returns the TLSRoute", func() {
+				r, err := store.GetTLSRoute("test-tlsroute", "test-namespace")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(r.Name).To(Equal("test-tlsroute"))
+			})
+		})
+		Context("when the TLSRoute does not exist", func() {
+			It("returns an error", func() {
+				r, err := store.GetTLSRoute("does-not-exist", "does-not-exist")
+				Expect(err).To(HaveOccurred())
+				Expect(r).To(BeNil())
+			})
+		})
+	})
+
+	var _ = Describe("GetTCPRoute", func() {
+		Context("when the TCPRoute exists", func() {
+			BeforeEach(func() {
+				r := testutils.NewTCPRoute("test-tcproute", "test-namespace")
+				Expect(store.Add(&r)).To(BeNil())
+			})
+			It("returns the TCPRoute", func() {
+				r, err := store.GetTCPRoute("test-tcproute", "test-namespace")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(r.Name).To(Equal("test-tcproute"))
+			})
+		})
+		Context("when the TCPRoute does not exist", func() {
+			It("returns an error", func() {
+				r, err := store.GetTCPRoute("does-not-exist", "does-not-exist")
+				Expect(err).To(HaveOccurred())
+				Expect(r).To(BeNil())
+			})
+		})
+	})
+
 	var _ = Describe("GetNgrokIngressV1", func() {
 		Context("when the ngrok ingress exists", func() {
 			BeforeEach(func() {
@@ -151,6 +235,201 @@ var _ = Describe("Store", func() {
 			It("doesn't error", func() {
 				ics := store.ListNgrokIngressClassesV1()
 				Expect(len(ics)).To(Equal(0))
+			})
+		})
+	})
+
+	var _ = Describe("ListGateways", func() {
+		Context("when there are Gateways", func() {
+			BeforeEach(func() {
+				gw1 := testutils.NewGateway("gateway-1", "test-namespace")
+				Expect(store.Add(&gw1)).To(BeNil())
+				gw2 := testutils.NewGateway("gateway-2", "test-namespace")
+				Expect(store.Add(&gw2)).To(BeNil())
+				gw3 := testutils.NewGateway("gateway-3", "test-namespace")
+				Expect(store.Add(&gw3)).To(BeNil())
+			})
+			It("returns the Gateways", func() {
+				expectedNames := []string{
+					"gateway-1",
+					"gateway-2",
+					"gateway-3",
+				}
+				gws := store.ListGateways()
+				Expect(len(gws)).To(Equal(3))
+
+				for _, expectedName := range expectedNames {
+					found := false
+					for _, gw := range gws {
+						if gw.Name == expectedName {
+							found = true
+							break
+						}
+					}
+					Expect(found, true)
+				}
+			})
+		})
+		Context("when there are no Gateways", func() {
+			It("doesn't error", func() {
+				gws := store.ListGateways()
+				Expect(len(gws)).To(Equal(0))
+			})
+		})
+	})
+
+	var _ = Describe("ListHTTPRoutes", func() {
+		Context("when there are HTTPRoutes", func() {
+			BeforeEach(func() {
+				r1 := testutils.NewHTTPRoute("httproute-1", "test-namespace")
+				Expect(store.Add(&r1)).To(BeNil())
+				r2 := testutils.NewHTTPRoute("httproute-2", "test-namespace")
+				Expect(store.Add(&r2)).To(BeNil())
+				r3 := testutils.NewHTTPRoute("httproute-3", "test-namespace")
+				Expect(store.Add(&r3)).To(BeNil())
+			})
+			It("returns the HTTPRoutes", func() {
+				expectedNames := []string{
+					"httproute-1",
+					"httproute-2",
+					"httproute-3",
+				}
+				rs := store.ListHTTPRoutes()
+				Expect(len(rs)).To(Equal(3))
+
+				for _, expectedName := range expectedNames {
+					found := false
+					for _, r := range rs {
+						if r.Name == expectedName {
+							found = true
+							break
+						}
+					}
+					Expect(found, true)
+				}
+			})
+		})
+		Context("when there are no HTTPRoutes", func() {
+			It("doesn't error", func() {
+				rs := store.ListHTTPRoutes()
+				Expect(len(rs)).To(Equal(0))
+			})
+		})
+	})
+
+	var _ = Describe("ListTCPRoutes", func() {
+		Context("when there are TCPRoutes", func() {
+			BeforeEach(func() {
+				r1 := testutils.NewTCPRoute("tcproute-1", "test-namespace")
+				Expect(store.Add(&r1)).To(BeNil())
+				r2 := testutils.NewTCPRoute("tcproute-2", "test-namespace")
+				Expect(store.Add(&r2)).To(BeNil())
+				r3 := testutils.NewTCPRoute("tcproute-3", "test-namespace")
+				Expect(store.Add(&r3)).To(BeNil())
+			})
+			It("returns the TCPRoutes", func() {
+				expectedNames := []string{
+					"tcproute-1",
+					"tcproute-2",
+					"tcproute-3",
+				}
+				rs := store.ListTCPRoutes()
+				Expect(len(rs)).To(Equal(3))
+
+				for _, expectedName := range expectedNames {
+					found := false
+					for _, r := range rs {
+						if r.Name == expectedName {
+							found = true
+							break
+						}
+					}
+					Expect(found, true)
+				}
+			})
+		})
+		Context("when there are no TCPRoutes", func() {
+			It("doesn't error", func() {
+				rs := store.ListTCPRoutes()
+				Expect(len(rs)).To(Equal(0))
+			})
+		})
+	})
+
+	var _ = Describe("ListTLSRoutes", func() {
+		Context("when there are TLSRoutes", func() {
+			BeforeEach(func() {
+				r1 := testutils.NewTLSRoute("tlsroute-1", "test-namespace")
+				Expect(store.Add(&r1)).To(BeNil())
+				r2 := testutils.NewTLSRoute("tlsroute-2", "test-namespace")
+				Expect(store.Add(&r2)).To(BeNil())
+				r3 := testutils.NewTLSRoute("tlsroute-3", "test-namespace")
+				Expect(store.Add(&r3)).To(BeNil())
+			})
+			It("returns the TLSRoutes", func() {
+				expectedNames := []string{
+					"tlsroute-1",
+					"tlsroute-2",
+					"tlsroute-3",
+				}
+				rs := store.ListTLSRoutes()
+				Expect(len(rs)).To(Equal(3))
+
+				for _, expectedName := range expectedNames {
+					found := false
+					for _, r := range rs {
+						if r.Name == expectedName {
+							found = true
+							break
+						}
+					}
+					Expect(found, true)
+				}
+			})
+		})
+		Context("when there are no TLSRoutes", func() {
+			It("doesn't error", func() {
+				rs := store.ListTLSRoutes()
+				Expect(len(rs)).To(Equal(0))
+			})
+		})
+	})
+
+	var _ = Describe("ListReferenceGrants", func() {
+		Context("when there are ReferenceGrants", func() {
+			BeforeEach(func() {
+				r1 := testutils.NewReferenceGrant("grant-1", "test-namespace")
+				Expect(store.Add(&r1)).To(BeNil())
+				r2 := testutils.NewReferenceGrant("grant-2", "test-namespace")
+				Expect(store.Add(&r2)).To(BeNil())
+				r3 := testutils.NewReferenceGrant("grant-3", "test-namespace")
+				Expect(store.Add(&r3)).To(BeNil())
+			})
+			It("returns the ReferenceGrants", func() {
+				expectedNames := []string{
+					"grant-1",
+					"grant-2",
+					"grant-3",
+				}
+				rs := store.ListReferenceGrants()
+				Expect(len(rs)).To(Equal(3))
+
+				for _, expectedName := range expectedNames {
+					found := false
+					for _, r := range rs {
+						if r.Name == expectedName {
+							found = true
+							break
+						}
+					}
+					Expect(found, true)
+				}
+			})
+		})
+		Context("when there are no ReferenceGrants", func() {
+			It("doesn't error", func() {
+				rs := store.ListReferenceGrants()
+				Expect(len(rs)).To(Equal(0))
 			})
 		})
 	})

--- a/internal/testutils/k8s-resources.go
+++ b/internal/testutils/k8s-resources.go
@@ -9,6 +9,11 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func NewTestIngressClass(name string, isDefault bool, isNgrok bool) netv1.IngressClass {
@@ -102,6 +107,118 @@ func NewDomainV1(name string, namespace string) ingressv1alpha1.Domain {
 		},
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: name,
+		},
+	}
+}
+
+func NewGateway(name string, namespace string) gatewayv1.Gateway {
+	return gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-gatewayclass",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+			},
+		},
+	}
+}
+
+func NewHTTPRoute(name string, namespace string) gatewayv1.HTTPRoute {
+	return gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+								Value: ptr.To("/"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewTLSRoute(name string, namespace string) gatewayv1alpha2.TLSRoute {
+	return gatewayv1alpha2.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gatewayv1alpha2.TLSRouteSpec{
+			Rules: []gatewayv1alpha2.TLSRouteRule{
+				{
+					BackendRefs: []gatewayv1alpha2.BackendRef{
+						{
+							BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+								Name: "test-service",
+								Port: ptr.To(gatewayv1.PortNumber(8000)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewTCPRoute(name string, namespace string) gatewayv1alpha2.TCPRoute {
+	return gatewayv1alpha2.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gatewayv1alpha2.TCPRouteSpec{
+			Rules: []gatewayv1alpha2.TCPRouteRule{
+				{
+					BackendRefs: []gatewayv1alpha2.BackendRef{
+						{
+							BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+								Name: "tcp-service",
+								Port: ptr.To(gatewayv1.PortNumber(8000)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewReferenceGrant(name string, namespace string) gatewayv1beta1.ReferenceGrant {
+	return gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1beta1.ReferenceGrantFrom{
+				{
+					Group:     "gateway.networking.k8s.io",
+					Kind:      "HTTPRoute",
+					Namespace: gatewayv1beta1.Namespace("other-namespace"),
+				},
+			},
+			To: []gatewayv1beta1.ReferenceGrantTo{
+				{
+					Group: "core",
+					Kind:  "Service",
+				},
+			},
 		},
 	}
 }

--- a/pkg/managerdriver/driver.go
+++ b/pkg/managerdriver/driver.go
@@ -125,6 +125,11 @@ func (d *Driver) WithNgrokMetadata(customNgrokMetadata map[string]string) *Drive
 	return d
 }
 
+// Useful for tests
+func (d *Driver) GetStore() store.Storer {
+	return d.store
+}
+
 func (d *Driver) setNgrokMetadataOwner(owner string, customNgrokMetadata map[string]string) (string, error) {
 	metaData := make(map[string]string)
 	for k, v := range customNgrokMetadata {

--- a/pkg/managerdriver/driver_test.go
+++ b/pkg/managerdriver/driver_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ngrok/ngrok-operator/internal/testutils"
 	"github.com/ngrok/ngrok-operator/internal/trafficpolicy"
 	"github.com/ngrok/ngrok-operator/internal/util"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 const defaultManagerName = "ngrok-ingress-controller"
@@ -44,6 +45,7 @@ var _ = Describe("Driver", func() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(ingressv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(gatewayv1.Install(scheme))
+	utilruntime.Must(gatewayv1alpha2.Install(scheme))
 	utilruntime.Must(ngrokv1alpha1.AddToScheme(scheme))
 	BeforeEach(func() {
 		// create a fake logger to pass into the cachestore

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-collapse-endpoints-multiple.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-collapse-endpoints-multiple.yaml
@@ -114,70 +114,69 @@ expected:
       labels:
         k8s.ngrok.com/controller-name: test-manager-name
         k8s.ngrok.com/controller-namespace: test-manager-namespace
-      name: e3b0c-test-service-1-default-8080
+      name: e3b0c-test-service-2-default-8080
       namespace: default
     spec:
       url: "https://test-hostname.ngrok.io"
       upstream:
-        url: "http://test-service-1.default:8080"
+        url: "http://test-service-2.default:8080"
       bindings:
       - "public"
       trafficPolicy:
         inline:
-            on_http_request:
-              - name: Initialize-Local-Service-Match
-                actions:
+          on_http_request:
+            - name: Initialize-Local-Service-Match
+              actions:
+              - type: set-vars
+                config:
+                  vars:
+                  - request_matched_local_svc: false
+            - name: Generated-Route
+              expressions:
+                - "req.url.path.startsWith('/test-service-1')"
+                - vars.request_matched_local_svc == false
+              actions:
+                - type: forward-internal
+                  config:
+                    url: https://e3b0c-test-service-1-default-8080.internal
+            - name: Generated-Route
+              expressions:
+                - "req.url.path.startsWith('/service1')"
+                - vars.request_matched_local_svc == false
+              actions:
+                - type: forward-internal
+                  config:
+                    url: https://e3b0c-test-service-1-default-8080.internal
+            - name: Generated-Local-Service-Route
+              expressions:
+                - "req.url.path.startsWith('/service2')"
+                - vars.request_matched_local_svc == false
+              actions:
                 - type: set-vars
                   config:
-                    vars:
-                    - request_matched_local_svc: false
-              - name: Generated-Local-Service-Route
-                expressions:
-                  - "req.url.path.startsWith('/test-service-1')"
-                  - vars.request_matched_local_svc == false
-                actions:
-                  - type: set-vars
-                    config:
-                      vars: 
-                      - request_matched_local_svc: true
-              - name: Generated-Local-Service-Route
-                expressions:
-                  - "req.url.path.startsWith('/service1')"
-                  - vars.request_matched_local_svc == false
-                actions:
-                  - type: set-vars
-                    config:
-                      vars: 
-                      - request_matched_local_svc: true
-              - name: Generated-Route
-                expressions:
-                  - "req.url.path.startsWith('/service2')"
-                  - vars.request_matched_local_svc == false
-                actions:
-                  - type: forward-internal
-                    config:
-                      url: https://e3b0c-test-service-2-default-8080.internal                      
-              - name: Fallback-404
-                expressions:
-                - vars.request_matched_local_svc == false
-                actions:
-                - type: custom-response
-                  config:
-                    status_code: 404
-                    content: "No route was found for this ngrok Endpoint"
-                    headers:
-                      content-type: text/plain
+                    vars: 
+                    - request_matched_local_svc: true
+            - name: Fallback-404
+              expressions:
+              - vars.request_matched_local_svc == false
+              actions:
+              - type: custom-response
+                config:
+                  status_code: 404
+                  content: "No route was found for this ngrok Endpoint"
+                  headers:
+                    content-type: text/plain
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
       labels:
         k8s.ngrok.com/controller-name: test-manager-name
         k8s.ngrok.com/controller-namespace: test-manager-namespace
-      name: e3b0c-test-service-2-default-8080
+      name: e3b0c-test-service-1-default-8080
       namespace: default
     spec:
-      url: "https://e3b0c-test-service-2-default-8080.internal"
+      url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
-        url: "http://test-service-2.default:8080"
+        url: "http://test-service-1.default:8080"
       bindings:
       - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-invalid-mapping-strategy.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-invalid-mapping-strategy.yaml
@@ -1,0 +1,115 @@
+# Tests that invalid values for the mapping-strategy cause a fallback to the default collapsed endpoints translation
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "foo" # This isn't a valid value so we should fall back to the default behaviour
+    spec:
+      gatewayClassName: ngrok
+      infrastructure:
+        annotations:
+          annotation-key: annotation-val
+        labels:
+          label-key: label-val
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      annotations:
+        annotation-key: annotation-val
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+        label-key: label-val
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://test-hostname.ngrok.io"
+      upstream:
+        url: "http://test-service-1.default:8080"
+      bindings:
+      - "public"
+      trafficPolicy:
+        inline:
+          on_http_request:
+            - name: Initialize-Local-Service-Match
+              actions:
+                - type: set-vars
+                  config:
+                    vars:
+                    - request_matched_local_svc: false
+            - name: Generated-Local-Service-Route
+              expressions:
+                - "req.url.path.startsWith('/test-service-1')"
+                - "vars.request_matched_local_svc == false"
+              actions:
+                - type: set-vars
+                  config:
+                    vars:
+                    - request_matched_local_svc: true
+            - name: Fallback-404
+              expressions:
+              - "vars.request_matched_local_svc == false"
+              actions:
+              - type: custom-response
+                config:
+                  status_code: 404
+                  content: "No route was found for this ngrok Endpoint"
+                  headers:
+                    content-type: text/plain

--- a/pkg/managerdriver/testdata/translator/gwapi-invalid-gateway-addresses.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-invalid-gateway-addresses.yaml
@@ -1,0 +1,74 @@
+# Tests translation for a Gateway that is invalid because the spec.addresses does not specify the type (and the default is IPAddress)
+# and another that specifies an IP address even though it says it is a Hostname
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - value: test-hostname.ngrok.io
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TLS
+        - name: p7000
+          port: 7000
+          protocol: TLS
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway-2
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: 192.168.1.1
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TLS
+        - name: p7000
+          port: 7000
+          protocol: TLS
+  tlsRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TLSRoute
+    metadata:
+      name: example-tlsroute
+      namespace: default
+    spec:
+      parentRefs:
+        - name: test-gateway
+        - name: test-gateway-2
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 11000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints: []

--- a/pkg/managerdriver/testdata/translator/gwapi-listener-port-and-protocol.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-listener-port-and-protocol.yaml
@@ -82,7 +82,7 @@ expected:
                 actions:
                   - type: forward-internal
                     config:
-                      url: "https://e3b0c-test-service-1-default-8080.internal"
+                      url: "http://e3b0c-test-service-1-default-8080.internal"
               - name: Fallback-404
                 actions:
                 - type: custom-response
@@ -102,7 +102,7 @@ expected:
       name: e3b0c-test-service-1-default-8080
       namespace: default
     spec:
-      url: "https://e3b0c-test-service-1-default-8080.internal"
+      url: "http://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
       bindings:

--- a/pkg/managerdriver/testdata/translator/gwapi-listner-doesnt-match-gateway-address.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-listner-doesnt-match-gateway-address.yaml
@@ -1,0 +1,68 @@
+# Tests that the following Gateway is discarded because one of the listeners does not match the address in the Gateway
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: foo.ngrok.io
+      listeners:
+        - name: test-hostname
+          hostname: "*.example.com" # Does not match Gateway address
+          port: 80
+          protocol: HTTPS
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - foo.example.com
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints: []

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-invalid-edges.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-invalid-edges.yaml
@@ -1,0 +1,59 @@
+# Tests translation for a simple TCPRoute and Gateway, but the Gateway specifies edges which is invalid for the TCPRoute
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "edges"
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TCP
+        - name: p7000 # Nothing matches this, so it should not result in any endpoints
+          port: 7000
+          protocol: TCP
+  tcpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TCPRoute
+    metadata:
+      name: example-tcproute
+      namespace: default
+    spec:
+      parentRefs:
+        - name: test-gateway
+          sectionName: p9000 # Match a specific listener on the gateway and ignore the other
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: tcp
+        port: 11000
+        protocol: TCP
+        targetPort: tcp
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints: []

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-multigateway.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-multigateway.yaml
@@ -1,0 +1,189 @@
+# Tests translation for a TCPRoute and two Gateways. Each Gateway specifies a hostname and a TCP listener with a port.
+# This means we should get 2 cloud endpoints (2 hostnames * 1 ports for each hostname) and 2 agent endpoints for the upstream services
+# since we are providing a mapping-strategy annotation to perform the endpoints-verbose translation
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TCP
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway-2
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname-2.ngrok.io
+      listeners:
+        - name: p7000
+          port: 7000
+          protocol: TCP
+  tcpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TCPRoute
+    metadata:
+      name: example-tcproute
+      namespace: default
+    spec:
+      hostnames:
+      - "*.ngrok.io"
+      parentRefs:
+        - name: test-gateway
+        - name: test-gateway-2
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+        - backendRefs:
+            - name: test-service-2
+              port: 12000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: tcp
+        port: 11000
+        protocol: TCP
+        targetPort: tcp
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: tcp
+        port: 12000
+        protocol: TCP
+        targetPort: tcp
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default.9000-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-2-default.internal:12000"
+      url: tcp://test-hostname.ngrok.io:9000
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway-2.default.7000-test-hostname-2.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-2-default.internal:12000"
+      url: tcp://test-hostname-2.ngrok.io:7000
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-11000
+      namespace: default
+    spec:
+      url: "tcp://e3b0c-test-service-1-default.internal:11000"
+      upstream:
+        url: "tcp://test-service-1.default:11000"
+      bindings:
+      - "internal"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-2-default-12000
+      namespace: default
+    spec:
+      url: "tcp://e3b0c-test-service-2-default.internal:12000"
+      upstream:
+        url: "tcp://test-service-2.default:12000"
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-multihost.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-multihost.yaml
@@ -1,0 +1,247 @@
+# Tests translation for a TCPRoute and Gateway, the Gateway specifies two hostnames, and has 2 TCP listeners on two different ports.
+# This means we should get 4 cloud endpoints (2 hostnames * 2 ports for each hostname) and 2 agent endpoints for the upstream services
+# since we are providing a mapping-strategy annotation to perform the endpoints-verbose translation
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      - type: Hostname
+        value: test-hostname-2.ngrok.io
+      listeners:
+        - name: upstream-1
+          port: 9000
+          protocol: TCP
+        - name: upstream-2
+          port: 7000
+          protocol: TCP
+  tcpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TCPRoute
+    metadata:
+      name: example-tcproute
+      namespace: default
+    spec:
+      hostnames:
+      - "*.ngrok.io"
+      parentRefs:
+        - name: test-gateway
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+        - backendRefs:
+            - name: test-service-2
+              port: 12000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: tcp
+        port: 11000
+        protocol: TCP
+        targetPort: tcp
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: tcp
+        port: 12000
+        protocol: TCP
+        targetPort: tcp
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default.9000-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-2-default.internal:12000"
+      url: tcp://test-hostname.ngrok.io:9000
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default.7000-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-2-default.internal:12000"
+      url: tcp://test-hostname.ngrok.io:7000
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default.9000-test-hostname-2.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-2-default.internal:12000"
+      url: tcp://test-hostname-2.ngrok.io:9000
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default.7000-test-hostname-2.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-2-default.internal:12000"
+      url: tcp://test-hostname-2.ngrok.io:7000
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-11000
+      namespace: default
+    spec:
+      url: "tcp://e3b0c-test-service-1-default.internal:11000"
+      upstream:
+        url: "tcp://test-service-1.default:11000"
+      bindings:
+      - "internal"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-2-default-12000
+      namespace: default
+    spec:
+      url: "tcp://e3b0c-test-service-2-default.internal:12000"
+      upstream:
+        url: "tcp://test-service-2.default:12000"
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-simple.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-simple.yaml
@@ -1,0 +1,72 @@
+# Tests translation for a simple TCPRoute and Gateway.
+# Since we aren't providing a mapping-strategy annotation, the default behaviour should translate this into an AgentEndpoint
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TCP
+        - name: p7000 # Nothing matches this, so it should not result in any endpoints
+          port: 7000
+          protocol: TCP
+  tcpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TCPRoute
+    metadata:
+      name: example-tcproute
+      namespace: default
+    spec:
+      parentRefs:
+        - name: test-gateway
+          sectionName: p9000 # Match a specific listener on the gateway and ignore the other
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: tcp
+        port: 11000
+        protocol: TCP
+        targetPort: tcp
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-11000
+      namespace: default
+    spec:
+      url: "tcp://test-hostname.ngrok.io:9000"
+      upstream:
+        url: "tcp://test-service-1.default:11000"
+      bindings:
+      - "public"

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-tls-upstream.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-tls-upstream.yaml
@@ -1,0 +1,74 @@
+# Tests translation for a simple TCPRoute and Gateway. The Service has an annotation specifying that the upstream expects TLS
+# Since we aren't providing a mapping-strategy annotation, the default behaviour should translate this into an AgentEndpoint
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TCP
+        - name: p7000 # Nothing matches this, so it should not result in any endpoints
+          port: 7000
+          protocol: TCP
+  tcpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TCPRoute
+    metadata:
+      name: example-tcproute
+      namespace: default
+    spec:
+      parentRefs:
+        - name: test-gateway
+          sectionName: p9000 # Match a specific listener on the gateway and ignore the other
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+      annotations:
+        k8s.ngrok.com/app-protocols: '{"tls":"tLs"}' # Tells the controller that the upstream scheme is different from the public URL scheme
+    spec:
+      ports:
+      - name: tls
+        port: 11000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-11000
+      namespace: default
+    spec:
+      url: "tcp://test-hostname.ngrok.io:9000"
+      upstream:
+        url: "tls://test-service-1.default:11000"
+      bindings:
+      - "public"

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-weighted.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-weighted.yaml
@@ -1,0 +1,135 @@
+# Tests translation for a TCPRoute and Gateway where the TCPRoute has multiple backends.
+# Since we aren't providing a mapping-strategy annotation, the default behaviour should translate this into AgentEndpoints
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TCP
+        - name: p7000 # Nothing matches this, so it should not result in any endpoints
+          port: 7000
+          protocol: TCP
+  tcpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TCPRoute
+    metadata:
+      name: example-tcproute
+      namespace: default
+    spec:
+      parentRefs:
+        - name: test-gateway
+          port: 9000 # Match a specific listener on the gateway and ignore the other
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+        - backendRefs:
+            - name: test-service-2
+              port: 12000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: tcp
+        port: 11000
+        protocol: TCP
+        targetPort: tcp
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: tcp
+        port: 12000
+        protocol: TCP
+        targetPort: tcp
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-2-default-12000
+      namespace: default
+    spec:
+      url: "tcp://test-hostname.ngrok.io:9000"
+      upstream:
+        url: "tcp://test-service-2.default:12000"
+      bindings:
+      - "public"
+      trafficPolicy:
+        inline:
+          on_tcp_connect:
+          - name: Initialize-Local-Service-Match
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: false
+          - name: Gen-Random-Number
+            expressions:
+            - "vars.request_matched_local_svc == false"
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - vars.request_matched_local_svc == false
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tcp://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Local-Service-Route
+            expressions:
+            - vars.request_matched_local_svc == false
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: set-vars
+                config:
+                  vars: 
+                  - request_matched_local_svc: true
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-11000
+      namespace: default
+    spec:
+      url: "tcp://e3b0c-test-service-1-default.internal:11000"
+      upstream:
+        url: "tcp://test-service-1.default:11000"
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-tls-tcp-routes-collapsed.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tls-tcp-routes-collapsed.yaml
@@ -1,0 +1,127 @@
+# Tests translation for a TLSRoute and TCPRoute that both get collapsed into an AgentEndpoint with no traffic policy
+# Since we aren't providing a mapping-strategy annotation, the default mapping-strategy should collapse them
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: tcp.ngrok.io-3
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: 3.tcp.ngrok.io
+      listeners:
+      - allowedRoutes:
+          namespaces:
+            from: Same
+        name: test-tls
+        port: 20183
+        protocol: TLS
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: tcp.ngrok.io-5
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: 5.tcp.ngrok.io
+      listeners:
+      - allowedRoutes:
+          namespaces:
+            from: Same
+        name: test-tcp
+        port: 24429
+        protocol: TCP
+  tcpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TCPRoute
+    metadata:
+      name: example
+      namespace: default
+    spec:
+      parentRefs:
+        - name: tcp.ngrok.io-5
+      rules:
+        - backendRefs:
+            - name: test-service-tcp
+              port: 7000
+  tlsRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TLSRoute
+    metadata:
+      name: example
+      namespace: default
+    spec:
+      parentRefs:
+        - name: tcp.ngrok.io-3
+      rules:
+        - backendRefs:
+            - name: test-service-tls
+              port: 9000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-tcp
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 7000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-tls
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 9000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-tcp-default-7000
+      namespace: default
+    spec:
+      url: "tcp://5.tcp.ngrok.io:24429"
+      upstream:
+        url: "tcp://test-service-tcp.default:7000"
+      bindings:
+      - "public"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-tls-default-9000
+      namespace: default
+    spec:
+      url: "tls://3.tcp.ngrok.io:20183"
+      upstream:
+        url: "tls://test-service-tls.default:9000"
+      bindings:
+      - "public"

--- a/pkg/managerdriver/testdata/translator/gwapi-tls-tcp-routes-invalid-backendrefs.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tls-tcp-routes-invalid-backendrefs.yaml
@@ -1,0 +1,109 @@
+# Tests translation for a TLSRoute and TCPRoute and TCPRoute that have invalid backend refs that should be ignored.
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: tcp.ngrok.io-3
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: 3.tcp.ngrok.io
+      listeners:
+      - allowedRoutes:
+          namespaces:
+            from: Same
+        name: test-tls
+        port: 20183
+        protocol: TLS
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: tcp.ngrok.io-5
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: 5.tcp.ngrok.io
+      listeners:
+      - allowedRoutes:
+          namespaces:
+            from: Same
+        name: test-tcp
+        port: 24429
+        protocol: TCP
+  tcpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TCPRoute
+    metadata:
+      name: example
+      namespace: default
+    spec:
+      parentRefs:
+        - name: tcp.ngrok.io-5
+      rules:
+        - backendRefs:
+            - name: test-service-tcp
+              port: 7000
+              kind: "foo" # Not a valid kind
+            - name: test-service-foo # Service does not exist
+              port: 7000
+            - name: test-service-tcp
+              port: 12000 # Port not valid for service
+            - name: test-service-tcp # Port not specified
+  tlsRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TLSRoute
+    metadata:
+      name: example
+      namespace: default
+    spec:
+      parentRefs:
+        - name: tcp.ngrok.io-3
+      rules:
+            - name: test-service-tls
+              port: 9000
+              kind: "foo" # Not a valid kind
+            - name: test-service-foo # Service does not exist
+              port: 9000
+            - name: test-service-tls
+              port: 12000 # Port not valid for service
+            - name: test-service-tls # Port not specified
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-tcp
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 7000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-tls
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 9000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints: []

--- a/pkg/managerdriver/testdata/translator/gwapi-tls-term-with-http.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tls-term-with-http.yaml
@@ -1,0 +1,78 @@
+# Tests that the following listener is ignored because it defines TLS configuration for an HTTP protocol listener
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 80
+          protocol: HTTP
+          tls:
+            mode: Terminate
+            certificateRefs:
+            - kind: Secret
+              name: tls-secret
+            frontendValidation:
+              caCertificateRefs:
+              - kind: ConfigMap
+                name: ca-configmap
+            options:
+              "k8s.ngrok.com/terminate-tls.min_version": "1.2"
+              "k8s.ngrok.com/terminate-tls.max_version": "1.3"
+              "k8s.ngrok.com/terminate-tls.mutual_tls_verification_strategy": "require-and-verify"
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /test-service-1
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints: []

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multigateway.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multigateway.yaml
@@ -1,0 +1,189 @@
+# Tests translation for a TLSRoute and two Gateways. Each Gateway specifies a hostname and a TLS listener with a port.
+# This means we should get 2 cloud endpoints (2 hostnames * 1 ports for each hostname) and 2 agent endpoints for the upstream services
+# since we are providing a mapping-strategy annotation to perform the endpoints-verbose translation
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TLS
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway-2
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname-2.ngrok.io
+      listeners:
+        - name: p7000
+          port: 7000
+          protocol: TLS
+  tlsRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TLSRoute
+    metadata:
+      name: example-tlsroute
+      namespace: default
+    spec:
+      hostnames:
+      - "*.ngrok.io"
+      parentRefs:
+        - name: test-gateway
+        - name: test-gateway-2
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+        - backendRefs:
+            - name: test-service-2
+              port: 12000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 11000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 12000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default.9000-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-2-default.internal:12000"
+      url: tls://test-hostname.ngrok.io:9000
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway-2.default.7000-test-hostname-2.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-2-default.internal:12000"
+      url: tls://test-hostname-2.ngrok.io:7000
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-11000
+      namespace: default
+    spec:
+      url: "tls://e3b0c-test-service-1-default.internal:11000"
+      upstream:
+        url: "tls://test-service-1.default:11000"
+      bindings:
+      - "internal"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-2-default-12000
+      namespace: default
+    spec:
+      url: "tls://e3b0c-test-service-2-default.internal:12000"
+      upstream:
+        url: "tls://test-service-2.default:12000"
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multihost.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multihost.yaml
@@ -1,0 +1,247 @@
+# Tests translation for a TLSRoute and Gateway, the Gateway specifies two hostnames, and has 2 TLS listeners on two different ports.
+# This means we should get 4 cloud endpoints (2 hostnames * 2 ports for each hostname) and 2 agent endpoints for the upstream services
+# since we are providing a mapping-strategy annotation to perform the endpoints-verbose translation
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      - type: Hostname
+        value: test-hostname-2.ngrok.io
+      listeners:
+        - name: upstream-1
+          port: 9000
+          protocol: TLS
+        - name: upstream-2
+          port: 7000
+          protocol: TLS
+  tlsRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TLSRoute
+    metadata:
+      name: example-tlsroute
+      namespace: default
+    spec:
+      hostnames:
+      - "*.ngrok.io"
+      parentRefs:
+        - name: test-gateway
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+        - backendRefs:
+            - name: test-service-2
+              port: 12000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 11000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 12000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default.9000-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-2-default.internal:12000"
+      url: tls://test-hostname.ngrok.io:9000
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default.7000-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-2-default.internal:12000"
+      url: tls://test-hostname.ngrok.io:7000
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default.9000-test-hostname-2.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-2-default.internal:12000"
+      url: tls://test-hostname-2.ngrok.io:9000
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default.7000-test-hostname-2.ngrok.io
+      namespace: default
+    spec:
+      bindings:
+      - public
+      trafficPolicy:
+        policy:
+          on_tcp_connect:
+          - name: Gen-Random-Number
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Route
+            expressions:
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-2-default.internal:12000"
+      url: tls://test-hostname-2.ngrok.io:7000
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-11000
+      namespace: default
+    spec:
+      url: "tls://e3b0c-test-service-1-default.internal:11000"
+      upstream:
+        url: "tls://test-service-1.default:11000"
+      bindings:
+      - "internal"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-2-default-12000
+      namespace: default
+    spec:
+      url: "tls://e3b0c-test-service-2-default.internal:12000"
+      upstream:
+        url: "tls://test-service-2.default:12000"
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-simple.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-simple.yaml
@@ -1,0 +1,72 @@
+# Tests translation for a simple TLSRoute and Gateway.
+# Since we aren't providing a mapping-strategy annotation, the default behaviour should translate this into an AgentEndpoint
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TLS
+        - name: p7000 # Nothing matches this, so it should not result in any endpoints
+          port: 7000
+          protocol: TLS
+  tlsRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TLSRoute
+    metadata:
+      name: example-tlsroute
+      namespace: default
+    spec:
+      parentRefs:
+        - name: test-gateway
+          sectionName: p9000 # Match a specific listener on the gateway and ignore the other
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 11000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-11000
+      namespace: default
+    spec:
+      url: "tls://test-hostname.ngrok.io:9000"
+      upstream:
+        url: "tls://test-service-1.default:11000"
+      bindings:
+      - "public"

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-tcp-upstream.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-tcp-upstream.yaml
@@ -1,0 +1,74 @@
+# Tests translation for a simple TLSRoute and Gateway. The Service has an annotation specifying that the upstream expects TLS
+# Since we aren't providing a mapping-strategy annotation, the default behaviour should translate this into an AgentEndpoint
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TLS
+        - name: p7000 # Nothing matches this, so it should not result in any endpoints
+          port: 7000
+          protocol: TLS
+  tlsRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TLSRoute
+    metadata:
+      name: example-tlsroute
+      namespace: default
+    spec:
+      parentRefs:
+        - name: test-gateway
+          sectionName: p9000 # Match a specific listener on the gateway and ignore the other
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+      annotations:
+        k8s.ngrok.com/app-protocols: '{"tcp":"tCp"}' # Tells the controller that the upstream scheme is different from the public URL scheme
+    spec:
+      ports:
+      - name: tcp
+        port: 11000
+        protocol: TCP
+        targetPort: tcp
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-11000
+      namespace: default
+    spec:
+      url: "tls://test-hostname.ngrok.io:9000"
+      upstream:
+        url: "tcp://test-service-1.default:11000"
+      bindings:
+      - "public"

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-weighted.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-weighted.yaml
@@ -1,0 +1,135 @@
+# Tests translation for a TLSRoute and Gateway where the TLSRoute has multiple backends.
+# Since we aren't providing a mapping-strategy annotation, the default behaviour should translate this into AgentEndpoints
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+    spec:
+      gatewayClassName: ngrok
+      addresses:
+      - type: Hostname
+        value: test-hostname.ngrok.io
+      listeners:
+        - name: p9000
+          port: 9000
+          protocol: TLS
+        - name: p7000 # Nothing matches this, so it should not result in any endpoints
+          port: 7000
+          protocol: TLS
+  tlsRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: TLSRoute
+    metadata:
+      name: example-tlsroute
+      namespace: default
+    spec:
+      parentRefs:
+        - name: test-gateway
+          port: 9000 # Match a specific listener on the gateway and ignore the other
+      rules:
+        - backendRefs:
+            - name: test-service-1
+              port: 11000
+        - backendRefs:
+            - name: test-service-2
+              port: 12000
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 11000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-2
+      namespace: default
+    spec:
+      ports:
+      - name: tls
+        port: 12000
+        protocol: TCP
+        targetPort: tls
+      type: ClusterIP
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-2-default-12000
+      namespace: default
+    spec:
+      url: "tls://test-hostname.ngrok.io:9000"
+      upstream:
+        url: "tls://test-service-2.default:12000"
+      bindings:
+      - "public"
+      trafficPolicy:
+        inline:
+          on_tcp_connect:
+          - name: Initialize-Local-Service-Match
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: false
+          - name: Gen-Random-Number
+            expressions:
+            - "vars.request_matched_local_svc == false"
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - "weighted_route_random_num": "${rand.int(0,1)}"
+          - name: Generated-Route
+            expressions:
+            - vars.request_matched_local_svc == false
+            - "int(vars.weighted_route_random_num) <= 0"
+            actions:
+              - type: forward-internal
+                config:
+                  url: "tls://e3b0c-test-service-1-default.internal:11000"
+          - name: Generated-Local-Service-Route
+            expressions:
+            - vars.request_matched_local_svc == false
+            - "int(vars.weighted_route_random_num) >= 1 && int(vars.weighted_route_random_num) <= 1"
+            actions:
+              - type: set-vars
+                config:
+                  vars: 
+                  - request_matched_local_svc: true
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-11000
+      namespace: default
+    spec:
+      url: "tls://e3b0c-test-service-1-default.internal:11000"
+      upstream:
+        url: "tls://test-service-1.default:11000"
+      bindings:
+      - "internal"

--- a/pkg/managerdriver/translate_gatewayapi.go
+++ b/pkg/managerdriver/translate_gatewayapi.go
@@ -3,6 +3,7 @@ package managerdriver
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/ngrok/ngrok-operator/internal/annotations"
@@ -15,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 const (
@@ -41,15 +43,9 @@ type GatewayMatch struct {
 // With ingress translation into ir/endpoints, we merge routes for the same hostname across all ingresses, but with
 // gateway API, we will only merge routes for the same gateway.
 func (t *translator) gatewayAPIToIR() []*ir.IRVirtualHost {
-	// Note: currently we don't do anything with Gateway.Spec.Addresses. It might be possible to support them, but
-	// given the nature of how ngrok endpoints work, I'm not sure it makes much sense for us to support this extended field
-
-	// TODO: (Alice) add support for gateway.BackendTLS in a follow-up. It requires changes in the AgentEndpoint fields and handling
-
 	virtualHostsPerGateway := make(map[types.NamespacedName]map[ir.IRListener]*ir.IRVirtualHost) // We key the list of virtual hosts by the gateway they are for
 	upstreamCache := make(map[ir.IRServiceKey]*ir.IRUpstream)                                    // Each unique service/port combo corresponds to one IRUpstream
 	gateways := t.store.ListGateways()
-	httpRoutes := t.store.ListHTTPRoutes()
 
 	// Add all of the gateways to a map for efficient lookup
 	gatewayMap := make(map[types.NamespacedName]*gatewayv1.Gateway)
@@ -60,8 +56,17 @@ func (t *translator) gatewayAPIToIR() []*ir.IRVirtualHost {
 		}] = gateway
 	}
 
+	httpRoutes := t.store.ListHTTPRoutes()
 	for _, httpRoute := range httpRoutes {
 		t.HTTPRouteToIR(httpRoute, upstreamCache, gatewayMap, virtualHostsPerGateway)
+	}
+	tcpRoutes := t.store.ListTCPRoutes()
+	for _, tcpRoute := range tcpRoutes {
+		t.TCPRouteToIR(tcpRoute, upstreamCache, gatewayMap, virtualHostsPerGateway)
+	}
+	tlsRoutes := t.store.ListTLSRoutes()
+	for _, tlsRoute := range tlsRoutes {
+		t.TLSRouteToIR(tlsRoute, upstreamCache, gatewayMap, virtualHostsPerGateway)
 	}
 
 	vHostSlice := []*ir.IRVirtualHost{}
@@ -74,25 +79,24 @@ func (t *translator) gatewayAPIToIR() []*ir.IRVirtualHost {
 	return vHostSlice
 }
 
-// #region HTTPRoute to IR
-
-// HTTPRouteToIR translates a single HTTPRoute into IR by finding which Gateways it matches and adding the rules from the HTTPRoute
-// as routes on the VirtualHost(s)
-func (t *translator) HTTPRouteToIR(
-	httpRoute *gatewayv1.HTTPRoute,
-	upstreamCache map[ir.IRServiceKey]*ir.IRUpstream,
-	gatewayMap map[types.NamespacedName]*gatewayv1.Gateway,
+func (t *translator) findMatchingVHostsForXRoute(
 	virtualHostsPerGateway map[types.NamespacedName]map[ir.IRListener]*ir.IRVirtualHost,
-) {
+	gatewayMap map[types.NamespacedName]*gatewayv1.Gateway,
+	routeName string,
+	routeNamespace string,
+	routeKind xRouteKind,
+	routeParentRefs []gatewayv1.ParentReference,
+	routeHostnames ...string,
+) map[*ir.IRVirtualHost]bool {
 	vHostsMatchingRoute := make(map[*ir.IRVirtualHost]bool)
 
-	// First, go through the HTTPRoute's parentRefs to find matching gateways and figure out which hostnames within those matching
-	// gateways this HTTPRoute matches. Along the way, build/update virtual hosts for all the hostnames this HTTPRoute matches
-	for _, parentRef := range httpRoute.Spec.ParentRefs {
+	// First, go through the route's parentRefs to find matching gateways and figure out which hostnames within those matching
+	// gateways this route matches. Along the way, build/update virtual hosts for all the hostnames this route matches
+	for _, parentRef := range routeParentRefs {
 
-		// Check matching Gateways for this HTTPRoute
+		// Check matching Gateways for this route
 		// The controller already filters the resources based on our gateway class, so no need to check that here
-		refNamespace := string(httpRoute.Namespace)
+		refNamespace := string(routeNamespace)
 		if parentRef.Namespace != nil {
 			refNamespace = string(*parentRef.Namespace)
 		}
@@ -103,11 +107,33 @@ func (t *translator) HTTPRouteToIR(
 		}
 		gateway, exists := gatewayMap[gatewayKey]
 		if !exists {
-			t.log.Error(fmt.Errorf("HTTPRoute parent ref not found"), "the HTTPRoute lists a Gateway parent ref that does not exist",
-				"httproute", fmt.Sprintf("%s.%s", httpRoute.Name, httpRoute.Namespace),
+			t.log.Error(fmt.Errorf("%s parent ref not found", routeKind), fmt.Sprintf("the %q lists a Gateway parent ref that does not exist", routeKind),
+				string(routeKind), fmt.Sprintf("%s.%s", routeName, routeNamespace),
 				"parentRef", fmt.Sprintf("%s.%s", string(parentRef.Name), refNamespace),
 			)
 			continue
+		}
+
+		// Grab all the hostnames from the Gateway's addresses field. We don't currently allow IP addresses to be specified here, only hostnames
+		gatewayAddressHostnames := []string{}
+		for _, gatewayAddress := range gateway.Spec.Addresses {
+			if gatewayAddress.Type == nil || *gatewayAddress.Type != gatewayv1.HostnameAddressType {
+				t.log.Error(fmt.Errorf("invalid Gateway. non-hostname address in spec.addresses"), "this Gateway will be skipped. only hostname type addresses are supported at the moment. The default type is IPAddress, so the type must explicitly be set to \"Hostname\"",
+					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+					"address value", gatewayAddress.Value,
+				)
+				continue
+			}
+
+			if net.ParseIP(gatewayAddress.Value) != nil {
+				t.log.Error(fmt.Errorf("ip address used as address value in spec.addresses"), "this Gateway will be skipped. only hostname type addresses are supported at the moment.",
+					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+					"address value", gatewayAddress.Value,
+				)
+				continue
+			}
+
+			gatewayAddressHostnames = appendStringUnique(gatewayAddressHostnames, gatewayAddress.Value)
 		}
 
 		// We currently require this annotation to be present for an Ingress to be translated into CloudEndpoints/AgentEndpoints, otherwise the default behaviour is to
@@ -118,10 +144,18 @@ func (t *translator) HTTPRouteToIR(
 			t.log.Error(err, fmt.Sprintf("failed to check %q annotation. defaulting to using endpoints", annotations.MappingStrategyAnnotation))
 		}
 		if mappingStrategy == ir.IRMappingStrategy_Edges {
-			t.log.Info(fmt.Sprintf("the Gateway and its HTTPRoutes will be provided by ngrok edges instead of endpoints because of the %q annotation",
-				annotations.MappingStrategyAnnotation),
-				"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
-			)
+			if routeKind != xRouteKind_HTTPRoute {
+				t.log.Error(fmt.Errorf("%ss cannot be used on Gateways with the the %q annotation because Edges are not supported for %ss", routeKind, annotations.MappingStrategyAnnotation, routeKind), "the TCPRoute will be ignored for this Gateway",
+					string(routeKind), fmt.Sprintf("%s.%s", routeName, routeNamespace),
+					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+				)
+			} else {
+				t.log.Info(fmt.Sprintf("the Gateway and its routes will be provided by ngrok edges instead of endpoints because of the %q annotation",
+					annotations.MappingStrategyAnnotation),
+					string(routeKind), fmt.Sprintf("%s.%s", routeName, routeNamespace),
+					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+				)
+			}
 			continue
 		}
 
@@ -130,7 +164,7 @@ func (t *translator) HTTPRouteToIR(
 			t.log.Error(err, fmt.Sprintf("failed to check %q annotation", annotations.MappingStrategyAnnotation))
 		}
 		if useEndpointPooling {
-			t.log.Info(fmt.Sprintf("the following Gateway and its HTTPRoutes will create endpoint(s) with pooling enabled because of the %q annotation",
+			t.log.Info(fmt.Sprintf("the following Gateway and its routes will create endpoint(s) with pooling enabled because of the %q annotation",
 				annotations.MappingStrategyAnnotation),
 				"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
 			)
@@ -181,23 +215,38 @@ func (t *translator) HTTPRouteToIR(
 			})
 		}
 
-		matchingListeners := t.matchingGatewayListenersForHTTPRoute(gateway, httpRoute)
+		matchingListeners := t.matchGatewayListenersToXRoute(gateway, gatewayAddressHostnames, routeNamespace, routeKind, parentRef.SectionName, parentRef.Port, routeHostnames...)
 		for _, matchingListener := range matchingListeners {
 			tlsTermCfg := matchingListener.TLS
 			if tlsTermCfg != nil {
-				if tlsTermCfg.Mode != nil && *tlsTermCfg.Mode == gatewayv1.TLSModePassthrough {
-					t.log.Error(fmt.Errorf("TLS passthrough mode is not currently supported"), "skipping gateway listener for HTTPRoutes because the tls mode is set to passthrough",
+
+				switch matchingListener.Protocol {
+				case gatewayv1.HTTPSProtocolType:
+					if tlsTermCfg.Mode != nil && *tlsTermCfg.Mode == gatewayv1.TLSModePassthrough {
+						t.log.Error(fmt.Errorf("TLS passthrough mode is not possible for HTTPS endpoints, you can use a TLS protocol listener for this functionality"), "skipping gateway listener for HTTPRoutes because the tls mode is set to passthrough",
+							"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+						)
+						continue
+					}
+				// HTTP and TCP endpoints don't do TLS, use HTTPS/TLS endpoints instead
+				case gatewayv1.HTTPProtocolType, gatewayv1.TCPProtocolType:
+					t.log.Error(fmt.Errorf("TLS termination is not supported for HTTP and TCP listeners. You can use an HTTPS/TLS listener for this functionality"), "skipping gateway listener",
 						"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
 					)
 					continue
 				}
 			}
-			irTLSTermination, err := t.gatewayTLSTermConfigToIR(tlsTermCfg, gateway)
-			if err != nil {
-				t.log.Error(err, "skipping gateway listener with invalid TLS configuration",
-					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
-				)
-				continue
+
+			var irTLSTermination *ir.IRTLSTermination
+			// No TLS termination for TCP and HTTP protocol listeners
+			if matchingListener.Protocol == gatewayv1.TLSProtocolType || matchingListener.Protocol == gatewayv1.HTTPSProtocolType {
+				irTLSTermination, err = t.gatewayTLSTermConfigToIR(tlsTermCfg, gateway)
+				if err != nil {
+					t.log.Error(err, "skipping gateway listener with invalid TLS configuration",
+						"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+					)
+					continue
+				}
 			}
 
 			// Check if this Gateway already has any virtual hosts
@@ -208,66 +257,103 @@ func (t *translator) HTTPRouteToIR(
 				virtualHostsPerGateway[gatewayKey] = vHostsForCurrentGateway
 			}
 
-			// Check if this Gateway already has an irVHost for this specific hostname, otherwise make one
-			irListener := ir.IRListener{
-				Hostname: ir.IRHostname(*matchingListener.Hostname),
-				Port:     int32(matchingListener.Port),
+			// If the Gateway specifies spec.addresses, use those for the hostnames for the endpoints, otherwise, use the listener's hostname
+
+			var virtualHostHostnames []string
+			if len(gatewayAddressHostnames) == 0 {
+				virtualHostHostnames = []string{string(*matchingListener.Hostname)}
+			} else {
+				virtualHostHostnames = gatewayAddressHostnames
 			}
 
-			switch matchingListener.Protocol {
-			case gatewayv1.HTTPProtocolType:
-				irListener.Protocol = ir.IRProtocol_HTTP
-			case gatewayv1.HTTPSProtocolType:
-				irListener.Protocol = ir.IRProtocol_HTTPS
-			default:
-				t.log.Error(fmt.Errorf("gateway with unsupported listener protocol"), "currently only HTTPRoutes are supported. listeners with TCP/TLS/UDP protocols will be skipped",
-					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
-				)
-				continue
-			}
+			for _, virtualHostHostname := range virtualHostHostnames {
+				// Check if this Gateway already has an irVHost for this specific hostname, otherwise make one
+				irListener := ir.IRListener{
+					Hostname: ir.IRHostname(virtualHostHostname),
+					Port:     int32(matchingListener.Port),
+				}
 
-			irVHost, exists := vHostsForCurrentGateway[irListener]
-			if !exists {
-				// Add a name prefix with the gateway name so that we can support endpoint pooling across multiple gateways
-				namePrefix := fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace)
-				irVHost = &ir.IRVirtualHost{
-					NamePrefix:             &namePrefix,
-					Namespace:              gateway.Namespace,
-					Listener:               irListener,
-					TLSTermination:         irTLSTermination,
-					LabelsToAdd:            t.managedResourceLabels,
-					AnnotationsToAdd:       make(map[string]string),
-					EndpointPoolingEnabled: useEndpointPooling,
-					TrafficPolicy:          annotationTrafficPolicy,
-					TrafficPolicyObj:       tpObjRef,
-					Metadata:               t.defaultGatewayMetadata,
-					Bindings:               bindings,
-					ClientCertRefs:         upstreamClientCertRefs,
-					MappingStrategy:        mappingStrategy,
+				switch matchingListener.Protocol {
+				case gatewayv1.HTTPProtocolType:
+					irListener.Protocol = ir.IRProtocol_HTTP
+				case gatewayv1.HTTPSProtocolType:
+					irListener.Protocol = ir.IRProtocol_HTTPS
+				case gatewayv1.TCPProtocolType:
+					irListener.Protocol = ir.IRProtocol_TCP
+				case gatewayv1.TLSProtocolType:
+					irListener.Protocol = ir.IRProtocol_TLS
+				default:
+					// Ignore other listener protocols
+					continue
 				}
+
+				irVHost, exists := vHostsForCurrentGateway[irListener]
+				if !exists {
+					// Add a name prefix with the gateway name so that we can support endpoint pooling across multiple gateways
+					namePrefix := fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace)
+
+					if irListener.Protocol == ir.IRProtocol_TCP || irListener.Protocol == ir.IRProtocol_TLS {
+						namePrefix += fmt.Sprintf(".%d", int32(matchingListener.Port))
+					}
+
+					irVHost = &ir.IRVirtualHost{
+						NamePrefix:             &namePrefix,
+						Namespace:              gateway.Namespace,
+						Listener:               irListener,
+						TLSTermination:         irTLSTermination,
+						LabelsToAdd:            t.managedResourceLabels,
+						AnnotationsToAdd:       make(map[string]string),
+						EndpointPoolingEnabled: useEndpointPooling,
+						TrafficPolicy:          annotationTrafficPolicy,
+						TrafficPolicyObjRef:    tpObjRef,
+						Metadata:               t.defaultGatewayMetadata,
+						Bindings:               bindings,
+						ClientCertRefs:         upstreamClientCertRefs,
+						MappingStrategy:        mappingStrategy,
+					}
+				}
+				irVHost.AddOwningResource(ir.OwningResource{
+					Kind:      "Gateway",
+					Name:      gateway.Name,
+					Namespace: gateway.Namespace,
+				})
+				irVHost.AddOwningResource(ir.OwningResource{
+					Kind:      string(routeKind),
+					Name:      routeName,
+					Namespace: routeNamespace,
+				})
+				if gateway.Spec.Infrastructure != nil {
+					for key, val := range gateway.Spec.Infrastructure.Labels {
+						irVHost.LabelsToAdd[string(key)] = string(val)
+					}
+					for key, val := range gateway.Spec.Infrastructure.Annotations {
+						irVHost.AnnotationsToAdd[string(key)] = string(val)
+					}
+				}
+				vHostsMatchingRoute[irVHost] = true
+				vHostsForCurrentGateway[irListener] = irVHost
 			}
-			irVHost.AddOwningResource(ir.OwningResource{
-				Kind:      "Gateway",
-				Name:      gateway.Name,
-				Namespace: gateway.Namespace,
-			})
-			irVHost.AddOwningResource(ir.OwningResource{
-				Kind:      "HTTPRoute",
-				Name:      httpRoute.Name,
-				Namespace: httpRoute.Namespace,
-			})
-			if gateway.Spec.Infrastructure != nil {
-				for key, val := range gateway.Spec.Infrastructure.Labels {
-					irVHost.LabelsToAdd[string(key)] = string(val)
-				}
-				for key, val := range gateway.Spec.Infrastructure.Annotations {
-					irVHost.AnnotationsToAdd[string(key)] = string(val)
-				}
-			}
-			vHostsMatchingRoute[irVHost] = true
-			vHostsForCurrentGateway[irListener] = irVHost
 		}
 	}
+
+	return vHostsMatchingRoute
+}
+
+// #region HTTPRoute to IR
+
+// HTTPRouteToIR translates a single HTTPRoute into IR by finding which Gateways it matches and adding the rules from the HTTPRoute
+// as routes on the VirtualHost(s)
+func (t *translator) HTTPRouteToIR(
+	httpRoute *gatewayv1.HTTPRoute,
+	upstreamCache map[ir.IRServiceKey]*ir.IRUpstream,
+	gatewayMap map[types.NamespacedName]*gatewayv1.Gateway,
+	virtualHostsPerGateway map[types.NamespacedName]map[ir.IRListener]*ir.IRVirtualHost,
+) {
+	var hostnameStrings []string
+	for _, h := range httpRoute.Spec.Hostnames {
+		hostnameStrings = append(hostnameStrings, string(h))
+	}
+	vHostsMatchingRoute := t.findMatchingVHostsForXRoute(virtualHostsPerGateway, gatewayMap, httpRoute.Name, httpRoute.Namespace, xRouteKind_HTTPRoute, httpRoute.Spec.ParentRefs, hostnameStrings...)
 
 	// Now that we have a set of the virtual hosts that are applicable to this HTTPRoute, go through and build new routes
 	// for all the HTTPRoute rules and add them to the matching virtual hosts
@@ -291,19 +377,126 @@ func (t *translator) HTTPRouteToIR(
 	}
 }
 
+// #region TCPRoute to IR
+
+// TCPRouteToIR translates a single TCPRoute into IR by finding which Gateways it matches and adding the backends for the TCPRoute
+// as routes on the VirtualHost(s)
+func (t *translator) TCPRouteToIR(
+	tcpRoute *gatewayv1alpha2.TCPRoute,
+	upstreamCache map[ir.IRServiceKey]*ir.IRUpstream,
+	gatewayMap map[types.NamespacedName]*gatewayv1.Gateway,
+	virtualHostsPerGateway map[types.NamespacedName]map[ir.IRListener]*ir.IRVirtualHost,
+) {
+	vHostsMatchingRoute := t.findMatchingVHostsForXRoute(virtualHostsPerGateway, gatewayMap, tcpRoute.Name, tcpRoute.Namespace, xRouteKind_TCPRoute, tcpRoute.Spec.ParentRefs)
+
+	// Now that we have a set of the virtual hosts that are applicable to this TCPRoute, go through and build new routes
+	// for all the TCPRoute rules and add them to the matching virtual hosts
+
+	// Add all the routes we just processed to all matching virtual hosts
+	for irVHost := range vHostsMatchingRoute {
+		// Note: it would be more efficient to build the routes for the TCPRoute once, then apply them to all matching virtualHosts, but
+		// each Gateway can specify upstream client certificates, so the routes we build are dependent on the current Gateway
+		routeToAdd := t.tcpRouteRulesToIR(irVHost, tcpRoute, upstreamCache)
+		for _, destination := range routeToAdd.Destinations {
+			// Inherit all the virtual host's owning resources
+			if destination.Upstream != nil {
+				for _, owningResource := range irVHost.OwningResources {
+					destination.Upstream.AddOwningResource(owningResource)
+				}
+			}
+		}
+		irVHost.Routes = append(irVHost.Routes, routeToAdd)
+	}
+}
+
+// #region TLSRoute to IR
+
+// TLSRouteToIR translates a single TLSRoute into IR by finding which Gateways it matches and adding the backends for the TLSRoute
+// as routes on the VirtualHost(s)
+func (t *translator) TLSRouteToIR(
+	tlsRoute *gatewayv1alpha2.TLSRoute,
+	upstreamCache map[ir.IRServiceKey]*ir.IRUpstream,
+	gatewayMap map[types.NamespacedName]*gatewayv1.Gateway,
+	virtualHostsPerGateway map[types.NamespacedName]map[ir.IRListener]*ir.IRVirtualHost,
+) {
+	var hostnameStrings []string
+	for _, h := range tlsRoute.Spec.Hostnames {
+		hostnameStrings = append(hostnameStrings, string(h))
+	}
+	vHostsMatchingRoute := t.findMatchingVHostsForXRoute(virtualHostsPerGateway, gatewayMap, tlsRoute.Name, tlsRoute.Namespace, xRouteKind_TLSRoute, tlsRoute.Spec.ParentRefs, hostnameStrings...)
+
+	// Now that we have a set of the virtual hosts that are applicable to this TLSRoute, go through and build new routes
+	// for all the TLSRoute rules and add them to the matching virtual hosts
+
+	// Add all the routes we just processed to all matching virtual hosts
+	for irVHost := range vHostsMatchingRoute {
+		// Note: it would be more efficient to build the routes for the TLSRoute once, then apply them to all matching virtualHosts, but
+		// each Gateway can specify upstream client certificates, so the routes we build are dependent on the current Gateway
+		routeToAdd := t.tlsRouteRulesToIR(irVHost, tlsRoute, upstreamCache)
+		for _, destination := range routeToAdd.Destinations {
+			// Inherit all the virtual host's owning resources
+			if destination.Upstream != nil {
+				for _, owningResource := range irVHost.OwningResources {
+					destination.Upstream.AddOwningResource(owningResource)
+				}
+			}
+		}
+		irVHost.Routes = append(irVHost.Routes, routeToAdd)
+	}
+}
+
+func (t *translator) tcpRouteRulesToIR(irVHost *ir.IRVirtualHost, tcpRoute *gatewayv1alpha2.TCPRoute, upstreamCache map[ir.IRServiceKey]*ir.IRUpstream) *ir.IRRoute {
+	irRoute := &ir.IRRoute{
+		TrafficPolicies: []*trafficpolicy.TrafficPolicy{},
+	}
+	for _, rule := range tcpRoute.Spec.Rules {
+		// For each rule create a route
+		for _, backendRef := range rule.BackendRefs {
+			irDestination, err := t.tcpBackendToIR(tcpRoute.Name, tcpRoute.Namespace, xRouteKind_TCPRoute, backendRef, upstreamCache, irVHost.ClientCertRefs)
+			if err != nil {
+				t.log.Error(err, "unable to translate TCPRoute backend ref",
+					"TCPRoute", fmt.Sprintf("%s.%s", tcpRoute.Name, tcpRoute.Namespace),
+				)
+				continue
+			}
+			irRoute.Destinations = append(irRoute.Destinations, irDestination)
+		}
+	}
+	return irRoute
+}
+
+func (t *translator) tlsRouteRulesToIR(irVHost *ir.IRVirtualHost, tlsRoute *gatewayv1alpha2.TLSRoute, upstreamCache map[ir.IRServiceKey]*ir.IRUpstream) *ir.IRRoute {
+	irRoute := &ir.IRRoute{
+		TrafficPolicies: []*trafficpolicy.TrafficPolicy{},
+	}
+	for _, rule := range tlsRoute.Spec.Rules {
+		for _, backendRef := range rule.BackendRefs {
+			irDestination, err := t.tcpBackendToIR(tlsRoute.Name, tlsRoute.Namespace, xRouteKind_TLSRoute, backendRef, upstreamCache, irVHost.ClientCertRefs)
+			if err != nil {
+				t.log.Error(err, "unable to translate TLSRoute backend ref",
+					"TLSRoute", fmt.Sprintf("%s.%s", tlsRoute.Name, tlsRoute.Namespace),
+				)
+				continue
+			}
+			irRoute.Destinations = append(irRoute.Destinations, irDestination)
+		}
+	}
+	return irRoute
+}
+
 func (t *translator) httpRouteRulesToIR(irVHost *ir.IRVirtualHost, httpRoute *gatewayv1.HTTPRoute, upstreamCache map[ir.IRServiceKey]*ir.IRUpstream) []*ir.IRRoute {
 	routesToAdd := []*ir.IRRoute{}
 	for _, rule := range httpRoute.Spec.Rules {
 		// For each rule.Match create a route
 		for _, match := range rule.Matches {
 			irRoute := &ir.IRRoute{
-				MatchCriteria:   GatewayAPIHTTPMatchToIR(match),
-				TrafficPolicies: []*trafficpolicy.TrafficPolicy{},
+				HTTPMatchCriteria: GatewayAPIHTTPMatchToIR(match),
+				TrafficPolicies:   []*trafficpolicy.TrafficPolicy{},
 			}
 
 			for _, filter := range rule.Filters {
 				// For each GatewayAPI filter for the route, we will inject additional config into the route's traffic policy
-				filterTrafficPolicy, err := t.gatewayAPIFilterToTrafficPolicy(httpRoute.Namespace, filter, httpRoute.Namespace, t.store, irRoute.MatchCriteria)
+				filterTrafficPolicy, err := t.gatewayAPIFilterToTrafficPolicy(httpRoute.Namespace, filter, httpRoute.Namespace, t.store, irRoute.HTTPMatchCriteria)
 				if err != nil {
 					t.log.Error(err, "skipping filter with error")
 					continue
@@ -312,7 +505,7 @@ func (t *translator) httpRouteRulesToIR(irVHost *ir.IRVirtualHost, httpRoute *ga
 			}
 
 			for _, backendRef := range rule.BackendRefs {
-				irDestination, err := t.httpRouteBackendToIR(httpRoute, backendRef, upstreamCache, irRoute.MatchCriteria, irVHost.ClientCertRefs)
+				irDestination, err := t.httpRouteBackendToIR(httpRoute, backendRef, upstreamCache, irRoute.HTTPMatchCriteria, irVHost.ClientCertRefs)
 				if err != nil {
 					t.log.Error(err, "unable to translate HTTPRoute backend ref",
 						"HTTPRoute", fmt.Sprintf("%s.%s", httpRoute.Name, httpRoute.Namespace),
@@ -332,22 +525,51 @@ func (t *translator) httpRouteRulesToIR(irVHost *ir.IRVirtualHost, httpRoute *ga
 
 // #region Find Gateway listners for HTTPRoute
 
-// matchingGatewayListenersForHTTPRoute takes a Gateway and an HTTPRoute and figures out which (if any) listeners from the Gateway the HTTPRoute matches
-func (t *translator) matchingGatewayListenersForHTTPRoute(gateway *gatewayv1.Gateway, httpRoute *gatewayv1.HTTPRoute) []gatewayv1.Listener {
+// xRouteKind identifies a type of Gateway API Route that we support translation for
+type xRouteKind string
+
+const (
+	xRouteKind_HTTPRoute xRouteKind = "HTTPRoute"
+	xRouteKind_TCPRoute  xRouteKind = "TCPRoute"
+	xRouteKind_TLSRoute  xRouteKind = "TLSRoute"
+
+	// GRPCRoute & UDPRoute not currently supported
+)
+
+// matchGatewayListenersToXRoute takes a Gateway and properties of an HTTPRoute/TLSRoute/TCPRoute and figures out which (if any) listeners from the Gateway the route matches
+func (t *translator) matchGatewayListenersToXRoute(
+	gateway *gatewayv1.Gateway,
+	gatewayAddressHostnames []string,
+	routeNamespace string,
+	routeKind xRouteKind,
+	listenerName *gatewayv1.SectionName,
+	listenerPort *gatewayv1.PortNumber,
+	routeHostnames ...string,
+) []gatewayv1.Listener {
 	matchingListeners := []gatewayv1.Listener{}
 
 	for _, listener := range gateway.Spec.Listeners {
+
+		// Ignore the current listener if a specific name/port is expected and it doesn't match the current listener
+		if listenerName != nil && listener.Name != *listenerName {
+			continue
+		}
+
+		if listenerPort != nil && listener.Port != *listenerPort {
+			continue
+		}
+
 		// When allowedRoutes is not specified, only routes in the same namespace as the gateway are allowed
-		if listener.AllowedRoutes == nil && (gateway.Namespace != httpRoute.Namespace) {
-			return matchingListeners
+		if listener.AllowedRoutes == nil && (gateway.Namespace != routeNamespace) {
+			continue
 		}
 
 		if listener.AllowedRoutes != nil {
-			allowedKind := true // Default to allowing HTTPRoutes in the same namespace when not specified
+			allowedKind := true // Default to allowing routes in the same namespace when not specified
 			if len(listener.AllowedRoutes.Kinds) > 0 {
 				allowedKind = false
 				for _, kind := range listener.AllowedRoutes.Kinds {
-					if kind.Kind == "HTTPRoute" {
+					if strings.EqualFold(string(kind.Kind), string(routeKind)) {
 						allowedKind = true
 						break
 					}
@@ -358,7 +580,7 @@ func (t *translator) matchingGatewayListenersForHTTPRoute(gateway *gatewayv1.Gat
 			}
 
 			// Validate namespaces
-			allowedNamespace := gateway.Namespace == httpRoute.Namespace // By default, only allow those in the same namespace
+			allowedNamespace := gateway.Namespace == routeNamespace // By default, only allow those in the same namespace
 			if listener.AllowedRoutes.Namespaces != nil {
 				nsPolicy := listener.AllowedRoutes.Namespaces.From
 				if nsPolicy != nil {
@@ -375,10 +597,10 @@ func (t *translator) matchingGatewayListenersForHTTPRoute(gateway *gatewayv1.Gat
 								t.log.Error(err, "unable to parse AllowedRoutes.Namespaces.Selector")
 								continue
 							}
-							// Get the namespace for the current HTTPRoute
-							namespace, err := t.store.GetNamespaceV1(httpRoute.Namespace)
+							// Get the namespace for the current route
+							namespace, err := t.store.GetNamespaceV1(routeNamespace)
 							if err != nil {
-								t.log.Error(err, "unable to validate whether current HTTPRoute labels match Gateway AllowedRoutes.Namespaces.Selector")
+								t.log.Error(err, fmt.Sprintf("unable to validate whether current %q labels match Gateway AllowedRoutes.Namespaces.Selector", routeKind))
 								continue
 							}
 							if !selector.Matches(labels.Set(namespace.Labels)) {
@@ -395,35 +617,74 @@ func (t *translator) matchingGatewayListenersForHTTPRoute(gateway *gatewayv1.Gat
 		}
 
 		// Handle listener hostnames
-		if listener.Hostname == nil {
-			t.log.Error(fmt.Errorf("gateway has a listener with a nil hostname"), "Gateway listeners with nil hostnames are not supported, gateway listeners must have a valid non-empty hostname other than \"*\". Invalid listeners will be skipped.",
-				"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
-			)
-			continue
+
+		// If the gateway does not specify a spec.Addresses, then the hostname of the listener is expected to serve as the address for the endpoint and can't be something with no top level domain (like "*").
+		// Due to the way that endpoints work, we must have some kind of a domain to use to generate the endpoints.
+		// For TCPRoute/TLSRoute, we allow you to specify them via the spec.Addresses since TCPRoute has no way to configure a hostname otherwise and a Gateway's listener is forbidden from specifying a hostname when the protocol is TCP/TLS
+		//
+		// To make this make sense for HTTP/HTTPS endpoints, when no Gateway.spec.addresses are provided, the listener must provide a non-nil, non-empty string, hostname to be used for the endpoint. The listeners hostnames become the domains for the endpoints
+		// If Gateway.spec.addresses are provided, then the listener's hostname may be left blank to match all of them, but when specified, it must match all of the hostnames in Gateway.spec.addresses. The gateway's spec.addresses become the domains for the endpoints
+		//
+		// Note: since we are introducing support for Gateway.spec.addresses, I think it would make sense for a future change to make it so that the domains for the endpoints must be specified in the Gateway.spec.addresses field, and the listener.hostname becomes something that is used
+		// for host header and SNI matching on requests.
+
+		listenerHostname := "*"
+		if len(gatewayAddressHostnames) == 0 {
+			if listener.Hostname == nil {
+				t.log.Error(fmt.Errorf("gateway has a listener with a nil hostname"), "Gateway listeners with nil hostnames are not supported when Gateway.spec.addresses is empty, gateway listeners must have a valid non-empty hostname other than \"*\". Invalid listeners will be skipped.",
+					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+				)
+				continue
+			}
+
+			if string(*listener.Hostname) == "*" {
+				t.log.Error(fmt.Errorf("gateway has a listener with hostname \"*\""), "Gateway listeners with hostname \"*\" are not supported when Gateway.spec.addresses is empty, gateway listeners must have a valid non-empty hostname other than \"*\". Invalid listeners will be skipped.",
+					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+				)
+				continue
+			}
+
+			if listener.Hostname != nil && string(*listener.Hostname) == "" {
+				t.log.Error(fmt.Errorf("gateway has a listener with an empty hostname"), "Gateway listeners with empty hostnames are not supported when Gateway.spec.addresses is empty, gateway listeners must have a valid non-empty hostname other than \"*\". Invalid listeners will be skipped.",
+					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+				)
+				continue
+			}
 		}
 
-		listenerHostname := string(*listener.Hostname)
-		if listenerHostname == "*" {
-			t.log.Error(fmt.Errorf("gateway has a listener with hostname \"*\""), "Gateway listeners with hostname \"*\" are not supported, gateway listeners must have a valid non-empty hostname other than \"*\". Invalid listeners will be skipped.",
-				"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
-			)
-			continue
-		}
-		if listenerHostname == "" {
-			t.log.Error(fmt.Errorf("gateway has a listener with an empty hostname"), "Gateway listeners with empty hostnames are not supported, gateway listeners must have a valid non-empty hostname other than \"*\". Invalid listeners will be skipped.",
-				"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
-			)
-			continue
+		if listener.Hostname != nil && string(*listener.Hostname) != "" {
+			listenerHostname = string(*listener.Hostname)
 		}
 
-		// When the HTTPRoute hostnames are empty, it matches all listeners for all parent gateways
-		if len(httpRoute.Spec.Hostnames) == 0 {
+		// From the Gateway API spec: "The implementation MUST bind all Listeners to every GatewayAddress", so all listener hostnames must match all address hostnames
+		for _, gatewgatewayAddressHostname := range gatewayAddressHostnames {
+			match, err := doHostGlobsMatch(listenerHostname, gatewgatewayAddressHostname)
+			if err != nil {
+				t.log.Error(err, "unable to compile hostname glob match for Gateway.spec.address and Gateway listener, this Gateway will be skipped",
+					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+					"gateway address", gatewgatewayAddressHostname,
+					"listener hostname", listenerHostname,
+				)
+				return []gatewayv1.Listener{}
+			}
+			if !match {
+				t.log.Error(fmt.Errorf("listener hostname does not match one of the Gateway's spec.addresses"), "all listener hostnames must match all Gateway addresses. this Gateway will be skipped",
+					"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+					"gateway address", gatewgatewayAddressHostname,
+					"listener hostname", listenerHostname,
+				)
+				return []gatewayv1.Listener{}
+			}
+		}
+
+		// When the route hostnames are empty, it matches all listeners for all parent gateways
+		if len(routeHostnames) == 0 {
 			matchingListeners = append(matchingListeners, listener)
-			return matchingListeners
+			continue
 		}
 
 		// Check matches for valid hostnames
-		for _, routeHostname := range httpRoute.Spec.Hostnames {
+		for _, routeHostname := range routeHostnames {
 			if routeHostname == "*" {
 				matchingListeners = append(matchingListeners, listener)
 				break
@@ -448,7 +709,7 @@ func (t *translator) matchingGatewayListenersForHTTPRoute(gateway *gatewayv1.Gat
 // #region HTTPMatch to IR
 
 // GatewayAPIHTTPMatchToIR translates an HTTPRouteMatch into an IRHTTPMatch
-func GatewayAPIHTTPMatchToIR(match gatewayv1.HTTPRouteMatch) ir.IRHTTPMatch {
+func GatewayAPIHTTPMatchToIR(match gatewayv1.HTTPRouteMatch) *ir.IRHTTPMatch {
 	// GatewayAPI specifies that when nil, the default path match behaviour should be a prefix match on "/"
 	path := "/"
 	pathType := ir.IRPathType_Prefix
@@ -494,7 +755,7 @@ func GatewayAPIHTTPMatchToIR(match gatewayv1.HTTPRouteMatch) ir.IRHTTPMatch {
 		})
 	}
 
-	ret := ir.IRHTTPMatch{
+	ret := &ir.IRHTTPMatch{
 		Path:        &path,
 		PathType:    &pathType,
 		Headers:     requiredHeaders,
@@ -541,7 +802,7 @@ func gatewayMethodToIR(method *gatewayv1.HTTPMethod) *ir.IRMethodMatch {
 // #region GWAPI Filters translation
 
 // gatewayAPIFilterToTrafficPolicy translates Gateway API filters into traffic policy config
-func (t *translator) gatewayAPIFilterToTrafficPolicy(currentNamespace string, filter gatewayv1.HTTPRouteFilter, namespace string, store store.Storer, matchCriteria ir.IRHTTPMatch) (*trafficpolicy.TrafficPolicy, error) {
+func (t *translator) gatewayAPIFilterToTrafficPolicy(currentNamespace string, filter gatewayv1.HTTPRouteFilter, namespace string, store store.Storer, matchCriteria *ir.IRHTTPMatch) (*trafficpolicy.TrafficPolicy, error) {
 	sharedErr := fmt.Errorf("unable to convert gateway API filter to traffic policy config")
 
 	switch filter.Type {
@@ -686,14 +947,14 @@ func gwapiResponseHeaderFilterToTrafficPolicy(filter gatewayv1.HTTPRouteFilter) 
 // #region Redirect Filter
 
 // gwapiRequestHeaderFilterToTrafficPolicy translates a GatewayAPI redirect filter into traffic policy config
-func gwapiRedirectFilterToTrafficPolicy(filter gatewayv1.HTTPRouteFilter, matchCriteria ir.IRHTTPMatch) (*trafficpolicy.TrafficPolicy, error) {
+func gwapiRedirectFilterToTrafficPolicy(filter gatewayv1.HTTPRouteFilter, matchCriteria *ir.IRHTTPMatch) (*trafficpolicy.TrafficPolicy, error) {
 	redirect := filter.RequestRedirect
 	if redirect == nil {
 		return nil, fmt.Errorf("filter type specified as RequestRedirect but the section config was nil")
 	}
 
 	prefix := ""
-	if matchCriteria.Path != nil {
+	if matchCriteria != nil && matchCriteria.Path != nil {
 		prefix = *matchCriteria.Path
 		prefix = strings.ReplaceAll(prefix, "/", `\/`)
 	}
@@ -778,7 +1039,7 @@ func gwapiRedirectFilterToTrafficPolicy(filter gatewayv1.HTTPRouteFilter, matchC
 // #region URL Rewrite Filter
 
 // gwapiRequestHeaderFilterToTrafficPolicy translates a GatewayAPI url rewrite filter into traffic policy config
-func gwapiURLRewriteFilterToTrafficPolicy(filter gatewayv1.HTTPRouteFilter, matchCriteria ir.IRHTTPMatch) (*trafficpolicy.TrafficPolicy, error) {
+func gwapiURLRewriteFilterToTrafficPolicy(filter gatewayv1.HTTPRouteFilter, matchCriteria *ir.IRHTTPMatch) (*trafficpolicy.TrafficPolicy, error) {
 	rewrite := filter.URLRewrite
 	if rewrite == nil {
 		return nil, fmt.Errorf("filter type specified as URLRewrite but the section config was nil")
@@ -789,7 +1050,7 @@ func gwapiURLRewriteFilterToTrafficPolicy(filter gatewayv1.HTTPRouteFilter, matc
 	}
 
 	prefix := ""
-	if matchCriteria.Path != nil {
+	if matchCriteria != nil && matchCriteria.Path != nil {
 		prefix = *matchCriteria.Path
 		prefix = strings.ReplaceAll(prefix, "/", `\/`)
 	}
@@ -848,7 +1109,7 @@ func gwapiURLRewriteFilterToTrafficPolicy(filter gatewayv1.HTTPRouteFilter, matc
 // #region HTTPRoute BackendRef IR
 
 // gwapiRequestHeaderFilterToTrafficPolicy translates a GatewayAPI backendRef into IR
-func (t *translator) httpRouteBackendToIR(httpRoute *gatewayv1.HTTPRoute, backendRef gatewayv1.HTTPBackendRef, upstreamCache map[ir.IRServiceKey]*ir.IRUpstream, matchCriteria ir.IRHTTPMatch, upstreamClientCertRefs []ir.IRObjectRef) (*ir.IRDestination, error) {
+func (t *translator) httpRouteBackendToIR(httpRoute *gatewayv1.HTTPRoute, backendRef gatewayv1.HTTPBackendRef, upstreamCache map[ir.IRServiceKey]*ir.IRUpstream, matchCriteria *ir.IRHTTPMatch, upstreamClientCertRefs []ir.IRObjectRef) (*ir.IRDestination, error) {
 	destination := &ir.IRDestination{
 		TrafficPolicies: []*trafficpolicy.TrafficPolicy{},
 	}
@@ -915,7 +1176,7 @@ func (t *translator) httpRouteBackendToIR(httpRoute *gatewayv1.HTTPRoute, backen
 		)
 	}
 
-	portProto, err := getProtoForServicePort(t.log, service, servicePort.Name)
+	portProto, err := getProtoForServicePort(t.log, service, servicePort.Name, ir.IRProtocol_HTTP)
 	if err != nil {
 		// When this function errors we still get a valid default, so no need to return
 		t.log.Error(err, "error getting protocol for HTTPRoute backendRef service port",
@@ -950,6 +1211,119 @@ func (t *translator) httpRouteBackendToIR(httpRoute *gatewayv1.HTTPRoute, backen
 	// _when_ implies to me that it is valid to have upstreams for a gateway with client certs that are not HTTPS and so we should not set these
 	// in those cases
 	if irScheme == ir.IRScheme_HTTPS {
+		irService.ClientCertRefs = upstreamClientCertRefs
+	}
+
+	upstream, exists := upstreamCache[irService.Key()]
+	if !exists {
+		upstream = &ir.IRUpstream{
+			Service: irService,
+		}
+		upstreamCache[irService.Key()] = upstream
+	}
+	destination.Upstream = upstream
+
+	return destination, nil
+}
+
+// #region TCP BackendRef IR
+
+// gwapiRequestHeaderFilterToTrafficPolicy translates a GatewayAPI backendRef into IR
+func (t *translator) tcpBackendToIR(routeName string, routeNamespace string, routeKind xRouteKind, backendRef gatewayv1.BackendRef, upstreamCache map[ir.IRServiceKey]*ir.IRUpstream, upstreamClientCertRefs []ir.IRObjectRef) (*ir.IRDestination, error) {
+	destination := &ir.IRDestination{
+		TrafficPolicies: []*trafficpolicy.TrafficPolicy{},
+	}
+
+	if backendRef.Weight != nil {
+		weight := int(*backendRef.Weight)
+		destination.Weight = &weight
+	}
+
+	if backendRef.Kind != nil && !strings.EqualFold(string(*backendRef.Kind), "Service") {
+		return nil, fmt.Errorf("invalid backendRef kind supplied to %s. only Service backends are currently supported", routeKind)
+	}
+
+	serviceName := string(backendRef.Name)
+	if serviceName == "" {
+		return destination, nil
+	}
+
+	serviceNamespace := routeNamespace
+	if backendRef.Namespace != nil && *backendRef.Namespace != "" {
+		serviceNamespace = string(*backendRef.Namespace)
+		if !t.isRefToNamespaceAllowed(routeNamespace, "gateway.networking.k8s.io", string(routeKind), serviceName, serviceNamespace, "", "Service") {
+			return nil, fmt.Errorf("reference to Service %q is not allowed without a valid ReferenceGrant",
+				fmt.Sprintf("%s.%s", serviceName, serviceNamespace),
+			)
+		}
+	}
+
+	if backendRef.Port == nil {
+		return nil, fmt.Errorf("backendRef supplied to %s is missing the required port. name: %q, namespace: %q",
+			routeKind,
+			serviceName,
+			serviceNamespace,
+		)
+	}
+
+	service, err := t.store.GetServiceV1(serviceName, serviceNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve Service for backendRef name: %q in namespace %q: %w",
+			serviceName,
+			serviceNamespace,
+			err,
+		)
+	}
+
+	servicePort, err := findServicesPort(t.log, service, netv1.ServiceBackendPort{Number: int32(*backendRef.Port)})
+	if err != nil || servicePort == nil {
+		return nil, fmt.Errorf("failed to resolve backendRef Service's port. name: %q, namespace: %q: %w",
+			serviceName,
+			serviceNamespace,
+			err,
+		)
+	}
+
+	defaultProto := ir.IRProtocol_TCP
+	if routeKind == xRouteKind_TLSRoute {
+		defaultProto = ir.IRProtocol_TLS
+	}
+
+	portProto, err := getProtoForServicePort(t.log, service, servicePort.Name, defaultProto)
+	if err != nil {
+		// When this function errors we still get a valid default, so no need to return
+		t.log.Error(err, fmt.Sprintf("error getting protocol for %s backendRef service port", routeKind),
+			string(routeKind), fmt.Sprintf("%s.%s", routeName, routeNamespace),
+			"backendRef", backendRef,
+		)
+	}
+
+	irScheme, err := protocolStringToIRScheme(portProto)
+	if err != nil {
+		t.log.Error(err, fmt.Sprintf("error getting scheme from port protocol for %s backendRef service port", routeKind),
+			string(routeKind), fmt.Sprintf("%s.%s", routeName, routeNamespace),
+			"backendRef", backendRef,
+			"service", fmt.Sprintf("%s.%s", service.Name, service.Namespace),
+			"port name", servicePort.Name,
+			"port number", servicePort.Port,
+		)
+	}
+
+	irService := ir.IRService{
+		UID:       string(service.UID),
+		Name:      serviceName,
+		Namespace: serviceNamespace,
+		Port:      servicePort.Port,
+		Scheme:    irScheme,
+	}
+
+	// The following is the wording from the Gateway API about supplied client certificate refs
+	//  BackendTLS configures TLS settings for when this Gateway is connecting to
+	//  backends with TLS
+	//
+	// _when_ implies to me that it is valid to have upstreams for a gateway with client certs that are not HTTPS and so we should not set these
+	// in those cases
+	if irScheme == ir.IRScheme_TLS {
 		irService.ClientCertRefs = upstreamClientCertRefs
 	}
 

--- a/pkg/managerdriver/translate_ingresses.go
+++ b/pkg/managerdriver/translate_ingresses.go
@@ -141,7 +141,7 @@ func (t *translator) ingressToIR(
 		irVHost, exists := hostCache[ir.IRHostname(ruleHostname)]
 		if exists {
 			// If we already have a virtual host for this hostname, the traffic policy config must be the same as the one we are currently processing
-			if !reflect.DeepEqual(irVHost.TrafficPolicyObj, annotationTrafficPolicyRef) {
+			if !reflect.DeepEqual(irVHost.TrafficPolicyObjRef, annotationTrafficPolicyRef) {
 				t.log.Error(fmt.Errorf("different traffic policy annotations provided for the same hostname"),
 					"when using the same hostname across multiple ingresses, ensure that they do not use different traffic policies provided via annotations",
 					"current ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
@@ -204,7 +204,7 @@ func (t *translator) ingressToIR(
 					Protocol: ir.IRProtocol_HTTPS,
 				},
 				TrafficPolicy:          ruleTrafficPolicy,
-				TrafficPolicyObj:       annotationTrafficPolicyRef,
+				TrafficPolicyObjRef:    annotationTrafficPolicyRef,
 				LabelsToAdd:            t.managedResourceLabels,
 				Routes:                 []*ir.IRRoute{},
 				DefaultDestination:     defaultDestination,
@@ -246,7 +246,7 @@ func (t *translator) ingressPathsToIR(ingress *netv1.Ingress, ruleHostname strin
 
 		pathType := netv1PathTypeToIR(t.log, pathMatch.PathType)
 		irRoutes = append(irRoutes, &ir.IRRoute{
-			MatchCriteria: ir.IRHTTPMatch{
+			HTTPMatchCriteria: &ir.IRHTTPMatch{
 				Path:     &pathMatch.Path,
 				PathType: &pathType,
 			},
@@ -314,7 +314,7 @@ func (t *translator) ingressBackendToIR(ingress *netv1.Ingress, backend *netv1.I
 			err,
 		)
 	}
-	portProto, err := getProtoForServicePort(t.log, service, servicePort.Name)
+	portProto, err := getProtoForServicePort(t.log, service, servicePort.Name, ir.IRProtocol_HTTP)
 	if err != nil {
 		// When this function errors we still get a valid default, so no need to return
 		t.log.Error(err, "error getting protocol for ingress backend service port")

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -219,25 +219,41 @@ func (t *translator) IRToEndpoints(irVHosts []*ir.IRVirtualHost) (cloudEndpoints
 		}
 
 		// Generate a traffic policy that has all the rules/actions for our routes and merge it into the existing one
-		routingPolicy := t.buildRoutingPolicy(irVHost, irVHost.Routes, agentEndpointCache)
+		routingPolicy := t.buildRoutingPolicy(irVHost, agentEndpointCache)
 		listenerTrafficPolicy.Merge(routingPolicy)
 
-		defaultDestinationPolicy := t.buildDefaultDestinationPolicy(irVHost, agentEndpointCache)
+		defaultDestinationPolicy, err := t.buildDefaultDestinationPolicy(irVHost, agentEndpointCache)
+		if err != nil {
+			t.log.Error(err, "failed to default destination traffic policy",
+				"hostname", irVHost.Listener.Hostname,
+				"port", irVHost.Listener.Port,
+				"protocol", irVHost.Listener.Protocol,
+				"generated from resources", irVHost.OwningResources,
+			)
+			continue
+		}
 		listenerTrafficPolicy.Merge(defaultDestinationPolicy)
 
-		// Add a default 404 response when no routes are found
-		default404Rule := buildDefault404TPRule()
-		// If we're collapsing into an AgentEndpoint, make sure this action only runs when we didn't match the local service
-		if irVHost.CollapseIntoServiceKey != nil {
-			default404Rule.Expressions = appendStringUnique(default404Rule.Expressions, "vars.request_matched_local_svc == false")
+		switch irVHost.Listener.Protocol {
+		case ir.IRProtocol_HTTP, ir.IRProtocol_HTTPS:
+			// Add a default 404 response when no routes are found
+			default404Rule := buildDefault404TPRule()
+			// If we're collapsing into an AgentEndpoint, make sure this action only runs when we didn't match the local service
+			if irVHost.CollapseIntoServiceKey != nil {
+				default404Rule.Expressions = appendStringUnique(default404Rule.Expressions, "vars.request_matched_local_svc == false")
+			}
+			listenerTrafficPolicy.AddRuleOnHTTPRequest(default404Rule)
+		case ir.IRProtocol_TCP, ir.IRProtocol_TLS:
+			// Not needed for TLS/TCP endpoints
 		}
-		listenerTrafficPolicy.AddRuleOnHTTPRequest(default404Rule)
 
 		// Marshal the updated TrafficPolicySpec back to JSON
 		listenerPolicyJSON, err := json.Marshal(listenerTrafficPolicy)
 		if err != nil {
 			t.log.Error(err, "failed to marshal traffic policy for generated CloudEndpoint",
 				"hostname", string(irVHost.Listener.Hostname),
+				"port", irVHost.Listener.Port,
+				"protocol", irVHost.Listener.Protocol,
 				"generated from resources", irVHost.OwningResources,
 			)
 			continue
@@ -254,7 +270,16 @@ func (t *translator) IRToEndpoints(irVHosts []*ir.IRVirtualHost) (cloudEndpoints
 				}
 			}
 		} else {
-			cloudEndpoint := buildCloudEndpoint(irVHost)
+			cloudEndpoint, err := buildCloudEndpoint(irVHost)
+			if err != nil {
+				t.log.Error(err, "failed to build CloudEndpoint",
+					"hostname", irVHost.Listener.Hostname,
+					"port", irVHost.Listener.Port,
+					"protocol", irVHost.Listener.Protocol,
+					"generated from resources", irVHost.OwningResources,
+				)
+				continue
+			}
 			cloudEndpoint.Spec.TrafficPolicy = &ngrokv1alpha1.NgrokTrafficPolicySpec{
 				Policy: json.RawMessage(listenerPolicyJSON),
 			}
@@ -277,17 +302,29 @@ func (t *translator) IRToEndpoints(irVHosts []*ir.IRVirtualHost) (cloudEndpoints
 	return cloudEndpoints, agentEndpoints
 }
 
-func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, routes []*ir.IRRoute, agentEndpointCache map[ir.IRServiceKey]*ngrokv1alpha1.AgentEndpoint) *trafficpolicy.TrafficPolicy {
+func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, agentEndpointCache map[ir.IRServiceKey]*ngrokv1alpha1.AgentEndpoint) *trafficpolicy.TrafficPolicy {
 	routingTrafficPolicy := trafficpolicy.NewTrafficPolicy()
 	// If we're collapsing this into an AgentEndpoint, set a variable so we know if routes match the local service or not since there could be other routes
 	if irVHost.CollapseIntoServiceKey != nil {
-		routingTrafficPolicy.AddRuleOnHTTPRequest(buildRouteLocallyVarRule("Initialize-Local-Service-Match", false))
+		switch irVHost.Listener.Protocol {
+		case ir.IRProtocol_HTTP, ir.IRProtocol_HTTPS:
+			routingTrafficPolicy.AddRuleOnHTTPRequest(buildRouteLocallyVarRule("Initialize-Local-Service-Match", false))
+		case ir.IRProtocol_TCP, ir.IRProtocol_TLS:
+			// This is only necessary for tcp:// and tls:// endpoints if we're balancing between multiple upstreams since othherwise they don't have match criteria
+			// TCP and TLS endpoints only ever have one route since there are no match criteria, but we might have more than one backend (weighted)
+			if len(irVHost.Routes) == 1 && len(irVHost.Routes[0].Destinations) > 1 {
+				routingTrafficPolicy.AddRuleOnTCPConnect(buildRouteLocallyVarRule("Initialize-Local-Service-Match", false))
+			}
+		}
 	}
 
 	// First, see if any of the traffic policies modify the request. If they do, we need to capture the original request data
 	captureOriginalParams := false
-	for _, irRoute := range routes {
-		actionModifiesRequest := func(action trafficpolicy.Action, matchCriteria ir.IRHTTPMatch) bool {
+	for _, irRoute := range irVHost.Routes {
+		actionModifiesRequest := func(action trafficpolicy.Action, matchCriteria *ir.IRHTTPMatch) bool {
+			if matchCriteria == nil {
+				return false
+			}
 			switch action.Type {
 			case trafficpolicy.ActionType_AddHeaders, trafficpolicy.ActionType_RemoveHeaders:
 				if len(matchCriteria.Headers) > 0 {
@@ -306,7 +343,7 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, routes []*ir.
 		for _, routeTrafficPolicy := range irRoute.TrafficPolicies {
 			for _, tpRule := range routeTrafficPolicy.OnHTTPRequest {
 				for _, ruleAction := range tpRule.Actions {
-					if actionModifiesRequest(ruleAction, irRoute.MatchCriteria) {
+					if actionModifiesRequest(ruleAction, irRoute.HTTPMatchCriteria) {
 						captureOriginalParams = true
 						break
 					}
@@ -319,7 +356,7 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, routes []*ir.
 				for _, destTrafficPolicy := range irDestination.TrafficPolicies {
 					for _, tpRule := range destTrafficPolicy.OnHTTPRequest {
 						for _, ruleAction := range tpRule.Actions {
-							if actionModifiesRequest(ruleAction, irRoute.MatchCriteria) {
+							if actionModifiesRequest(ruleAction, irRoute.HTTPMatchCriteria) {
 								captureOriginalParams = true
 								break
 							}
@@ -348,17 +385,17 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, routes []*ir.
 		})
 	}
 
-	for _, irRoute := range routes {
+	for _, irRoute := range irVHost.Routes {
 		if len(irRoute.Destinations) == 0 && len(irRoute.TrafficPolicies) == 0 {
 			t.log.Error(fmt.Errorf("generated route does not have a destination"), "skipping endpoint configuration generation for invalid route, other routes will continue to be processed",
 				"generated from resources", irVHost.OwningResources,
 				"hostname", string(irVHost.Listener.Hostname),
-				"match criteria", irRoute.MatchCriteria,
+				"match criteria", irRoute.HTTPMatchCriteria,
 			)
 			continue
 		}
 
-		matchExpressions := irMatchCriteriaToTPExpressions(irRoute.MatchCriteria, captureOriginalParams)
+		matchExpressions := irMatchCriteriaToTPExpressions(irRoute.HTTPMatchCriteria, captureOriginalParams)
 		if irVHost.CollapseIntoServiceKey != nil {
 			// If we're collapsing this into an AgentEndpoint, add an expression to make sure that none of the prior rules have matched the local service.
 			// For example, an Ingress with a rule /paththatislonger that routes to the local service and a rule /path that matches something else, we don't want to bother
@@ -403,14 +440,23 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, routes []*ir.
 					"weighted_route_random_num": fmt.Sprintf("${rand.int(0,%d)}", routeTotalWeight-1),
 				}},
 			}
-			routingTrafficPolicy.AddRuleOnHTTPRequest(trafficpolicy.Rule{
+
+			randomNumRule := trafficpolicy.Rule{
 				Name:        "Gen-Random-Number",
 				Expressions: matchExpressions,
 				Actions: []trafficpolicy.Action{{
 					Type:   trafficpolicy.ActionType_SetVars,
 					Config: setvarWeightCfg,
 				}},
-			})
+			}
+
+			switch irVHost.Listener.Protocol {
+			case ir.IRProtocol_HTTP, ir.IRProtocol_HTTPS:
+				routingTrafficPolicy.AddRuleOnHTTPRequest(randomNumRule)
+			case ir.IRProtocol_TCP, ir.IRProtocol_TLS:
+				routingTrafficPolicy.AddRuleOnTCPConnect(randomNumRule)
+			}
+
 		}
 
 		currentLowerBound := 0 // starting value for the random number range
@@ -454,11 +500,21 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, routes []*ir.
 				irService := irDestination.Upstream.Service
 				agentEndpoint, exists := agentEndpointCache[irService.Key()]
 				if !exists {
-					agentEndpoint = buildAgentEndpoint(
+					var err error
+					agentEndpoint, err = buildAgentEndpoint(
 						irVHost,
 						irService,
 						t.clusterDomain,
 						irVHost.Metadata)
+					if err != nil {
+						t.log.Error(err, "failed to build AgentEndpoint",
+							"hostname", irVHost.Listener.Hostname,
+							"port", irVHost.Listener.Port,
+							"protocol", irVHost.Listener.Protocol,
+							"generated from resources", irDestination.Upstream.OwningResources,
+						)
+						continue
+					}
 					agentEndpointCache[irService.Key()] = agentEndpoint
 				}
 
@@ -477,7 +533,16 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, routes []*ir.
 				if weightedRouteExpression != nil {
 					tpRouteRule.Expressions = appendStringUnique(tpRouteRule.Expressions, *weightedRouteExpression)
 				}
-				routingTrafficPolicy.AddRuleOnHTTPRequest(tpRouteRule)
+
+				switch irVHost.Listener.Protocol {
+				case ir.IRProtocol_HTTP, ir.IRProtocol_HTTPS:
+					routingTrafficPolicy.AddRuleOnHTTPRequest(tpRouteRule)
+				case ir.IRProtocol_TCP, ir.IRProtocol_TLS:
+					// This is only necessary for tcp:// and tls:// endpoints if we're balancing between multiple upstreams since othherwise they don't have match criteria
+					if len(irVHost.Routes) == 1 && len(irVHost.Routes[0].Destinations) > 1 {
+						routingTrafficPolicy.AddRuleOnTCPConnect(tpRouteRule)
+					}
+				}
 			}
 		}
 	}
@@ -487,8 +552,12 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, routes []*ir.
 // buildPathMatchExpressionExpressionToTPRule creates an expression for a traffic policy rule to control path matching.
 // Normally it will check the request data from the req. variable, but when we have actions such as a url-rewrite that
 // modify the request, then we instead need to check the request data from a set-vars action that will store it before it is transformed
-func irMatchCriteriaToTPExpressions(matchCriteria ir.IRHTTPMatch, getRequestDataFromVar bool) []string {
+func irMatchCriteriaToTPExpressions(matchCriteria *ir.IRHTTPMatch, getRequestDataFromVar bool) []string {
 	expressions := []string{}
+
+	if matchCriteria == nil {
+		return expressions
+	}
 
 	// 1. Path matching
 	if matchCriteria.Path != nil {
@@ -625,11 +694,11 @@ func buildRouteLocallyVarRule(name string, value bool) trafficpolicy.Rule {
 	}
 }
 
-func (t *translator) buildDefaultDestinationPolicy(irVHost *ir.IRVirtualHost, agentEndpointCache map[ir.IRServiceKey]*ngrokv1alpha1.AgentEndpoint) *trafficpolicy.TrafficPolicy {
+func (t *translator) buildDefaultDestinationPolicy(irVHost *ir.IRVirtualHost, agentEndpointCache map[ir.IRServiceKey]*ngrokv1alpha1.AgentEndpoint) (*trafficpolicy.TrafficPolicy, error) {
 	defaultDestination := irVHost.DefaultDestination
 	defaultDestTrafficPolicy := trafficpolicy.NewTrafficPolicy()
 	if defaultDestination == nil {
-		return defaultDestTrafficPolicy
+		return defaultDestTrafficPolicy, nil
 	}
 
 	// If the default backend has a set of traffic policies, then just append all of their rules
@@ -650,12 +719,16 @@ func (t *translator) buildDefaultDestinationPolicy(irVHost *ir.IRVirtualHost, ag
 		irService := upstream.Service
 		agentEndpoint, exists := agentEndpointCache[irService.Key()]
 		if !exists {
-			agentEndpoint = buildAgentEndpoint(
+			var err error
+			agentEndpoint, err = buildAgentEndpoint(
 				irVHost,
 				irService,
 				t.clusterDomain,
 				t.defaultIngressMetadata,
 			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build AgentEndpoint. upstream generated from resources: %v, err: %w", upstream.OwningResources, err)
+			}
 			agentEndpointCache[irService.Key()] = agentEndpoint
 		}
 		// If we're collapsing this into an AgentEndpoint, we only want to run this when a request did not match the local service
@@ -670,33 +743,42 @@ func (t *translator) buildDefaultDestinationPolicy(irVHost *ir.IRVirtualHost, ag
 		}
 		defaultDestTrafficPolicy.AddRuleOnHTTPRequest(routeRule)
 	}
-	return defaultDestTrafficPolicy
+	return defaultDestTrafficPolicy, nil
 }
 
-func buildPublicURL(irVHost *ir.IRVirtualHost) string {
+func buildPublicURL(irVHost *ir.IRVirtualHost) (string, error) {
 	url := ""
+
+	scheme, err := protocolStringToIRScheme(irVHost.Listener.Protocol)
+	if err != nil {
+		return "", err
+	}
+
+	url += string(scheme)
+
 	var port *int32
 	switch irVHost.Listener.Protocol {
 	case ir.IRProtocol_HTTPS:
-		url += "https://"
 		if irVHost.Listener.Port != 443 {
 			port = &irVHost.Listener.Port
 		}
 	case ir.IRProtocol_HTTP:
-		url += "http://"
 		if irVHost.Listener.Port != 80 {
 			port = &irVHost.Listener.Port
 		}
+	case ir.IRProtocol_TCP, ir.IRProtocol_TLS:
+		// for tls:// and tcp:// we always add the port
+		port = &irVHost.Listener.Port
 	}
 	url += string(irVHost.Listener.Hostname)
 	if port != nil {
 		url = fmt.Sprintf("%s:%d", url, *port)
 	}
-	return url
+	return url, nil
 }
 
 // buildCloudEndpoint initializes a new CloudEndpoint
-func buildCloudEndpoint(irVHost *ir.IRVirtualHost) *ngrokv1alpha1.CloudEndpoint {
+func buildCloudEndpoint(irVHost *ir.IRVirtualHost) (*ngrokv1alpha1.CloudEndpoint, error) {
 	name := ""
 	if irVHost.NamePrefix != nil {
 		name = fmt.Sprintf("%s-", *irVHost.NamePrefix)
@@ -710,6 +792,11 @@ func buildCloudEndpoint(irVHost *ir.IRVirtualHost) *ngrokv1alpha1.CloudEndpoint 
 		irVHost.LabelsToAdd = nil
 	}
 
+	publicURL, err := buildPublicURL(irVHost)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build public URL for CloudEndpoint, err: %w", err)
+	}
+
 	return &ngrokv1alpha1.CloudEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        sanitizeStringForK8sName(name),
@@ -718,12 +805,12 @@ func buildCloudEndpoint(irVHost *ir.IRVirtualHost) *ngrokv1alpha1.CloudEndpoint 
 			Annotations: irVHost.AnnotationsToAdd,
 		},
 		Spec: ngrokv1alpha1.CloudEndpointSpec{
-			URL:            buildPublicURL(irVHost),
+			URL:            publicURL,
 			PoolingEnabled: irVHost.EndpointPoolingEnabled,
 			Metadata:       irVHost.Metadata,
 			Bindings:       irVHost.Bindings,
 		},
-	}
+	}, nil
 }
 
 // buildAgentEndpoint initializes a new AgentEndpoint
@@ -732,14 +819,22 @@ func buildAgentEndpoint(
 	irService ir.IRService,
 	clusterDomain string,
 	metadata string,
-) *ngrokv1alpha1.AgentEndpoint {
+) (*ngrokv1alpha1.AgentEndpoint, error) {
 	bindings := []string{"internal"}
 	var url string
 	if irVHost.CollapseIntoServiceKey != nil && irService.Key() == *irVHost.CollapseIntoServiceKey {
-		url = buildPublicURL(irVHost)
+		publicURL, err := buildPublicURL(irVHost)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build public URL for AgentEndpoint, err: %w", err)
+		}
+		url = publicURL
 		bindings = irVHost.Bindings
 	} else {
-		url = buildInternalEndpointURL(irService.UID, irService.Name, irService.Namespace, clusterDomain, irService.Port, irService.ClientCertRefs)
+		internalURL, err := buildInternalEndpointURL(irVHost.Listener.Protocol, irService.UID, irService.Name, irService.Namespace, clusterDomain, irService.Port, irService.ClientCertRefs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build internal URL for AgentEndpoint, err: %w", err)
+		}
+		url = internalURL
 	}
 
 	if len(irVHost.AnnotationsToAdd) == 0 {
@@ -774,7 +869,7 @@ func buildAgentEndpoint(
 		})
 	}
 
-	return ret
+	return ret, nil
 }
 
 // buildDefault404TPRule builds the default rule that will fire if no other rules are matched to return a 404 response

--- a/pkg/managerdriver/tunnels.go
+++ b/pkg/managerdriver/tunnels.go
@@ -296,13 +296,13 @@ func (d *Driver) getTunnelBackendFromGateway(backendRef gatewayv1.BackendRef, na
 }
 
 func (d *Driver) getTunnelBackendCommon(svc *corev1.Service, port *corev1.ServicePort) (string, int32, string, *common.ApplicationProtocol, error) {
-	protocol, err := getProtoForServicePort(d.log, svc, port.Name)
+	protocol, err := getProtoForServicePort(d.log, svc, port.Name, ir.IRProtocol_HTTP)
 	if err != nil {
 		return "", 0, "", nil, err
 	}
 
 	appProtocol := getPortAppProtocol(d.log, svc, port)
-	return string(svc.UID), port.Port, protocol, appProtocol, nil
+	return string(svc.UID), port.Port, string(protocol), appProtocol, nil
 }
 
 func (d *Driver) tunnelLabels(serviceName string, port int32) map[string]string {


### PR DESCRIPTION
Adds support for TLSRoute and TCPRoute.

I was initially planning on using the listener. hostname from the Gateway to define the domain for these endpoints as we do with HTTPRoute. This is valid per the scheme of the Gateway API and would have made things nice and neat, but Gateway API has X-Validations on the listener hostname that forbid you from using it if the listener protocol is TCP/TLS. This was a major bummer and complicated things a fair bit.

My solution was to add support for Gateway. addresses. This way, you can specify the TCP/TLS addresses from ngrok that you want and then use the listeners to define the ports that all the addresses should listen on. Unfortunately, this limitation means that you will likely have to make several Gateway resources instead of being able to specify all of your TLS/TCP addresses in a single Gateway, but there's nothing we can do about that limitation.

I wasn't initially planning on adding support for Gateway. addresses, but since this introduces that support, I think in the future it might make more sense to move to always using this model, and then instead of using the listener hostnames to define endpoint domains (for HTTPRoutes), we instead use them to add match criteria for the SNI/Host header. That would standardize things but would be a shift in how we do things. I think that a decent middle-ground solution would be to keep the current behavior when Gateway. addresses are not supplied.


Aside from that, something to note is that since TLSRoute/TCPRoute are in the experimental channel, they are not in the standard channel set of CRDs, so we only enable the controllers for them if those CRDs are detected.