### PR TITLE
fix(api-manager): panic when TCP/TLS Route CRDs are not installed.

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -228,20 +228,20 @@ func startOperator(ctx context.Context, opts managerOpts) error {
 			resourceList, err := discoveryClient.ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1alpha2")
 			if err != nil {
 				setupLog.Error(err, "unable to check if TLSRoute/TCPRoute CRDs are installed, support for them will not be enabled")
-			}
-
-			for _, r := range resourceList.APIResources {
-				if strings.EqualFold(r.Name, "TLSRoutes") {
-					tlsRouteCRDInstalled = true
-					continue
-				}
-				if strings.EqualFold(r.Name, "TCPRoutes") {
-					tcpRouteCRDInstalled = true
-					continue
-				}
-				// If we found both, no need to check other resources
-				if tcpRouteCRDInstalled && tlsRouteCRDInstalled {
-					break
+			} else {
+				for _, r := range resourceList.APIResources {
+					if strings.EqualFold(r.Name, "TLSRoutes") {
+						tlsRouteCRDInstalled = true
+						continue
+					}
+					if strings.EqualFold(r.Name, "TCPRoutes") {
+						tcpRouteCRDInstalled = true
+						continue
+					}
+					// If we found both, no need to check other resources
+					if tcpRouteCRDInstalled && tlsRouteCRDInstalled {
+						break
+					}
 				}
 			}
 

--- a/pkg/managerdriver/driver.go
+++ b/pkg/managerdriver/driver.go
@@ -55,6 +55,8 @@ type Driver struct {
 	syncAllowConcurrent bool
 
 	gatewayEnabled                bool
+	gatewayTCPRouteEnabled        bool
+	gatewayTLSRouteEnabled        bool
 	disableGatewayReferenceGrants bool
 }
 
@@ -81,6 +83,18 @@ func WithSyncAllowConcurrent(allowed bool) DriverOpt {
 func WithClusterDomain(domain string) DriverOpt {
 	return func(d *Driver) {
 		d.clusterDomain = domain
+	}
+}
+
+func WithGatewayTCPRouteEnabled(enabled bool) DriverOpt {
+	return func(d *Driver) {
+		d.gatewayTCPRouteEnabled = enabled
+	}
+}
+
+func WithGatewayTLSRouteEnabled(enabled bool) DriverOpt {
+	return func(d *Driver) {
+		d.gatewayTLSRouteEnabled = enabled
 	}
 }
 
@@ -285,10 +299,16 @@ func (d *Driver) Seed(ctx context.Context, c client.Reader) error {
 			&gatewayv1.Gateway{},
 			&gatewayv1.GatewayClass{},
 			&gatewayv1.HTTPRoute{},
-			&gatewayv1alpha2.TCPRoute{},
-			&gatewayv1alpha2.TLSRoute{},
 			&gatewayv1beta1.ReferenceGrant{},
 		)
+
+		if d.gatewayTCPRouteEnabled {
+			typesToSeed = append(typesToSeed, &gatewayv1alpha2.TCPRoute{})
+		}
+
+		if d.gatewayTLSRouteEnabled {
+			typesToSeed = append(typesToSeed, &gatewayv1alpha2.TLSRoute{})
+		}
 	}
 
 	for _, v := range typesToSeed {

--- a/pkg/managerdriver/translator_test.go
+++ b/pkg/managerdriver/translator_test.go
@@ -535,6 +535,8 @@ func TestTranslate(t *testing.T) {
 			},
 			WithGatewayEnabled(true),
 			WithSyncAllowConcurrent(true),
+			WithGatewayTCPRouteEnabled(true),
+			WithGatewayTLSRouteEnabled(true),
 		)
 		t.Run(filepath.Base(file), func(t *testing.T) {
 			tc := loadTranslatorTestCase(t, file, sch)


### PR DESCRIPTION
## What

Ran into a panic locally on the latest release when having the Gateway API CRDs installed, but without the TCP & TLS Route CRDs. This should fix the panic.

## How

1. Only try to read the resource list from the dynamic client for `gateway.networking.k8s.io/v1alpha2` if the `err == nil`. This  fixes the panic.
2. We also need to conditionally seed `&gatewayv1alpha2.TCPRoute{})` and `&gatewayv1alpha2.TLSRoute{})` only if they are enabled.

## Breaking Changes
No