### PR TITLE
feat: Add a default domain reclaim policy

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
+	"k8s.io/utils/ptr"
+)
+
+func validateDomainReclaimPolicy(policy string) (*ingressv1alpha1.DomainReclaimPolicy, error) {
+	switch policy {
+	case string(ingressv1alpha1.DomainReclaimPolicyDelete):
+		return ptr.To(ingressv1alpha1.DomainReclaimPolicyDelete), nil
+	case string(ingressv1alpha1.DomainReclaimPolicyRetain):
+		return ptr.To(ingressv1alpha1.DomainReclaimPolicyRetain), nil
+	default:
+		return nil, fmt.Errorf("invalid default domain reclaim policy: %s. Allowed Values are: %v",
+			policy,
+			[]ingressv1alpha1.DomainReclaimPolicy{
+				ingressv1alpha1.DomainReclaimPolicyDelete,
+				ingressv1alpha1.DomainReclaimPolicyRetain,
+			},
+		)
+	}
+}

--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -70,31 +70,32 @@ To uninstall the chart:
 
 ### Operator Manager parameters
 
-| Name                                 | Description                                                                               | Value   |
-| ------------------------------------ | ----------------------------------------------------------------------------------------- | ------- |
-| `replicaCount`                       | The number of controllers to run.                                                         | `1`     |
-| `affinity`                           | Affinity for the controller pod assignment                                                | `{}`    |
-| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`    |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`  |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`    |
-| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                    | `""`    |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                 | `[]`    |
-| `nodeSelector`                       | Node labels for manager pod(s)                                                            | `{}`    |
-| `tolerations`                        | Tolerations for manager pod(s)                                                            | `[]`    |
-| `topologySpreadConstraints`          | Topology Spread Constraints for manager pod(s)                                            | `[]`    |
-| `priorityClassName`                  | Priority class for pod scheduling                                                         | `""`    |
-| `lifecycle`                          | an object containing lifecycle configuration                                              | `{}`    |
-| `podDisruptionBudget.create`         | Enable a Pod Disruption Budget creation                                                   | `false` |
-| `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable                            | `""`    |
-| `podDisruptionBudget.minAvailable`   | Minimum number/percentage of pods that should remain scheduled                            | `""`    |
-| `resources.limits`                   | The resources limits for the container                                                    | `{}`    |
-| `resources.requests`                 | The requested resources for the container                                                 | `{}`    |
-| `extraVolumes`                       | An array of extra volumes to add to the controller.                                       | `[]`    |
-| `extraVolumeMounts`                  | An array of extra volume mounts to add to the controller.                                 | `[]`    |
-| `extraEnv`                           | an object of extra environment variables to add to the controller.                        | `{}`    |
-| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                      | `true`  |
-| `serviceAccount.name`                | The name of the ServiceAccount to use.                                                    | `""`    |
-| `serviceAccount.annotations`         | Additional annotations to add to the ServiceAccount                                       | `{}`    |
+| Name                                 | Description                                                                                                                                    | Value    |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `replicaCount`                       | The number of controllers to run.                                                                                                              | `1`      |
+| `affinity`                           | Affinity for the controller pod assignment                                                                                                     | `{}`     |
+| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                            | `""`     |
+| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                       | `soft`   |
+| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                      | `""`     |
+| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                                                                         | `""`     |
+| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                                                                      | `[]`     |
+| `nodeSelector`                       | Node labels for manager pod(s)                                                                                                                 | `{}`     |
+| `tolerations`                        | Tolerations for manager pod(s)                                                                                                                 | `[]`     |
+| `topologySpreadConstraints`          | Topology Spread Constraints for manager pod(s)                                                                                                 | `[]`     |
+| `priorityClassName`                  | Priority class for pod scheduling                                                                                                              | `""`     |
+| `lifecycle`                          | an object containing lifecycle configuration                                                                                                   | `{}`     |
+| `podDisruptionBudget.create`         | Enable a Pod Disruption Budget creation                                                                                                        | `false`  |
+| `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable                                                                                 | `""`     |
+| `podDisruptionBudget.minAvailable`   | Minimum number/percentage of pods that should remain scheduled                                                                                 | `""`     |
+| `resources.limits`                   | The resources limits for the container                                                                                                         | `{}`     |
+| `resources.requests`                 | The requested resources for the container                                                                                                      | `{}`     |
+| `extraVolumes`                       | An array of extra volumes to add to the controller.                                                                                            | `[]`     |
+| `extraVolumeMounts`                  | An array of extra volume mounts to add to the controller.                                                                                      | `[]`     |
+| `extraEnv`                           | an object of extra environment variables to add to the controller.                                                                             | `{}`     |
+| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                                                                           | `true`   |
+| `serviceAccount.name`                | The name of the ServiceAccount to use.                                                                                                         | `""`     |
+| `serviceAccount.annotations`         | Additional annotations to add to the ServiceAccount                                                                                            | `{}`     |
+| `defaultDomainReclaimPolicy`         | The default domain reclaim policy to use for domains created by the operator. Valid values are "Delete" and "Retain". The default is "Delete". | `Delete` |
 
 ### Logging configuration
 

--- a/helm/ngrok-operator/templates/agent/deployment.yaml
+++ b/helm/ngrok-operator/templates/agent/deployment.yaml
@@ -91,6 +91,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --manager-name={{ include "ngrok-operator.fullname" . }}-agent-manager
+        - --default-domain-reclaim-policy={{ .Values.defaultDomainReclaimPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
         env:

--- a/helm/ngrok-operator/templates/controller-deployment.yaml
+++ b/helm/ngrok-operator/templates/controller-deployment.yaml
@@ -72,6 +72,7 @@ spec:
         args:
         - api-manager
         - --release-name={{ .Release.Name }}
+        - --default-domain-reclaim-policy={{ .Values.defaultDomainReclaimPolicy }}
         {{- include "ngrok-operator.manager.cliFeatureFlags" . | nindent 8 }}
         {{- if .Values.oneClickDemoMode }}
         - --one-click-demo-mode

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -54,6 +54,7 @@ Should match all-options snapshot:
             - args:
                 - api-manager
                 - --release-name=RELEASE-NAME
+                - --default-domain-reclaim-policy=Delete
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=true
                 - --disable-reference-grants=false
@@ -765,6 +766,7 @@ Should match default snapshot:
             - args:
                 - api-manager
                 - --release-name=RELEASE-NAME
+                - --default-domain-reclaim-policy=Delete
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=true
                 - --disable-reference-grants=false

--- a/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
@@ -60,6 +60,7 @@ Should match snapshot:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=:8080
                 - --manager-name=RELEASE-NAME-ngrok-operator-agent-manager
+                - --default-domain-reclaim-policy=Delete
               command:
                 - /ngrok-operator
               env:

--- a/helm/ngrok-operator/tests/agent/deployment_test.yaml
+++ b/helm/ngrok-operator/tests/agent/deployment_test.yaml
@@ -90,3 +90,11 @@ tests:
   - equal:
       path: spec.template.spec.containers[0].resources
       value: *resources
+- it: Should set the default domain reclaim policy arg
+  set:
+    defaultDomainReclaimPolicy: "Retain"
+  template: agent/deployment.yaml
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --default-domain-reclaim-policy=Retain

--- a/helm/ngrok-operator/tests/controller-deployment_test.yaml
+++ b/helm/ngrok-operator/tests/controller-deployment_test.yaml
@@ -277,6 +277,15 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: --zap-stacktrace-level=error
+- it: Should set the default domain reclaim policy arg
+  set:
+    defaultDomainReclaimPolicy: "Retain"
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --default-domain-reclaim-policy=Retain
 - it: Defaults to having "soft" pod anti-affinity
   template: controller-deployment.yaml
   documentIndex: 0 # Document 0 is the deployment since its the first template

--- a/helm/ngrok-operator/values.schema.json
+++ b/helm/ngrok-operator/values.schema.json
@@ -243,6 +243,11 @@
                 }
             }
         },
+        "defaultDomainReclaimPolicy": {
+            "type": "string",
+            "description": "The default domain reclaim policy to use for domains created by the operator. Valid values are \"Delete\" and \"Retain\". The default is \"Delete\".",
+            "default": "Delete"
+        },
         "log": {
             "type": "object",
             "properties": {

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -197,6 +197,9 @@ serviceAccount:
   name: ""
   annotations: {}
 
+## @param defaultDomainReclaimPolicy The default domain reclaim policy to use for domains created by the operator. Valid values are "Delete" and "Retain". The default is "Delete".
+defaultDomainReclaimPolicy: "Delete"
+
 ##
 ## @section Logging configuration
 ##

--- a/internal/controller/agent/agent_endpoint_controller.go
+++ b/internal/controller/agent/agent_endpoint_controller.go
@@ -74,6 +74,8 @@ type AgentEndpointReconciler struct {
 	TunnelDriver *tunneldriver.TunnelDriver
 
 	controller *controller.BaseController[*ngrokv1alpha1.AgentEndpoint]
+
+	DefaultDomainReclaimPolicy *ingressv1alpha1.DomainReclaimPolicy
 }
 
 // SetupWithManager sets up the controller with the Manager
@@ -415,6 +417,11 @@ func (r *AgentEndpointReconciler) ensureDomainExists(ctx context.Context, aep *n
 			Domain: domain,
 		},
 	}
+
+	if r.DefaultDomainReclaimPolicy != nil {
+		newDomain.Spec.ReclaimPolicy = *r.DefaultDomainReclaimPolicy
+	}
+
 	if err := r.Create(ctx, newDomain); err != nil {
 		r.Recorder.Event(aep, v1.EventTypeWarning, "DomainCreationFailed", fmt.Sprintf("Failed to create Domain CRD %s", hyphenatedDomain))
 		return err

--- a/internal/controller/gateway/httproute_controller_test.go
+++ b/internal/controller/gateway/httproute_controller_test.go
@@ -132,15 +132,15 @@ var _ = Describe("HTTPRoute controller", Ordered, func() {
 
 		When("the parent ref is an unsupported type", func() {
 			var (
-				service v1.Service
+				service *v1.Service
 				svcGVK  schema.GroupVersionKind
 			)
 
 			BeforeEach(func(ctx SpecContext) {
 				var err error
 				service = testutils.NewTestServiceV1(testutils.RandomName("svc"), "default")
-				Expect(k8sClient.Create(ctx, &service)).To(Succeed())
-				svcGVK, err = k8sClient.GroupVersionKindFor(&service)
+				Expect(k8sClient.Create(ctx, service)).To(Succeed())
+				svcGVK, err = k8sClient.GroupVersionKindFor(service)
 				Expect(err).ToNot(HaveOccurred())
 
 				route = &gatewayv1.HTTPRoute{

--- a/internal/controller/ngrok/cloudendpoint_controller.go
+++ b/internal/controller/ngrok/cloudendpoint_controller.go
@@ -63,6 +63,8 @@ type CloudEndpointReconciler struct {
 	Log            logr.Logger
 	Recorder       record.EventRecorder
 	NgrokClientset ngrokapi.Clientset
+
+	DefaultDomainReclaimPolicy *ingressv1alpha1.DomainReclaimPolicy
 }
 
 // Define a custom error types to catch and handle requeuing logic for
@@ -372,6 +374,11 @@ func (r *CloudEndpointReconciler) ensureDomainExists(ctx context.Context, clep *
 			Domain: domain,
 		},
 	}
+
+	if r.DefaultDomainReclaimPolicy != nil {
+		newDomain.Spec.ReclaimPolicy = *r.DefaultDomainReclaimPolicy
+	}
+
 	if err := r.Create(ctx, newDomain); err != nil {
 		r.Recorder.Event(clep, v1.EventTypeWarning, "DomainCreationFailed", fmt.Sprintf("Failed to create Domain CRD %s", hyphenatedDomain))
 		return newDomain, err

--- a/internal/testutils/k8s-resources.go
+++ b/internal/testutils/k8s-resources.go
@@ -17,7 +17,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func NewTestIngressClass(name string, isDefault bool, isNgrok bool) netv1.IngressClass {
+func NewTestIngressClass(name string, isDefault bool, isNgrok bool) *netv1.IngressClass {
 	i := netv1.IngressClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -39,17 +39,17 @@ func NewTestIngressClass(name string, isDefault bool, isNgrok bool) netv1.Ingres
 		}
 	}
 
-	return i
+	return &i
 }
 
-func NewTestIngressV1WithClass(name string, namespace string, ingressClass string) netv1.Ingress {
+func NewTestIngressV1WithClass(name string, namespace string, ingressClass string) *netv1.Ingress {
 	i := NewTestIngressV1(name, namespace)
 	i.Spec.IngressClassName = &ingressClass
 	return i
 }
 
-func NewTestIngressV1(name string, namespace string) netv1.Ingress {
-	return netv1.Ingress{
+func NewTestIngressV1(name string, namespace string) *netv1.Ingress {
+	return &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -81,8 +81,8 @@ func NewTestIngressV1(name string, namespace string) netv1.Ingress {
 	}
 }
 
-func NewTestServiceV1(name string, namespace string) corev1.Service {
-	return corev1.Service{
+func NewTestServiceV1(name string, namespace string) *corev1.Service {
+	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -100,10 +100,10 @@ func NewTestServiceV1(name string, namespace string) corev1.Service {
 	}
 }
 
-func NewDomainV1(name string, namespace string) ingressv1alpha1.Domain {
-	return ingressv1alpha1.Domain{
+func NewDomainV1(name string, namespace string) *ingressv1alpha1.Domain {
+	return &ingressv1alpha1.Domain{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      ingressv1alpha1.HyphenatedDomainNameFromURL(name),
 			Namespace: namespace,
 		},
 		Spec: ingressv1alpha1.DomainSpec{


### PR DESCRIPTION
See https://github.com/ngrok/ngrok-operator/pull/641 for more context

## What

Now that Domains have a Reclaim Policy, we can set a default Domain Reclaim Policy for Domains created by the operator. It respects existing created domain CRs deletion policy. For example, if a domain CR was created manually with a Reclaim Policy of Retain, and the `defaultDomainReclaimPolicy` is set to Delete, it will not overwrite the existing ReclaimPolicy of Retain.

## How
* Add a setting for `defaultDomainReclaimPolicy` to the helm chart
* Pass the defaultDomainReclaimPolicy through to the driver and the Controllers that need it
* Only set the Reclaim Policy on creates

## Breaking Changes
No. The current domain Reclaim Policy defaults to "Delete" and the `defaultDomainReclaimPolicy` mirrors this. We still do not delete Domain CRs when they drop out of scope of the driver.