### PR TITLE
refactor: Update statuses concurrently and pre-calculate domains

### DIFF
--- a/pkg/managerdriver/controller-handler.go
+++ b/pkg/managerdriver/controller-handler.go
@@ -52,7 +52,7 @@ func (e *ControllerEventHandler) Update(ctx context.Context, evt event.UpdateEve
 		e.log.Error(err, "error updating object in update", "object", evt.ObjectNew)
 		return
 	}
-	if err := e.driver.updateIngressStatuses(ctx, e.client); err != nil {
+	if err := e.driver.updateStatuses(ctx, e.client); err != nil {
 		e.log.Error(err, "error syncing after object update", "object", evt.ObjectNew)
 		return
 	}

--- a/pkg/managerdriver/driver_test.go
+++ b/pkg/managerdriver/driver_test.go
@@ -581,7 +581,9 @@ var _ = Describe("Driver", func() {
 				).
 				WithScheme(scheme).
 				Build()
-			status = calculateIngressLoadBalancerIPStatus(driver.log, &ingress, c)
+			domainsByDomain, err := getDomainsByDomain(GinkgoT().Context(), c)
+			Expect(err).ToNot(HaveOccurred())
+			status = calculateIngressLoadBalancerIPStatus(&ingress, domainsByDomain)
 		})
 
 		addIngressHostname := func(i *netv1.Ingress, hostname string) {


### PR DESCRIPTION
## What

While working on setting status for gateway API resources, I noticed we were listing all the domains more times than we need to be. 

We'd also return early if we encountered any type of error. This could potentially result in a domain not getting updated that should be updated.

## How
* Pre-compute the map of domains and pass it to the function that calculates the ingress status.
* When updating ingress status, if we encounter an error, keep going. This is accomplished by first calculating which ingresses need to be updated and then updating them in an errorgroup.
* Finally, I scaffolded out some of the pieces that we'll need for updating httproute and gateway status. (Will be implemented in a future PR).

## Breaking Changes
No
