### PR TITLE
enable trivy container scanning job

### DIFF
--- a/.github/workflows/trivy-image-scan.yaml
+++ b/.github/workflows/trivy-image-scan.yaml
@@ -1,0 +1,52 @@
+name: Trivy Image Scan
+
+on:
+  push:
+    branches:
+    - "main"
+  schedule:
+  - cron: '0 16 * * 1' # Run every Monday at 8:00 Pacific (16:00 UTC)
+
+env:
+  GO_VERSION: '1.24'
+  DOCKER_BUILDX_PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  image-scan:
+    name: Image Scan
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      security-events: write   # so SARIF can appear in “Code scanning”
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - id: buildx-setup
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        platforms: linux/amd64 # Load in the following step supports only one image and linux/amd64 is fine for scanning
+    - name: Build
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        platforms: linux/amd64
+        push: false
+        load: true # Loads the image to the local docker daemon so trivy can scan it without us needing to push anything
+        tags: ngrok/ngrok-operator:latest
+
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@v0.30.0
+      with:
+        image-ref: ngrok/ngrok-operator:latest
+        severity: 'CRITICAL,HIGH'
+        exit-code: '1' # fail job on HIGH/CRITICAL vulns
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Enables a job that will run on merge to main and every Monday at ~8:00 Pacific (at least one of us who works on the operator should be awake and online by then). The job builds an image from main and uses trivy to scan the built image for vulnerabilities. 