### PR TITLE
feat(gateway-api): Add gateay status addresses

### DIFF
--- a/internal/controller/gateway/gateway_controller_test.go
+++ b/internal/controller/gateway/gateway_controller_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"fmt"
 	"time"
 
 	testutils "github.com/ngrok/ngrok-operator/internal/testutils"
@@ -8,6 +9,8 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -34,8 +37,13 @@ var _ = Describe("Gateway controller", Ordered, func() {
 			DeleteAllGatewayClasses(ctx, timeout, interval)
 		})
 
-		BeforeEach(func(ctx SpecContext) {
+		BeforeEach(func() {
 			gw = newGateway(gatewayClass)
+		})
+
+		// Create The gateway just before each test. This allows customization of
+		// the gateway in the BeforeEach function for scoped test below.
+		JustBeforeEach(func(ctx SpecContext) {
 			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
 		})
 
@@ -45,6 +53,64 @@ var _ = Describe("Gateway controller", Ordered, func() {
 
 		It("Should accept the gatewway", func(ctx SpecContext) {
 			ExpectGatewayAccepted(ctx, gw, timeout, interval)
+		})
+
+		When("the gateway has a listener with a hostname", func() {
+			var (
+				domain string
+			)
+
+			When("the hostname is a ngrok managed domain", func() {
+				BeforeEach(func() {
+					domain = fmt.Sprintf("%s.ngrok.io", rand.String(10))
+					gw.Spec.Listeners = []gatewayv1.Listener{
+						{
+							Name:     gatewayv1.SectionName(testutils.RandomName("listener")),
+							Hostname: ptr.To(gatewayv1.Hostname(domain)),
+							Port:     443,
+							Protocol: gatewayv1.HTTPSProtocolType,
+						},
+					}
+				})
+
+				It("The domain should appear in the gateway addresses", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						obj := &gatewayv1.Gateway{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gw), obj)).To(Succeed())
+
+						By("Checking the gateway has an address")
+						g.Expect(obj.Status.Addresses).To(HaveLen(1))
+						g.Expect(obj.Status.Addresses[0].Type).To(Equal(gatewayv1.HostnameAddressType))
+						g.Expect(obj.Status.Addresses[0].Value).To(Equal(domain))
+					})
+				})
+			})
+
+			When("the hostname is a custom domain", func() {
+				BeforeEach(func() {
+					domain = fmt.Sprintf("%s.custom.domain", rand.String(10))
+					gw.Spec.Listeners = []gatewayv1.Listener{
+						{
+							Name:     gatewayv1.SectionName(testutils.RandomName("listener")),
+							Hostname: ptr.To(gatewayv1.Hostname(domain)),
+							Port:     443,
+							Protocol: gatewayv1.HTTPSProtocolType,
+						},
+					}
+				})
+
+				It("The addresses should have a ngrok cname", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						obj := &gatewayv1.Gateway{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gw), obj)).To(Succeed())
+
+						By("Checking the gateway has an address")
+						g.Expect(obj.Status.Addresses).To(HaveLen(1))
+						g.Expect(obj.Status.Addresses[0].Type).To(Equal(gatewayv1.HostnameAddressType))
+						g.Expect(obj.Status.Addresses[0].Value).To(MatchRegexp("\\.ngrok-cname\\.com$"))
+					})
+				})
+			})
 		})
 	})
 

--- a/tools/make/test.mk
+++ b/tools/make/test.mk
@@ -2,7 +2,7 @@
 
 .PHONY: test
 test: manifests generate fmt vet ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -timeout 60s
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -timeout 120s
 
 
 .PHONY: validate


### PR DESCRIPTION
## What

This updates the gateway status addresses so that our Gateway API implementation can be used in conjunction with tools like external DNS.

## How
* In the manager driver, we loop through each of the gateways and calculate their addresses from the list of domains.
* Start a Domain Reconciler with a mocked domain client in the gateway suite tests to provide statuses for domain objects so we can test what happens when there is and isn't a CNAME target for a gateway Domain.
* TODO: There is still a good amount of work to be done on updating all of the Listener Status conditions to conform with the spec and some edge cases that need to be handled for what happens when a gateway is invalid.

## Breaking Changes
No
