### PR TITLE
feat: Add a reclaimPolicy to domains

### DIFF
--- a/api/ingress/v1alpha1/domain_types.go
+++ b/api/ingress/v1alpha1/domain_types.go
@@ -34,6 +34,13 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+type DomainReclaimPolicy string
+
+const (
+	DomainReclaimPolicyDelete DomainReclaimPolicy = "Delete"
+	DomainReclaimPolicyRetain DomainReclaimPolicy = "Retain"
+)
+
 // DomainSpec defines the desired state of Domain
 type DomainSpec struct {
 	ngrokAPICommon `json:",inline"`
@@ -45,6 +52,11 @@ type DomainSpec struct {
 	// Region is the region in which to reserve the domain
 	// +kubebuilder:validation:Required
 	Region string `json:"region,omitempty"`
+
+	// DomainReclaimPolicy is the policy to use when the domain is deleted
+	// +kubebuilder:validation:Enum=Delete;Retain
+	// +kubebuilder:default=Delete
+	ReclaimPolicy DomainReclaimPolicy `json:"reclaimPolicy,omitempty"`
 }
 
 // DomainStatus defines the observed state of Domain
@@ -71,9 +83,10 @@ type DomainStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ID",type=string,JSONPath=`.status.id`,description="Domain ID"
+// +kubebuilder:printcolumn:name="Reclaim Policy",type=string,JSONPath=`.spec.reclaimPolicy`,description="Reclaim Policy"
 // +kubebuilder:printcolumn:name="Region",type=string,JSONPath=`.status.region`,description="Region"
 // +kubebuilder:printcolumn:name="Domain",type=string,JSONPath=`.status.domain`,description="Domain"
-// +kubebuilder:printcolumn:name="CNAME Target",type=string,JSONPath=`.status.cnameTarget`,description="CNAME Target"
+// +kubebuilder:printcolumn:name="CNAME Target",type=string,JSONPath=`.status.cnameTarget`,description="CNAME Target",priority=2
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 
 // Domain is the Schema for the domains API

--- a/helm/ngrok-operator/templates/crds/ingress.k8s.ngrok.com_domains.yaml
+++ b/helm/ngrok-operator/templates/crds/ingress.k8s.ngrok.com_domains.yaml
@@ -19,6 +19,10 @@ spec:
       jsonPath: .status.id
       name: ID
       type: string
+    - description: Reclaim Policy
+      jsonPath: .spec.reclaimPolicy
+      name: Reclaim Policy
+      type: string
     - description: Region
       jsonPath: .status.region
       name: Region
@@ -30,6 +34,7 @@ spec:
     - description: CNAME Target
       jsonPath: .status.cnameTarget
       name: CNAME Target
+      priority: 2
       type: string
     - description: Age
       jsonPath: .metadata.creationTimestamp
@@ -72,6 +77,14 @@ spec:
                 default: '{"owned-by":"kubernetes-ingress-controller"}'
                 description: Metadata is a string of arbitrary data associated with
                   the object in the ngrok API/Dashboard
+                type: string
+              reclaimPolicy:
+                default: Delete
+                description: DomainReclaimPolicy is the policy to use when the domain
+                  is deleted
+                enum:
+                - Delete
+                - Retain
                 type: string
               region:
                 description: Region is the region in which to reserve the domain

--- a/internal/controller/ingress/domain_controller.go
+++ b/internal/controller/ingress/domain_controller.go
@@ -163,6 +163,10 @@ func (r *DomainReconciler) update(ctx context.Context, domain *ingressv1alpha1.D
 }
 
 func (r *DomainReconciler) delete(ctx context.Context, domain *ingressv1alpha1.Domain) error {
+	if domain.Spec.ReclaimPolicy != ingressv1alpha1.DomainReclaimPolicyDelete {
+		return nil
+	}
+
 	err := r.DomainsClient.Delete(ctx, domain.Status.ID)
 	if err == nil || ngrok.IsNotFound(err) {
 		domain.Status.ID = ""


### PR DESCRIPTION
## What

Domains are somewhat unique among the ngrok API types, especially ngrok managed domains. Once you reserve one, it belongs to you. If you delete it, it is released back into the pool and someone else can reserve it. Since domains also count against your limits, sometimes you want to delete them if they are only used temporarily so it doesn't impact your account limits. Other times, you want to keep the domain around as it is a well known domain that you want to use again.

## How

This adds a reclaim policy to domains. If the `reclaimPolicy == "Delete"`, the domain is deleted from your account when the `Domain` CR is deleted. If the `reclaimPolicy == "Retain"`, the domain is not deleted from your account and only the CR is deleted.

In a subsequent PR, we'll be plumbing this value through the helm chart so that you can set the default domain reclaim policy for new domains that are created by the operator.

## Breaking Changes

The output format when you run `kubectl get domains.ingress.k8s.ngrok.com` has changed. The `CNAMETarget` will now only be shown with the `-o wide` flag.
