### PR TITLE
feat(cloud-endpoints): Add CloudEndpoint ID to printer column

### DIFF
--- a/api/ngrok/v1alpha1/cloudendpoint_types.go
+++ b/api/ngrok/v1alpha1/cloudendpoint_types.go
@@ -99,6 +99,7 @@ type CloudEndpointStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories="networking";"ngrok"
 // +kubebuilder:resource:shortName=clep
+// +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.id"
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".spec.url"
 // +kubebuilder:printcolumn:name="Traffic Policy",type="string",JSONPath=".spec.trafficPolicyName"
 // +kubebuilder:printcolumn:name="Bindings",type="string",JSONPath=".spec.bindings"

--- a/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_cloudendpoints.yaml
+++ b/helm/ngrok-operator/templates/crds/ngrok.k8s.ngrok.com_cloudendpoints.yaml
@@ -17,6 +17,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.id
+      name: ID
+      type: string
     - jsonPath: .spec.url
       name: URL
       type: string


### PR DESCRIPTION
## What

Adds the `.status.id` field from the CloudEndpoint to the list of printer columns, so you can more easily see which cloud endpoint it is.
 
## How
* Add kubebuilder marker for "ID" printcolumn.


## Breaking Changes
No
