### PR TITLE
feat(gateway-api): Set accepted conditions on gateways & httproutes

### DIFF
--- a/internal/controller/gateway/gateway_controller_test.go
+++ b/internal/controller/gateway/gateway_controller_test.go
@@ -1,0 +1,86 @@
+package gateway
+
+import (
+	"time"
+
+	testutils "github.com/ngrok/ngrok-operator/internal/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var _ = Describe("Gateway controller", Ordered, func() {
+	const (
+		timeout  = 10 * time.Second
+		duration = 10 * time.Second
+		interval = 250 * time.Millisecond
+	)
+
+	var (
+		gatewayClass *gatewayv1.GatewayClass
+		gw           *gatewayv1.Gateway
+	)
+
+	When("the gateway's gateway class should be handled by us", func() {
+		BeforeAll(func(ctx SpecContext) {
+			gatewayClass = testutils.NewGatewayClass(true)
+			CreateGatewayClassAndWaitForAcceptance(ctx, gatewayClass, timeout, interval)
+		})
+
+		AfterAll(func(ctx SpecContext) {
+			DeleteAllGatewayClasses(ctx, timeout, interval)
+		})
+
+		BeforeEach(func(ctx SpecContext) {
+			gw = newGateway(gatewayClass)
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+		})
+
+		AfterEach(func(ctx SpecContext) {
+			Expect(k8sClient.Delete(ctx, gw)).To(Succeed())
+		})
+
+		It("Should accept the gatewway", func(ctx SpecContext) {
+			ExpectGatewayAccepted(ctx, gw, timeout, interval)
+		})
+	})
+
+	When("The gateway's gateway class should not be handled by us", func() {
+		BeforeAll(func(ctx SpecContext) {
+			gatewayClass = testutils.NewGatewayClass(false)
+			Expect(k8sClient.Create(ctx, gatewayClass)).To(Succeed())
+		})
+
+		AfterAll(func(ctx SpecContext) {
+			DeleteAllGatewayClasses(ctx, timeout, interval)
+		})
+
+		BeforeEach(func(ctx SpecContext) {
+			gw = newGateway(gatewayClass)
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+		})
+
+		AfterEach(func(ctx SpecContext) {
+			Expect(k8sClient.Delete(ctx, gw)).To(Succeed())
+		})
+
+		It("should not accept the gateway", func(ctx SpecContext) {
+			Consistently(func(g Gomega) {
+				obj := &gatewayv1.Gateway{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gw), obj)).To(Succeed())
+				By("Consistently not having an accepted condition with Status True")
+				cond := meta.FindStatusCondition(obj.Status.Conditions, string(gatewayv1.GatewayConditionAccepted))
+				g.Expect(cond.Status).NotTo(Equal(metav1.ConditionTrue))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+})
+
+func newGateway(gwc *gatewayv1.GatewayClass) *gatewayv1.Gateway {
+	gw := testutils.NewGateway(testutils.RandomName("gateway"), "default")
+	gw.Spec.GatewayClassName = gatewayv1.ObjectName(gwc.Name)
+	return &gw
+}

--- a/internal/controller/gateway/httproute_controller.go
+++ b/internal/controller/gateway/httproute_controller.go
@@ -26,18 +26,27 @@ package gateway
 
 import (
 	"context"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"errors"
+	"fmt"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
 	"github.com/ngrok/ngrok-operator/pkg/managerdriver"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // HTTPRouteReconciler reconciles a HTTPRoute object
@@ -60,10 +69,8 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	httproute := new(gatewayv1.HTTPRoute)
 	err := r.Client.Get(ctx, req.NamespacedName, httproute)
-	switch {
-	case err == nil:
-		// all good, continue
-	case client.IgnoreNotFound(err) == nil:
+
+	if apierrors.IsNotFound(err) {
 		if err := r.Driver.DeleteNamedHTTPRoute(req.NamespacedName); err != nil {
 			log.Error(err, "Failed to delete httproute from store")
 			return ctrl.Result{}, err
@@ -76,22 +83,13 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		return ctrl.Result{}, nil
-	default:
-		return ctrl.Result{}, err
 	}
 
-	httproute, err = r.Driver.UpdateHTTPRoute(httproute)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if controller.IsUpsert(httproute) {
-		// The object is not being deleted, so register and sync finalizer
-		if err := controller.RegisterAndSyncFinalizer(ctx, r.Client, httproute); err != nil {
-			log.Error(err, "Failed to register finalizer")
-			return ctrl.Result{}, err
-		}
-	} else {
+	if controller.IsDelete(httproute) {
 		log.Info("Deleting httproute from store")
 		if controller.HasFinalizer(httproute) {
 			if err := controller.RemoveAndSyncFinalizer(ctx, r.Client, httproute); err != nil {
@@ -101,9 +99,24 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		// Remove it from the store
-		if err := r.Driver.DeleteHTTPRoute(httproute); err != nil {
-			return ctrl.Result{}, err
-		}
+		return ctrl.Result{}, r.Driver.DeleteHTTPRoute(httproute)
+	}
+
+	// The object is not being deleted, so register and sync finalizer
+	if err := controller.RegisterAndSyncFinalizer(ctx, r.Client, httproute); err != nil {
+		log.Error(err, "Failed to register finalizer")
+		return ctrl.Result{}, err
+	}
+
+	// Validate the HTTPRoute before updating the store
+	if err := r.validateHTTPRoute(ctx, httproute); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Update the HTTPRoute in the store if it passes validation
+	_, err = r.Driver.UpdateHTTPRoute(httproute)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if err := r.Driver.Sync(ctx, r.Client); err != nil {
@@ -126,7 +139,17 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// &ingressv1alpha1.NgrokModuleSet{},
 	}
 
-	builder := ctrl.NewControllerManagedBy(mgr).For(&gatewayv1.HTTPRoute{})
+	builder := ctrl.NewControllerManagedBy(mgr).
+		For(
+			&gatewayv1.HTTPRoute{},
+			builder.WithPredicates(
+				predicate.Or(
+					predicate.AnnotationChangedPredicate{},
+					predicate.GenerationChangedPredicate{},
+				),
+			),
+		)
+
 	for _, obj := range storedResources {
 		builder = builder.Watches(
 			obj,
@@ -138,4 +161,167 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 	}
 	return builder.Complete(r)
+}
+
+var (
+	ErrValidation          = errors.New("validation")
+	ErrParentRefNotFound   = errors.New("parentRefs not found")
+	ErrRouteGKNotSupported = errors.New("route group kind not supported")
+)
+
+func (r *HTTPRouteReconciler) validateHTTPRoute(ctx context.Context, route *gatewayv1.HTTPRoute) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	parentRefsAccepted, err := r.validateRouteParentRefs(ctx, route)
+	if err != nil {
+		return err
+	}
+
+	route.Status.RouteStatus = gatewayv1.RouteStatus{
+		Parents: parentRefsAccepted,
+	}
+
+	err = r.Client.Status().Update(ctx, route)
+	if err != nil {
+		return fmt.Errorf("failed to update httproute status: %w", err)
+	}
+
+	// Check to make sure that all parentRefs have been accepted
+	log.V(3).Info("Checking if all parentRefs have been accepted", "parents", route.Status.RouteStatus.Parents)
+	for _, parentStatus := range route.Status.RouteStatus.Parents {
+		for _, cond := range parentStatus.Conditions {
+			if cond.Status != metav1.ConditionTrue {
+				return fmt.Errorf("%w: route has not been accepted by all parentRefs", ErrValidation)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *HTTPRouteReconciler) validateRouteParentRefs(ctx context.Context, route *gatewayv1.HTTPRoute) ([]gatewayv1.RouteParentStatus, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	log.V(5).Info("Validating route parentRefs")
+
+	if len(route.Spec.ParentRefs) == 0 {
+		return nil, ErrParentRefNotFound
+	}
+
+	parentStatuses := []gatewayv1.RouteParentStatus{}
+
+	for _, parentRef := range route.Spec.ParentRefs {
+		parentStatus := gatewayv1.RouteParentStatus{
+			ParentRef:      parentRef,
+			ControllerName: ControllerName,
+			Conditions:     []metav1.Condition{},
+		}
+
+		// Find & use existing conditions for this parentRef so we preserve previous conditions
+		for _, s := range route.Status.RouteStatus.Parents {
+			if !reflect.DeepEqual(s.ParentRef, parentRef) {
+				continue
+			}
+
+			parentStatus.Conditions = s.Conditions
+		}
+
+		group := ptr.Deref(parentRef.Group, gatewayv1.GroupName)
+
+		var cnd metav1.Condition
+
+		switch group {
+		case gatewayv1.GroupName:
+			parentRefName := string(parentRef.Name)
+			// Get the parentRef namespace if supplied. If it's not supplied, use the route namespace.
+			parentRefNamespace := string(ptr.Deref(parentRef.Namespace, gatewayv1.Namespace(route.Namespace)))
+			parentRefLog := log.WithValues("parentRef", types.NamespacedName{
+				Name:      parentRefName,
+				Namespace: parentRefNamespace,
+			})
+
+			// TODO: Get the gateway from the store to limit the number of API calls
+			gw := &gatewayv1.Gateway{}
+			err := r.Client.Get(ctx, types.NamespacedName{
+				Name:      parentRefName,
+				Namespace: parentRefNamespace,
+			}, gw)
+
+			if err != nil {
+				if client.IgnoreNotFound(err) != nil {
+					// Some other error besides not found
+					parentRefLog.Error(err, "Failed to get gateway")
+					break
+				}
+
+				cnd = r.newCondition(
+					route,
+					gatewayv1.RouteConditionAccepted,
+					gatewayv1.RouteReasonNoMatchingParent,
+					"",
+				)
+				break
+			}
+
+			// Find the listener that matches the parentRef
+			noMatchingParent := true
+			for _, listener := range gw.Spec.Listeners {
+				if parentRef.Port != nil && *parentRef.Port != listener.Port {
+					continue
+				}
+
+				if parentRef.SectionName != nil && *parentRef.SectionName != listener.Name {
+					continue
+				}
+
+				noMatchingParent = false
+			}
+
+			var reason gatewayv1.RouteConditionReason
+			if noMatchingParent {
+				reason = gatewayv1.RouteReasonNoMatchingParent
+			} else {
+				reason = gatewayv1.RouteReasonAccepted
+			}
+
+			cnd = r.newCondition(
+				route,
+				gatewayv1.RouteConditionAccepted,
+				reason,
+				"",
+			)
+
+		case "":
+			// TODO: From the spec:
+			//    To set the core API group (such as for a "Service" kind referent),
+			//    Group must be explicitly set to "".
+			fallthrough
+		default:
+			cnd = r.newCondition(
+				route,
+				gatewayv1.RouteConditionAccepted,
+				gatewayv1.RouteReasonInvalidKind,
+				fmt.Sprintf("Group '%s' is not supported", group),
+			)
+		}
+
+		meta.SetStatusCondition(&parentStatus.Conditions, cnd)
+		parentStatuses = append(parentStatuses, parentStatus)
+	}
+
+	return parentStatuses, nil
+}
+
+func (r *HTTPRouteReconciler) newCondition(route *gatewayv1.HTTPRoute, t gatewayv1.RouteConditionType, reason gatewayv1.RouteConditionReason, msg string) metav1.Condition {
+	status := metav1.ConditionTrue
+	if reason != gatewayv1.RouteReasonAccepted && reason != gatewayv1.RouteReasonResolvedRefs {
+		status = metav1.ConditionFalse
+	}
+	return metav1.Condition{
+		Type:               string(t),
+		Status:             status,
+		ObservedGeneration: route.Generation,
+		Reason:             string(reason),
+		Message:            msg,
+	}
 }

--- a/internal/controller/gateway/httproute_controller_test.go
+++ b/internal/controller/gateway/httproute_controller_test.go
@@ -1,0 +1,189 @@
+package gateway
+
+import (
+	"time"
+
+	testutils "github.com/ngrok/ngrok-operator/internal/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var _ = Describe("HTTPRoute controller", Ordered, func() {
+	const (
+		ManagedControllerName   = ControllerName
+		UnmanagedControllerName = "k8s.io/some-other-controller"
+
+		timeout  = 10 * time.Second
+		duration = 10 * time.Second
+		interval = 250 * time.Millisecond
+	)
+
+	var (
+		gatewayClass *gatewayv1.GatewayClass
+		route        *gatewayv1.HTTPRoute
+	)
+
+	When("the gateway class is managed by us", Ordered, func() {
+		BeforeAll(func(ctx SpecContext) {
+			gatewayClass = testutils.NewGatewayClass(true)
+			CreateGatewayClassAndWaitForAcceptance(ctx, gatewayClass, timeout, interval)
+		})
+
+		AfterAll(func(ctx SpecContext) {
+			DeleteAllGatewayClasses(ctx, timeout, interval)
+		})
+
+		When("the parent ref is a gateway", func() {
+			var (
+				gw *gatewayv1.Gateway
+			)
+
+			BeforeEach(func(ctx SpecContext) {
+				gw = newGateway(gatewayClass)
+				CreateGatewayAndWaitForAcceptance(ctx, gw, timeout, interval)
+
+				route = &gatewayv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testutils.RandomName("httproute"),
+						Namespace: "default",
+					},
+					Spec: gatewayv1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1.CommonRouteSpec{
+							ParentRefs: []gatewayv1.ParentReference{
+								{
+									Name: gatewayv1.ObjectName(gw.Name),
+								},
+							},
+						},
+						Rules: []gatewayv1.HTTPRouteRule{
+							{
+								Matches: []gatewayv1.HTTPRouteMatch{
+									{
+										Path: &gatewayv1.HTTPPathMatch{},
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+
+			AfterEach(func(ctx SpecContext) {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, gw))).To(Succeed())
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			JustBeforeEach(func(ctx SpecContext) {
+				Expect(k8sClient.Create(ctx, route)).To(Succeed())
+			})
+
+			When("the gateway exists", func() {
+				It("Should accept the HTTPRoute", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						obj := &gatewayv1.HTTPRoute{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(route), obj)).To(Succeed())
+
+						g.Expect(obj.Status.Parents).To(HaveLen(1))
+						parent := obj.Status.Parents[0]
+						g.Expect(parent.ParentRef.Name).To(Equal(gatewayv1.ObjectName(gw.Name)))
+						g.Expect(parent.ControllerName).To(Equal(ManagedControllerName))
+
+						g.Expect(parent.Conditions).To(HaveLen(1))
+						cond := meta.FindStatusCondition(parent.Conditions, string(gatewayv1.RouteConditionAccepted))
+						g.Expect(cond).ToNot(BeNil())
+						g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+						g.Expect(cond.Reason).To(Equal(string(gatewayv1.RouteReasonAccepted)))
+
+					}, timeout, interval).Should(Succeed())
+				})
+			})
+
+			When("the gateway does not exist", func() {
+				BeforeEach(func(ctx SpecContext) {
+					Expect(k8sClient.Delete(ctx, gw)).To(Succeed())
+				})
+
+				It("Should not accept the HTTPRoute", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						obj := &gatewayv1.HTTPRoute{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(route), obj)).To(Succeed())
+
+						g.Expect(obj.Status.Parents).To(HaveLen(1))
+
+						parent := obj.Status.Parents[0]
+						g.Expect(parent.ParentRef.Name).To(Equal(gatewayv1.ObjectName(gw.Name)))
+
+						g.Expect(parent.Conditions).To(HaveLen(1))
+						cond := meta.FindStatusCondition(parent.Conditions, string(gatewayv1.RouteConditionAccepted))
+						g.Expect(cond).ToNot(BeNil())
+						g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+						g.Expect(cond.Reason).To(Equal(string(gatewayv1.RouteReasonNoMatchingParent)))
+					}, 30*time.Second, interval).Should(Succeed())
+				})
+			})
+		})
+
+		When("the parent ref is an unsupported type", func() {
+			var (
+				service v1.Service
+				svcGVK  schema.GroupVersionKind
+			)
+
+			BeforeEach(func(ctx SpecContext) {
+				var err error
+				service = testutils.NewTestServiceV1(testutils.RandomName("svc"), "default")
+				Expect(k8sClient.Create(ctx, &service)).To(Succeed())
+				svcGVK, err = k8sClient.GroupVersionKindFor(&service)
+				Expect(err).ToNot(HaveOccurred())
+
+				route = &gatewayv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testutils.RandomName("httproute"),
+						Namespace: "default",
+					},
+					Spec: gatewayv1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1.CommonRouteSpec{
+							ParentRefs: []gatewayv1.ParentReference{
+								{
+									Kind:      ptr.To(gatewayv1.Kind(svcGVK.Kind)),
+									Group:     ptr.To(gatewayv1.Group(svcGVK.Group)),
+									Namespace: ptr.To(gatewayv1.Namespace(service.Namespace)),
+									Name:      gatewayv1.ObjectName(service.Name),
+								},
+							},
+						},
+					},
+				}
+			})
+
+			JustBeforeEach(func(ctx SpecContext) {
+				Expect(k8sClient.Create(ctx, route)).To(Succeed())
+			})
+
+			It("Should have a parentRef condition with a reason of Unsupported", func(ctx SpecContext) {
+				Eventually(func(g Gomega) {
+					obj := &gatewayv1.HTTPRoute{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(route), obj)).To(Succeed())
+
+					g.Expect(obj.Status.Parents).To(HaveLen(1))
+					parent := obj.Status.Parents[0]
+					g.Expect(parent.ParentRef.Name).To(Equal(gatewayv1.ObjectName(service.Name)))
+					g.Expect(parent.ControllerName).To(Equal(ManagedControllerName))
+
+					g.Expect(parent.Conditions).To(HaveLen(1))
+					cond := meta.FindStatusCondition(parent.Conditions, string(gatewayv1.RouteConditionAccepted))
+					g.Expect(cond).ToNot(BeNil())
+					g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+					g.Expect(cond.Reason).To(Equal(string(gatewayv1.RouteReasonInvalidKind)))
+				}, timeout, interval).Should(Succeed())
+			})
+		})
+	})
+})

--- a/internal/testutils/k8s-resources.go
+++ b/internal/testutils/k8s-resources.go
@@ -9,6 +9,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -107,6 +108,30 @@ func NewDomainV1(name string, namespace string) ingressv1alpha1.Domain {
 		},
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: name,
+		},
+	}
+}
+
+// RandomName generates a random name with the given prefix. The random part is 5 characters long.
+// This is useful for generating unique names for resources in tests.
+func RandomName(prefix string) string {
+	return prefix + "-" + rand.String(5)
+}
+
+// NewGatewayClass creates a new GatewayClass with a random name to be used in tests. If
+// isManaged is true, the controller name will be set to the ngrok gateway controller name.
+// If isManaged is false, the controller name will be set to a different value.
+func NewGatewayClass(isManaged bool) *gatewayv1.GatewayClass {
+	var controllerName gatewayv1.GatewayController = "ngrok.com/gateway-controller"
+	if !isManaged {
+		controllerName = "k8s.io/some-other-controller"
+	}
+	return &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: RandomName("gateway-class"),
+		},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: controllerName,
 		},
 	}
 }

--- a/tools/make/_common.mk
+++ b/tools/make/_common.mk
@@ -57,10 +57,10 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.1
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
-ENVTEST_VERSION ?= release-0.17
+ENVTEST_VERSION ?= release-0.20
 GOLANGCI_LINT_VERSION ?= v1.64.6
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.29.0
+ENVTEST_K8S_VERSION = 1.33.0
 
 
 # ==============================================

--- a/tools/make/test.mk
+++ b/tools/make/test.mk
@@ -2,7 +2,7 @@
 
 .PHONY: test
 test: manifests generate fmt vet ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -timeout 20s
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -timeout 60s
 
 
 .PHONY: validate


### PR DESCRIPTION
## What

The Gateway API specificies that conditions should be set on resources when they are accepted, programmed, and ready.
This tackles the first part by setting accepted conditions on resources along with the status and reason for the condition.

## How
* refactored the gatewayclass controller tests to use some more shrared helpers
* Added tests for gateway and http route resources to verify that they have the appropriate accepted condition
* Updated the gateway and http route reconcilers to set the accepted condition

## Breaking Changes
*No
