### PR TITLE
remove generated bindings from ingress/gateway resources

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -202,7 +202,7 @@ func ExtractUseBindings(obj client.Object) ([]string, error) {
 	bindings, err := parser.GetStringSliceAnnotation("bindings", obj)
 	if err != nil {
 		if errors.IsMissingAnnotations(err) {
-			return []string{"public"}, nil
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func ExtractUseBindings(obj client.Object) ([]string, error) {
 	case n == 1:
 		return bindings, nil
 	default:
-		return []string{"public"}, nil
+		return nil, nil
 	}
 }
 

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -244,7 +244,7 @@ func TestExtractUseBindings(t *testing.T) {
 		{
 			name:        "Annotation Not present",
 			annotations: nil,
-			expected:    []string{"public"},
+			expected:    nil,
 			expectedErr: nil,
 		},
 	}

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
@@ -104,8 +104,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -150,5 +148,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - internal

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
@@ -94,8 +94,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -135,8 +133,6 @@ expected:
       url: "https://e3b0c-same-namespace-svc-default-8080.internal"
       upstream:
         url: "http://same-namespace-svc.default:8080"
-      bindings:
-      - internal
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -149,5 +145,3 @@ expected:
       url: "https://e3b0c-cross-namespace-svc-other-8080.internal"
       upstream:
         url: "http://cross-namespace-svc.other:8080"
-      bindings:
-      - internal

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
@@ -74,8 +74,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -108,5 +106,3 @@ expected:
       url: "https://e3b0c-test-service-1-foo-8080.internal"
       upstream:
         url: "http://test-service-1.foo:8080"
-      bindings:
-      - internal

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
@@ -84,8 +84,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -118,5 +116,3 @@ expected:
       url: "https://e3b0c-test-service-1-foo-8080.internal"
       upstream:
         url: "http://test-service-1.foo:8080"
-      bindings:
-      - internal

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-valid-kinds.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-valid-kinds.yaml
@@ -74,8 +74,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -108,5 +106,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation-invalid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation-invalid.yaml
@@ -106,5 +106,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-collapse-endpoints-multiple.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-collapse-endpoints-multiple.yaml
@@ -120,8 +120,6 @@ expected:
       url: "https://test-hostname.ngrok.io"
       upstream:
         url: "http://test-service-2.default:8080"
-      bindings:
-      - "public"
       trafficPolicy:
         inline:
           on_http_request:
@@ -154,7 +152,7 @@ expected:
               actions:
                 - type: set-vars
                   config:
-                    vars: 
+                    vars:
                     - request_matched_local_svc: true
             - name: Fallback-404
               expressions:
@@ -178,5 +176,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-default-to-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-default-to-endpoints.yaml
@@ -74,8 +74,6 @@ expected:
       url: "https://test-hostname.ngrok.io"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "public"
       trafficPolicy:
         inline:
             on_http_request:
@@ -92,7 +90,7 @@ expected:
                 actions:
                   - type: set-vars
                     config:
-                      vars: 
+                      vars:
                       - request_matched_local_svc: true
               - name: Fallback-404
                 expressions:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-endpoints-non-collapsable.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-endpoints-non-collapsable.yaml
@@ -98,8 +98,6 @@ expected:
       name: test-gateway.default-test-hostname-2.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -135,8 +133,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -176,8 +172,6 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -190,5 +184,3 @@ expected:
       url: "https://e3b0c-test-service-2-default-8080.internal"
       upstream:
         url: "http://test-service-2.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-infrastructure.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-infrastructure.yaml
@@ -79,8 +79,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -116,5 +114,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-invalid-mapping-strategy.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-invalid-mapping-strategy.yaml
@@ -83,8 +83,6 @@ expected:
       url: "https://test-hostname.ngrok.io"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "public"
       trafficPolicy:
         inline:
           on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
@@ -122,8 +122,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -168,5 +166,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - internal

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid.yaml
@@ -102,8 +102,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -148,5 +146,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-multi-gateway.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-multi-gateway.yaml
@@ -116,8 +116,6 @@ expected:
       name: test-gateway-1.default-test-hostname-1.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -146,8 +144,6 @@ expected:
       name: test-gateway-2.default-test-hostname-2.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -183,8 +179,6 @@ expected:
       url: "https://e3b0c-test-service-1-default-mtls-3039d-8080.internal"
       upstream:
         url: "https://test-service-1.default:8080"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -200,5 +194,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-mtls-96179-8080.internal"
       upstream:
         url: "https://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-refgrant.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-refgrant.yaml
@@ -124,8 +124,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -168,8 +166,6 @@ expected:
       url: "https://e3b0c-test-service-https-default-mtls-f2538-8443.internal"
       upstream:
         url: "https://test-service-https.default:8443"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -182,5 +178,3 @@ expected:
       url: "https://e3b0c-test-service-http-default-8080.internal"
       upstream:
         url: "http://test-service-http.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid.yaml
@@ -108,8 +108,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -152,8 +150,6 @@ expected:
       url: "https://e3b0c-test-service-https-default-mtls-baff5-443.internal"
       upstream:
         url: "https://test-service-https.default:443"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -166,5 +162,3 @@ expected:
       url: "https://e3b0c-test-service-http-default-80.internal"
       upstream:
         url: "http://test-service-http.default:80"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-glob-hostname.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-glob-hostname.yaml
@@ -71,8 +71,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -105,5 +103,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-no-hostnames.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-no-hostnames.yaml
@@ -69,8 +69,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -103,5 +101,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-weighted-routes-with-rewrite.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-weighted-routes-with-rewrite.yaml
@@ -50,7 +50,7 @@ input:
             filters:
             - type: URLRewrite
               urlRewrite:
-                path: 
+                path:
                   type: ReplacePrefixMatch
                   replacePrefixMatch: "/rewrite-svc-1"
           - group: ""
@@ -61,7 +61,7 @@ input:
             filters:
             - type: URLRewrite
               urlRewrite:
-                path: 
+                path:
                   type: ReplacePrefixMatch
                   replacePrefixMatch: "/rewrite-svc-2"
   services:
@@ -100,8 +100,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -177,8 +175,6 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -191,5 +187,3 @@ expected:
       url: "https://e3b0c-test-service-2-default-8080.internal"
       upstream:
         url: "http://test-service-2.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-invalid-backendrefs.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-invalid-backendrefs.yaml
@@ -110,8 +110,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -144,5 +142,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-invalid-externalref-filters.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-invalid-externalref-filters.yaml
@@ -82,8 +82,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -116,5 +114,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-listener-port-and-protocol.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-listener-port-and-protocol.yaml
@@ -71,8 +71,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -105,5 +103,3 @@ expected:
       url: "http://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-matching-rules.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-matching-rules.yaml
@@ -86,8 +86,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -125,5 +123,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-missing-filter-configs.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-missing-filter-configs.yaml
@@ -78,8 +78,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -112,5 +110,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
@@ -102,8 +102,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -139,6 +137,3 @@ expected:
       url: "https://e3b0c-same-namespace-svc-default-8080.internal"
       upstream:
         url: "http://same-namespace-svc.default:8080"
-      bindings:
-      - internal
-

--- a/pkg/managerdriver/testdata/translator/gwapi-redirects.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-redirects.yaml
@@ -44,7 +44,7 @@ input:
         filters:
         - type: RequestRedirect
           requestRedirect:
-            path: 
+            path:
               type: ReplacePrefixMatch
               replacePrefixMatch: "/redirect"
       - matches:
@@ -54,7 +54,7 @@ input:
         filters:
         - type: RequestRedirect
           requestRedirect:
-            path: 
+            path:
               type: ReplaceFullPath
               replaceFullPath: "/redirect"
       - matches:
@@ -105,8 +105,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-request-headers.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-request-headers.yaml
@@ -93,8 +93,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -155,5 +153,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-request-mirror-not-supported.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-request-mirror-not-supported.yaml
@@ -79,8 +79,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -113,5 +111,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-response-headers.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-response-headers.yaml
@@ -93,8 +93,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -156,5 +154,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-rewrites.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-rewrites.yaml
@@ -44,7 +44,7 @@ input:
         filters:
         - type: URLRewrite
           urlRewrite:
-            path: 
+            path:
               type: ReplacePrefixMatch
               replacePrefixMatch: "/rewrite"
       - matches:
@@ -54,7 +54,7 @@ input:
         filters:
         - type: URLRewrite
           urlRewrite:
-            path: 
+            path:
               type: ReplaceFullPath
               replaceFullPath: "/rewrite"
       - matches:
@@ -89,8 +89,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_http_request:

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-multigateway.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-multigateway.yaml
@@ -97,8 +97,6 @@ expected:
       name: test-gateway.default.9000-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -132,8 +130,6 @@ expected:
       name: test-gateway-2.default.7000-test-hostname-2.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -171,8 +167,6 @@ expected:
       url: "tcp://e3b0c-test-service-1-default.internal:11000"
       upstream:
         url: "tcp://test-service-1.default:11000"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -185,5 +179,3 @@ expected:
       url: "tcp://e3b0c-test-service-2-default.internal:12000"
       upstream:
         url: "tcp://test-service-2.default:12000"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-multihost.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-multihost.yaml
@@ -85,8 +85,6 @@ expected:
       name: test-gateway.default.9000-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -120,8 +118,6 @@ expected:
       name: test-gateway.default.7000-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -155,8 +151,6 @@ expected:
       name: test-gateway.default.9000-test-hostname-2.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -190,8 +184,6 @@ expected:
       name: test-gateway.default.7000-test-hostname-2.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -229,8 +221,6 @@ expected:
       url: "tcp://e3b0c-test-service-1-default.internal:11000"
       upstream:
         url: "tcp://test-service-1.default:11000"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -243,5 +233,3 @@ expected:
       url: "tcp://e3b0c-test-service-2-default.internal:12000"
       upstream:
         url: "tcp://test-service-2.default:12000"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-simple.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-simple.yaml
@@ -68,5 +68,3 @@ expected:
       url: "tcp://test-hostname.ngrok.io:9000"
       upstream:
         url: "tcp://test-service-1.default:11000"
-      bindings:
-      - "public"

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-tls-upstream.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-tls-upstream.yaml
@@ -70,5 +70,3 @@ expected:
       url: "tcp://test-hostname.ngrok.io:9000"
       upstream:
         url: "tls://test-service-1.default:11000"
-      bindings:
-      - "public"

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-weighted.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-weighted.yaml
@@ -83,8 +83,6 @@ expected:
       url: "tcp://test-hostname.ngrok.io:9000"
       upstream:
         url: "tcp://test-service-2.default:12000"
-      bindings:
-      - "public"
       trafficPolicy:
         inline:
           on_tcp_connect:
@@ -117,7 +115,7 @@ expected:
             actions:
               - type: set-vars
                 config:
-                  vars: 
+                  vars:
                   - request_matched_local_svc: true
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
@@ -131,5 +129,3 @@ expected:
       url: "tcp://e3b0c-test-service-1-default.internal:11000"
       upstream:
         url: "tcp://test-service-1.default:11000"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-tls-tcp-routes-collapsed.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tls-tcp-routes-collapsed.yaml
@@ -109,8 +109,6 @@ expected:
       url: "tcp://5.tcp.ngrok.io:24429"
       upstream:
         url: "tcp://test-service-tcp.default:7000"
-      bindings:
-      - "public"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -123,5 +121,3 @@ expected:
       url: "tls://3.tcp.ngrok.io:20183"
       upstream:
         url: "tls://test-service-tls.default:9000"
-      bindings:
-      - "public"

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multigateway.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multigateway.yaml
@@ -97,8 +97,6 @@ expected:
       name: test-gateway.default.9000-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -132,8 +130,6 @@ expected:
       name: test-gateway-2.default.7000-test-hostname-2.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -171,8 +167,6 @@ expected:
       url: "tls://e3b0c-test-service-1-default.internal:11000"
       upstream:
         url: "tls://test-service-1.default:11000"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -185,5 +179,3 @@ expected:
       url: "tls://e3b0c-test-service-2-default.internal:12000"
       upstream:
         url: "tls://test-service-2.default:12000"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multihost.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multihost.yaml
@@ -85,8 +85,6 @@ expected:
       name: test-gateway.default.9000-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -120,8 +118,6 @@ expected:
       name: test-gateway.default.7000-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -155,8 +151,6 @@ expected:
       name: test-gateway.default.9000-test-hostname-2.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -190,8 +184,6 @@ expected:
       name: test-gateway.default.7000-test-hostname-2.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
           on_tcp_connect:
@@ -229,8 +221,6 @@ expected:
       url: "tls://e3b0c-test-service-1-default.internal:11000"
       upstream:
         url: "tls://test-service-1.default:11000"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -243,5 +233,3 @@ expected:
       url: "tls://e3b0c-test-service-2-default.internal:12000"
       upstream:
         url: "tls://test-service-2.default:12000"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-simple.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-simple.yaml
@@ -68,5 +68,3 @@ expected:
       url: "tls://test-hostname.ngrok.io:9000"
       upstream:
         url: "tls://test-service-1.default:11000"
-      bindings:
-      - "public"

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-tcp-upstream.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-tcp-upstream.yaml
@@ -70,5 +70,3 @@ expected:
       url: "tls://test-hostname.ngrok.io:9000"
       upstream:
         url: "tcp://test-service-1.default:11000"
-      bindings:
-      - "public"

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-weighted.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-weighted.yaml
@@ -83,8 +83,6 @@ expected:
       url: "tls://test-hostname.ngrok.io:9000"
       upstream:
         url: "tls://test-service-2.default:12000"
-      bindings:
-      - "public"
       trafficPolicy:
         inline:
           on_tcp_connect:
@@ -117,7 +115,7 @@ expected:
             actions:
               - type: set-vars
                 config:
-                  vars: 
+                  vars:
                   - request_matched_local_svc: true
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
@@ -131,5 +129,3 @@ expected:
       url: "tls://e3b0c-test-service-1-default.internal:11000"
       upstream:
         url: "tls://test-service-1.default:11000"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-annotation.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-annotation.yaml
@@ -91,8 +91,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -135,5 +133,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-filter-tcp-error.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-filter-tcp-error.yaml
@@ -65,7 +65,7 @@ input:
         protocol: TCP
         targetPort: http
       type: ClusterIP
-  trafficPolicies: 
+  trafficPolicies:
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: NgrokTrafficPolicy
     metadata:
@@ -90,8 +90,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -124,5 +122,4 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"
+

--- a/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
@@ -109,8 +109,6 @@ expected:
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       trafficPolicy:
         policy:
             on_http_request:
@@ -150,8 +148,6 @@ expected:
       url: "https://e3b0c-same-namespace-svc-default-8080.internal"
       upstream:
         url: "http://same-namespace-svc.default:8080"
-      bindings:
-      - internal
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -164,5 +160,3 @@ expected:
       url: "https://e3b0c-cross-namespace-svc-other-8080.internal"
       upstream:
         url: "http://cross-namespace-svc.other:8080"
-      bindings:
-      - internal

--- a/pkg/managerdriver/testdata/translator/ingress-app-protocols.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-app-protocols.yaml
@@ -113,8 +113,6 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:
@@ -169,8 +167,6 @@ expected:
       upstream:
         url: "http://test-service-1.default:80"
         protocol: http1
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -183,8 +179,6 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -198,8 +192,6 @@ expected:
       upstream:
         url: "http://test-service-2.default:443"
         protocol: http2
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -213,5 +205,3 @@ expected:
       upstream:
         url: "http://test-service-3.default:443"
         protocol: http2
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/ingress-default-backend-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-default-backend-conflict.yaml
@@ -90,7 +90,7 @@ input:
       type: ClusterIP
   trafficPolicies: []
 expected:
-  # Generated cloud endpoint should have the routes and default backend from the first ingress, but 
+  # Generated cloud endpoint should have the routes and default backend from the first ingress, but
   # the second ingress will not be processed due to the conflicting default destination
   cloudEndpoints:
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
@@ -102,8 +102,6 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:
@@ -141,5 +139,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/ingress-namespace-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-namespace-conflict.yaml
@@ -92,8 +92,6 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: aaa
     spec:
-      bindings:
-      - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:
@@ -126,5 +124,3 @@ expected:
       url: "https://e3b0c-test-service-1-aaa-8080.internal"
       upstream:
         url: "http://test-service-1.aaa:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/ingress-pooling-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-pooling-conflict.yaml
@@ -94,8 +94,6 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       url: https://test-ingresses.ngrok.io
       poolingEnabled: true
       trafficPolicy:
@@ -129,5 +127,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/ingress-trafficpolicy-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-trafficpolicy-conflict.yaml
@@ -80,7 +80,7 @@ input:
         protocol: TCP
         targetPort: http
       type: ClusterIP
-  trafficPolicies: 
+  trafficPolicies:
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: NgrokTrafficPolicy
     metadata:
@@ -130,8 +130,6 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:
@@ -174,5 +172,3 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/ingress-valid-collapse-default-backend.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid-collapse-default-backend.yaml
@@ -50,7 +50,7 @@ input:
         protocol: TCP
         targetPort: http
       type: ClusterIP
-  trafficPolicies: 
+  trafficPolicies:
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: NgrokTrafficPolicy
     metadata:
@@ -82,8 +82,6 @@ expected:
       url: "https://test-ingresses.ngrok.io"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "public"
       trafficPolicy:
         inline:
           on_http_request:
@@ -110,7 +108,7 @@ expected:
             actions:
             - type: set-vars
               config:
-                vars: 
+                vars:
                 - request_matched_local_svc: true
           - name: Fallback-404
             expressions:

--- a/pkg/managerdriver/testdata/translator/ingress-valid-collapse-simple.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid-collapse-simple.yaml
@@ -46,7 +46,7 @@ input:
         protocol: TCP
         targetPort: http
       type: ClusterIP
-  trafficPolicies: 
+  trafficPolicies:
 expected:
   cloudEndpoints: []
   agentEndpoints:
@@ -62,8 +62,6 @@ expected:
       url: "https://test-ingresses.ngrok.io"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "public"
       trafficPolicy:
         inline:
           on_http_request:

--- a/pkg/managerdriver/testdata/translator/ingress-valid-default-to-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid-default-to-endpoints.yaml
@@ -89,7 +89,7 @@ input:
         protocol: TCP
         targetPort: http
       type: ClusterIP
-  trafficPolicies: 
+  trafficPolicies:
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: NgrokTrafficPolicy
     metadata:
@@ -125,8 +125,6 @@ expected:
       url: "https://test-ingresses.ngrok.io"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "public"
       trafficPolicy:
         inline:
           on_http_request:
@@ -193,5 +191,3 @@ expected:
       url: "https://e3b0c-test-service-2-default-8080.internal"
       upstream:
         url: "http://test-service-2.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/testdata/translator/ingress-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid.yaml
@@ -90,7 +90,7 @@ input:
         protocol: TCP
         targetPort: http
       type: ClusterIP
-  trafficPolicies: 
+  trafficPolicies:
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: NgrokTrafficPolicy
     metadata:
@@ -122,8 +122,6 @@ expected:
       name: test-ingresses.ngrok.io
       namespace: default
     spec:
-      bindings:
-      - public
       url: https://test-ingresses.ngrok.io
       trafficPolicy:
         policy:
@@ -178,8 +176,6 @@ expected:
       url: "https://e3b0c-test-service-1-default-8080.internal"
       upstream:
         url: "http://test-service-1.default:8080"
-      bindings:
-      - "internal"
   - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
     kind: AgentEndpoint
     metadata:
@@ -192,5 +188,3 @@ expected:
       url: "https://e3b0c-test-service-2-default-8080.internal"
       upstream:
         url: "http://test-service-2.default:8080"
-      bindings:
-      - "internal"

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -820,7 +820,7 @@ func buildAgentEndpoint(
 	clusterDomain string,
 	metadata string,
 ) (*ngrokv1alpha1.AgentEndpoint, error) {
-	bindings := []string{"internal"}
+	bindings := []string{}
 	var url string
 	if irVHost.CollapseIntoServiceKey != nil && irService.Key() == *irVHost.CollapseIntoServiceKey {
 		publicURL, err := buildPublicURL(irVHost)
@@ -858,8 +858,11 @@ func buildAgentEndpoint(
 				URL:      agentEndpointUpstreamURL(irService.Name, irService.Namespace, clusterDomain, irService.Port, irService.Scheme),
 				Protocol: irService.Protocol,
 			},
-			Bindings: bindings,
 		},
+	}
+
+	if len(bindings) > 0 {
+		ret.Spec.Bindings = bindings
 	}
 
 	for _, certRef := range irService.ClientCertRefs {

--- a/pkg/managerdriver/translator_test.go
+++ b/pkg/managerdriver/translator_test.go
@@ -142,7 +142,7 @@ func TestBuildInternalAgentEndpoint(t *testing.T) {
 			assert.Equal(t, tc.metadata, result.Spec.Metadata, "unexpected metadata for test case: %s", tc.name)
 			assert.Equal(t, tc.expectedURL, result.Spec.URL, "unexpected URL for test case: %s", tc.name)
 			assert.Equal(t, tc.expectedUpstream, result.Spec.Upstream.URL, "unexpected upstream URL for test case: %s", tc.name)
-			assert.Equal(t, []string{"internal"}, result.Spec.Bindings, "unexpected bindings for test case: %s", tc.name)
+			assert.ElementsMatch(t, []string{}, result.Spec.Bindings, "unexpected bindings for test case: %s", tc.name)
 			assert.Equal(t, tc.irService.Protocol, result.Spec.Upstream.Protocol, "unexpected upstream protocol for test case: %s", tc.name)
 		})
 	}


### PR DESCRIPTION
Removes the `spec.bindings` which was always added to `CloudEndpoint` and `AgentEndpoint` resources that were generated from `Ingress` and `Gateway`/`HTTPRoute`/`TLSRoute`/`TCPRoute` resources.

We used to always include `bindings: ["public"]` and `bindings: ["internal"]` for public/internal endpoints, but this is not necessary as the server will create a public/internal endpoint for you based on the TLD.

This means that you are no longer required to supply `k8s.ngrok.io/bindings: internal` if you want internal endpoints from Gateway API and Ingress resources. Just make sure your hostname ends in `.internal` if you want internal endpoints (this was already a requirement).

For Kubernetes bound endpoints, `k8s.ngrok.io/bindings: kubernetes` is still required 