### PR TITLE
Lb services reserve tcp addr for endpoints

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -490,6 +490,10 @@ func enableIngressFeatureSet(_ context.Context, opts managerOpts, mgr ctrl.Manag
 		Recorder:      mgr.GetEventRecorderFor("service-controller"),
 		Namespace:     opts.namespace,
 		ClusterDomain: opts.clusterDomain,
+		// TODO(stacks): Once we have a way to support unqualified tcp addresses(i.e. 'tcp://') in the Cloud & Agent Endpoint CRs,
+		// we can remove this. It feels weird to have this here since the ServiceReconciler should only be performing translations
+		// and not dependent on the ngrok API.
+		TCPAddresses: ngrokClientset.TCPAddresses(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Service")
 		os.Exit(1)

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -35,6 +35,13 @@ import (
 )
 
 const (
+	// ComputedURLAnnotation is the annotation key for the computed URL of an endpoint.
+	// This is temporarily used by the Service controller to store reserved TCP addresses,
+	// while we work to add support for assigning TCP addresses to Cloud/Agent Endpoints
+	// when their URL is specified as 'tcp://', for example.
+	ComputedURLAnnotation = "k8s.ngrok.com/computed-url"
+	ComputedURLKey        = "computed-url"
+
 	// DeniedKeyName name of the key that contains the reason to deny a location
 	DeniedKeyName = "Denied"
 
@@ -221,4 +228,10 @@ func ExtractURL(obj client.Object) (string, error) {
 // an error.
 func ExtractDomain(obj client.Object) (string, error) {
 	return parser.GetStringAnnotation(DomainKey, obj)
+}
+
+// ExtractComputedURL extracts the computed URL from the annotation "k8s.ngrok.com/computed-url" if it is present. Otherwise, it returns
+// an error.
+func ExtractComputedURL(obj client.Object) (string, error) {
+	return parser.GetStringAnnotation(ComputedURLKey, obj)
 }

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -38,12 +38,25 @@ const (
 	// DeniedKeyName name of the key that contains the reason to deny a location
 	DeniedKeyName = "Denied"
 
+	// This annotation can be used on services to listen on a specific domain(i.e. a TLS endpoint)
+	// Deprecated: Use the URL annotation instead
+	DomainAnnotation = "k8s.ngrok.com/domain"
+	DomainKey        = "domain"
+
 	// This annotation can be used on ingress/gateway resources to control which ngrok resources (endpoints/edges) get created from it
 	MappingStrategyAnnotation    = "k8s.ngrok.com/mapping-strategy"
 	MappingStrategyAnnotationKey = "mapping-strategy"
 
 	EndpointPoolingAnnotation    = "k8s.ngrok.com/pooling-enabled"
 	EndpointPoolingAnnotationKey = "pooling-enabled"
+
+	// This annotation can be used on a service to control whether the endpoint is a TCP or TLS endpoint.
+	// Examples:
+	//   * tcp://1.tcp.ngrok.io:12345
+	//   * tls://my-domain.com
+	//
+	URLAnnotation = "k8s.ngrok.com/url"
+	URLKey        = "url"
 )
 
 type MappingStrategy string
@@ -196,4 +209,16 @@ func ExtractUseBindings(obj client.Object) ([]string, error) {
 	default:
 		return []string{"public"}, nil
 	}
+}
+
+// Retrieves the value of the annotation "k8s.ngrok.com/url" if it is present. Otherwise, it returns
+// an error.
+func ExtractURL(obj client.Object) (string, error) {
+	return parser.GetStringAnnotation(URLKey, obj)
+}
+
+// ExtractDomain extracts the domain from the annotation "k8s.ngrok.com/domain" if it is present. Otherwise, it returns
+// an error.
+func ExtractDomain(obj client.Object) (string, error) {
+	return parser.GetStringAnnotation(DomainKey, obj)
 }

--- a/internal/controller/agent/agent_endpoint_controller.go
+++ b/internal/controller/agent/agent_endpoint_controller.go
@@ -372,11 +372,16 @@ func (r *AgentEndpointReconciler) ensureDomainExists(ctx context.Context, aep *n
 		return fmt.Errorf("failed to parse URL %q from AgentEndpoint \"%s.%s\"", aep.Spec.URL, aep.Name, aep.Namespace)
 	}
 
+	// Ngrok TCP URLs do not have to be reserved
+	if parsedURL.Scheme == "tcp" && strings.HasSuffix(parsedURL.Hostname(), "tcp.ngrok.io") {
+		return nil
+	}
+
 	// TODO: generate a domain for blank strings
 	domain := parsedURL.Hostname()
 	hyphenatedDomain := ingressv1alpha1.HyphenatedDomainNameFromURL(domain)
 	if strings.HasSuffix(domain, ".internal") {
-		// Skip creating the Domain CRD for reserved TLDs
+		// Skip creating the Domain CR for ngrok TCP URLs
 		return nil
 	}
 

--- a/internal/controller/ingress/service_controller.go
+++ b/internal/controller/ingress/service_controller.go
@@ -507,6 +507,12 @@ func (r *ServiceReconciler) buildEndpoints(ctx context.Context, svc *corev1.Serv
 			},
 		})
 
+		// We've added a new rule to the traffic policy, so we need to re-marshall it
+		rawPolicy, err = json.Marshal(tp)
+		if err != nil {
+			return objects, err
+		}
+
 		cloudEndpoint := &ngrokv1alpha1.CloudEndpoint{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: svc.Name + "-",

--- a/internal/controller/ngrok/cloudendpoint_controller.go
+++ b/internal/controller/ngrok/cloudendpoint_controller.go
@@ -310,7 +310,18 @@ func (r *CloudEndpointReconciler) findTrafficPolicyByName(ctx context.Context, t
 
 // ensureDomainExists checks if the Domain CRD exists, and if not, creates it.
 func (r *CloudEndpointReconciler) ensureDomainExists(ctx context.Context, clep *ngrokv1alpha1.CloudEndpoint) (*ingressv1alpha1.Domain, error) {
-	domain := r.extractDomain(clep)
+	parsedURL, err := url.Parse(clep.Spec.URL)
+	if err != nil {
+		r.Recorder.Event(clep, v1.EventTypeWarning, "InvalidURL", fmt.Sprintf("Failed to parse URL: %s", clep.Spec.URL))
+		return nil, err
+	}
+
+	if parsedURL.Scheme == "tcp" && strings.HasSuffix(parsedURL.Hostname(), "tcp.ngrok.io") {
+		// Skip creating the Domain CR for ngrok TCP URLs
+		return nil, nil
+	}
+	domain := parsedURL.Hostname()
+
 	hyphenatedDomain := ingressv1alpha1.HyphenatedDomainNameFromURL(domain)
 	if domainEndsInReservedTLD(domain) {
 		// Skip creating the Domain CRD for reserved TLDs
@@ -321,7 +332,7 @@ func (r *CloudEndpointReconciler) ensureDomainExists(ctx context.Context, clep *
 
 	// Check if the Domain CRD already exists
 	domainObj := &ingressv1alpha1.Domain{}
-	err := r.Get(ctx, client.ObjectKey{Name: hyphenatedDomain, Namespace: clep.Namespace}, domainObj)
+	err = r.Get(ctx, client.ObjectKey{Name: hyphenatedDomain, Namespace: clep.Namespace}, domainObj)
 	if err == nil {
 		// Domain already exists
 		if domainObj.Status.ID == "" {
@@ -360,15 +371,4 @@ func (r *CloudEndpointReconciler) ensureDomainExists(ctx context.Context, clep *
 func domainEndsInReservedTLD(domain string) bool {
 	// Check if the domain ends in the "internal" tld
 	return strings.HasSuffix(domain, ".internal")
-}
-
-// extractDomain parses the URL using Go's net/url package and extracts the host part.
-func (r *CloudEndpointReconciler) extractDomain(clep *ngrokv1alpha1.CloudEndpoint) string {
-	parsedURL, err := url.Parse(clep.Spec.URL)
-	if err != nil {
-		r.Recorder.Event(clep, v1.EventTypeWarning, "InvalidURL", fmt.Sprintf("Failed to parse URL: %s", clep.Spec.URL))
-		return ""
-	}
-
-	return parsedURL.Hostname()
 }

--- a/internal/controller/ngrok/cloudendpoint_controller_test.go
+++ b/internal/controller/ngrok/cloudendpoint_controller_test.go
@@ -15,55 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func Test_extractDomain(t *testing.T) {
-	r := &CloudEndpointReconciler{}
-
-	tests := []struct {
-		name     string
-		inputURL string
-		expected string
-	}{
-		{
-			name:     "standard https URL",
-			inputURL: "https://example.com",
-			expected: "example.com",
-		},
-		{
-			name:     "URL with port",
-			inputURL: "https://example.com:8080",
-			expected: "example.com",
-		},
-		{
-			name:     "URL with path",
-			inputURL: "https://example.com/path",
-			expected: "example.com",
-		},
-		{
-			name:     "tcp URL",
-			inputURL: "tcp://example.com:443",
-			expected: "example.com",
-		},
-		{
-			name:     "invalid URL",
-			inputURL: "http:/example.com",
-			expected: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a CloudEndpoint with the input URL
-			clep := &ngrokv1alpha1.CloudEndpoint{
-				Spec: ngrokv1alpha1.CloudEndpointSpec{
-					URL: tt.inputURL,
-				},
-			}
-			result := r.extractDomain(clep)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func Test_findTrafficPolicy(t *testing.T) {
 	// Set up a fake client with a sample TrafficPolicy
 	scheme := runtime.NewScheme()


### PR DESCRIPTION
This should fix #618

## What

When using the endpoints mapping strategy, LB services weren't working and were stuck in progressing due to the cloud endpoints not being able to be created. The long term plan is that CloudEndpoints and Agent Endpoints can handle a URL like `tcp://` by reserving one. Ideally, this is even handled in the ngrok API for you.

For now, we need a workaround for this.

## How

* There is a new annotation `k8s.ngrok.com/url` that more closely matches the semantics of the ngrok CLI command.
* If the `k8s.ngrok.com/url` annotation is unspecified, we fall back to the old `k8s.ngrok.com/domain` annotation and warn that this annotation is deprecated.
* This isn't a great long term solution, but since making CLEP and AEP understand how to reserve addrs is a bigger refactor, we reserve a TCP addr in the services controller if the url is `tcp://` and then write it back as a `k8s.ngrok.com/computed-url` annotation. I don't love this solution, as it adds the ngrok API into the service controller instead of being a pure translation layer.
* We should come back and fix this in a better way once CLEP & AEP can reserve addrs.

## Breaking Changes
No