### PR TITLE
perf: Enable 'use-errors-new' revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   enable:
   - gofmt           # Format enforcement
-  - gocritic        # Code pattern analysis    
+  - gocritic        # Code pattern analysis
   - govet           # Built-in static checks
   - staticcheck     # Strong static analysis
   - errcheck        # Enforce checking errors
@@ -42,3 +42,4 @@ linters-settings:
     - name: unnecessary-stmt        # Suggests removing or simplifying unnecessary statements
     - name: unreachable-code        # Warns on unreachable code
     - name: unused-parameter        # Suggests to rename or remove unused function parameters
+    - name: use-errors-new          # identifies calls to fmt.Errorf that can be safely replaced by, the more efficient, errors.New.

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package annotations_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/ngrok/ngrok-operator/internal/annotations"
@@ -232,7 +231,7 @@ func TestExtractUseBindings(t *testing.T) {
 			annotations: map[string]string{
 				"k8s.ngrok.com/bindings": "public,internal",
 			},
-			expectedErr: fmt.Errorf("multiple bindings are not supported: [public internal]"),
+			expectedErr: errors.New("multiple bindings are not supported: [public internal]"),
 		},
 		{
 			name: "Missing Bindings Value",

--- a/internal/annotations/parser/parser.go
+++ b/internal/annotations/parser/parser.go
@@ -243,11 +243,11 @@ func StringToURL(input string) (*url.URL, error) {
 
 	switch {
 	case parsedURL.Scheme == "":
-		return nil, fmt.Errorf("url scheme is empty")
+		return nil, errors.New("url scheme is empty")
 	case parsedURL.Host == "":
-		return nil, fmt.Errorf("url host is empty")
+		return nil, errors.New("url host is empty")
 	case strings.Contains(parsedURL.Host, ".."):
-		return nil, fmt.Errorf("invalid url host")
+		return nil, errors.New("invalid url host")
 	}
 
 	return parsedURL, nil

--- a/internal/controller/agent/agent_endpoint_controller.go
+++ b/internal/controller/agent/agent_endpoint_controller.go
@@ -83,7 +83,7 @@ type AgentEndpointReconciler struct {
 
 func (r *AgentEndpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.TunnelDriver == nil {
-		return fmt.Errorf("TunnelDriver is nil")
+		return errors.New("TunnelDriver is nil")
 	}
 
 	r.controller = &controller.BaseController[*ngrokv1alpha1.AgentEndpoint]{

--- a/internal/controller/agent/tunnel_controller.go
+++ b/internal/controller/agent/tunnel_controller.go
@@ -26,6 +26,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -61,7 +62,7 @@ func (r *TunnelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	var err error
 
 	if r.TunnelDriver == nil {
-		return fmt.Errorf("TunnelDriver is nil")
+		return errors.New("TunnelDriver is nil")
 	}
 
 	r.controller = &controller.BaseController[*ingressv1alpha1.Tunnel]{

--- a/internal/controller/bindings/boundendpoint_controller.go
+++ b/internal/controller/bindings/boundendpoint_controller.go
@@ -26,6 +26,7 @@ package bindings
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -545,7 +546,7 @@ func (r *BoundEndpointReconciler) testBoundEndpointConnectivity(ctx context.Cont
 	for i := range retries {
 		select {
 		case <-ctx.Done():
-			err = fmt.Errorf("attempting to connect to BoundEndpoint URI timed out")
+			err = errors.New("attempting to connect to BoundEndpoint URI timed out")
 			log.Error(err, bindErrMsg)
 			return err
 
@@ -573,7 +574,7 @@ func (r *BoundEndpointReconciler) testBoundEndpointConnectivity(ctx context.Cont
 
 	}
 
-	err = fmt.Errorf("exceeded max retries")
+	err = errors.New("exceeded max retries")
 	log.Error(err, bindErrMsg)
 	return err
 

--- a/internal/controller/ingress/domain_controller.go
+++ b/internal/controller/ingress/domain_controller.go
@@ -26,6 +26,7 @@ package ingress
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
@@ -58,7 +59,7 @@ type DomainReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *DomainReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.DomainsClient == nil {
-		return fmt.Errorf("DomainsClient must be set")
+		return errors.New("DomainsClient must be set")
 	}
 
 	r.controller = &controller.BaseController[*ingressv1alpha1.Domain]{

--- a/internal/controller/ingress/httpsedge_controller.go
+++ b/internal/controller/ingress/httpsedge_controller.go
@@ -27,7 +27,6 @@ package ingress
 import (
 	"context"
 	"errors"
-	"fmt"
 	"maps"
 	"reflect"
 	"slices"
@@ -833,7 +832,7 @@ func (u *edgeRouteModuleUpdater) setEdgeRouteOAuth(ctx context.Context, route *n
 	}
 
 	if module == nil {
-		return ierr.NewErrInvalidConfiguration(fmt.Errorf("no OAuth provider configured"))
+		return ierr.NewErrInvalidConfiguration(errors.New("no OAuth provider configured"))
 	}
 
 	if reflect.DeepEqual(module, route.OAuth) {

--- a/internal/controller/ingress/ippolicy_controller.go
+++ b/internal/controller/ingress/ippolicy_controller.go
@@ -26,6 +26,7 @@ package ingress
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
@@ -64,10 +65,10 @@ type IPPolicyReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *IPPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.IPPoliciesClient == nil {
-		return fmt.Errorf("IPPoliciesClient must be set")
+		return errors.New("IPPoliciesClient must be set")
 	}
 	if r.IPPolicyRulesClient == nil {
-		return fmt.Errorf("IPPolicyRulesClient must be set")
+		return errors.New("IPPolicyRulesClient must be set")
 	}
 
 	r.controller = &controller.BaseController[*ingressv1alpha1.IPPolicy]{

--- a/internal/controller/ingress/service_controller.go
+++ b/internal/controller/ingress/service_controller.go
@@ -898,7 +898,7 @@ func (r *baseSubresourceReconciler[T, PT]) Reconcile(ctx context.Context, c clie
 	// We only support one desired resource of a particular type for now
 	// If there are cases where we need to create multiple edges or tunnels, we will need to change this handling
 	if len(desired) > 1 {
-		return fmt.Errorf("multiple desired resources not supported")
+		return errors.New("multiple desired resources not supported")
 	}
 
 	d := desired[0]

--- a/internal/controller/ingress/tlsedge_controller.go
+++ b/internal/controller/ingress/tlsedge_controller.go
@@ -27,7 +27,6 @@ package ingress
 import (
 	"context"
 	"errors"
-	"fmt"
 	"maps"
 	"slices"
 	"strconv"
@@ -645,7 +644,7 @@ func (r *TLSEdgeReconciler) getDesiredDomains(ctx context.Context, edge *ingress
 func parseHostAndPort(hostport string) (string, int32, error) {
 	pieces := strings.SplitN(hostport, ":", 2)
 	if len(pieces) != 2 {
-		return "", 0, fmt.Errorf("invalid hostport")
+		return "", 0, errors.New("invalid hostport")
 	}
 
 	port, err := strconv.ParseInt(pieces[1], 10, 32)

--- a/internal/mocks/nmockapi/iter_test.go
+++ b/internal/mocks/nmockapi/iter_test.go
@@ -2,7 +2,7 @@ package nmockapi_test
 
 import (
 	context "context"
-	"fmt"
+	"errors"
 
 	"github.com/ngrok/ngrok-api-go/v7"
 	"github.com/ngrok/ngrok-operator/internal/mocks/nmockapi"
@@ -29,7 +29,7 @@ var _ = Describe("Iter", func() {
 	Describe("Item()", func() {
 		Context("when there is an error", func() {
 			BeforeEach(func() {
-				iterErr = fmt.Errorf("ut-oh")
+				iterErr = errors.New("ut-oh")
 			})
 
 			It("should return an empty item", func() {
@@ -74,7 +74,7 @@ var _ = Describe("Iter", func() {
 	Describe("Next", func() {
 		Context("when there is an error", func() {
 			BeforeEach(func() {
-				iterErr = fmt.Errorf("ut-oh")
+				iterErr = errors.New("ut-oh")
 			})
 
 			It("should return false", func() {
@@ -113,7 +113,7 @@ var _ = Describe("Iter", func() {
 	Describe("Err()", func() {
 		Context("when there is an error", func() {
 			BeforeEach(func() {
-				iterErr = fmt.Errorf("ut-oh")
+				iterErr = errors.New("ut-oh")
 			})
 
 			It("should return the error", func() {

--- a/internal/ngrokapi/bindingendpoint_aggregator.go
+++ b/internal/ngrokapi/bindingendpoint_aggregator.go
@@ -1,6 +1,7 @@
 package ngrokapi
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -91,7 +92,7 @@ func (p *parsedHostport) String() string {
 // parseHostport parses the hostport from its 4-tuple into a struct
 func parseHostport(proto string, publicURL string) (*parsedHostport, error) {
 	if publicURL == "" {
-		return nil, fmt.Errorf("missing publicURL")
+		return nil, errors.New("missing publicURL")
 	}
 
 	// to be parsed and filled in

--- a/internal/util/traffic_policy_test.go
+++ b/internal/util/traffic_policy_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -221,7 +220,7 @@ func TestToCRDJson(t *testing.T) {
 					PhaseOnHttpRequest: {[]byte(`ngrok is built to deliver applications and APIs with  zero networking configuration and zero hardware`)},
 				},
 			},
-			expectedErr: fmt.Errorf(`json: error calling MarshalJSON for type json.RawMessage: invalid character 'g' in literal null (expecting 'u')`),
+			expectedErr: errors.New(`json: error calling MarshalJSON for type json.RawMessage: invalid character 'g' in literal null (expecting 'u')`),
 		},
 	}
 
@@ -285,14 +284,14 @@ func TestFilterEnabled(t *testing.T) {
 			msg:                   []byte(`Industry leaders rely on ngrok`),
 			expectedReturnedMsg:   nil,
 			expectedSetEnabledVal: nil,
-			expectedErr:           fmt.Errorf("invalid character 'I' looking for beginning of value"),
+			expectedErr:           errors.New("invalid character 'I' looking for beginning of value"),
 		},
 		{
 			name:                  "message is empty json",
 			msg:                   []byte(""),
 			expectedReturnedMsg:   nil,
 			expectedSetEnabledVal: nil,
-			expectedErr:           fmt.Errorf("unexpected end of JSON input"),
+			expectedErr:           errors.New("unexpected end of JSON input"),
 		},
 		{
 			name:                  "message is nil",
@@ -492,7 +491,7 @@ func TestMergeEndpointRule(t *testing.T) {
 			addedPhase: PhaseOnHttpRequest,
 			// original traffic policy should be unaffected
 			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, nil),
-			expectedErr:                 fmt.Errorf("json: error calling MarshalJSON for type json.RawMessage: invalid character 'i' looking for beginning of value"),
+			expectedErr:                 errors.New("json: error calling MarshalJSON for type json.RawMessage: invalid character 'i' looking for beginning of value"),
 		},
 	}
 

--- a/pkg/managerdriver/driver.go
+++ b/pkg/managerdriver/driver.go
@@ -870,15 +870,15 @@ func (d *Driver) createEndpointPolicyForGateway(rule *gatewayv1.HTTPRouteRule, n
 		}
 
 		if match.Method != nil {
-			d.log.Error(fmt.Errorf("unsupported match type"), "Unsupported match type", "HTTPMethod", *match.Method)
+			d.log.Error(errors.New("unsupported match type"), "Unsupported match type", "HTTPMethod", *match.Method)
 		}
 
 		if len(match.Headers) > 0 {
-			d.log.Error(fmt.Errorf("unsupported match type"), "Unsupported match type", "HTTPHeaderMatch", match.Headers)
+			d.log.Error(errors.New("unsupported match type"), "Unsupported match type", "HTTPHeaderMatch", match.Headers)
 		}
 
 		if len(match.QueryParams) > 0 {
-			d.log.Error(fmt.Errorf("unsupported match type"), "Unsupported match type", "HTTPQueryParamMatch", match.QueryParams)
+			d.log.Error(errors.New("unsupported match type"), "Unsupported match type", "HTTPQueryParamMatch", match.QueryParams)
 		}
 	}
 
@@ -1218,7 +1218,7 @@ func (d *Driver) handleURLRewriteFilter(filter *gatewayv1.HTTPURLRewriteFilter, 
 			return err
 		}
 	default:
-		d.log.Error(fmt.Errorf("unsupported path modifier type"), "unsupported path modifier type", "HTTPPathModifier", filter.Path.Type)
+		d.log.Error(errors.New("unsupported path modifier type"), "unsupported path modifier type", "HTTPPathModifier", filter.Path.Type)
 		return nil
 	}
 	return nil
@@ -1270,7 +1270,7 @@ func (d *Driver) handleRequestRedirectFilter(filter *gatewayv1.HTTPRequestRedire
 			return err
 		}
 	default:
-		d.log.Error(fmt.Errorf("unsupported path modifier type"), "unsupported path modifier type", "HTTPPathModifier", filter.Path.Type)
+		d.log.Error(errors.New("unsupported path modifier type"), "unsupported path modifier type", "HTTPPathModifier", filter.Path.Type)
 		return nil
 	}
 	return nil

--- a/pkg/managerdriver/driver_test.go
+++ b/pkg/managerdriver/driver_test.go
@@ -2,7 +2,6 @@ package managerdriver
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,6 +26,7 @@ import (
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
+	"github.com/ngrok/ngrok-operator/internal/errors"
 	"github.com/ngrok/ngrok-operator/internal/testutils"
 	"github.com/ngrok/ngrok-operator/internal/trafficpolicy"
 	"github.com/ngrok/ngrok-operator/internal/util"
@@ -1310,16 +1310,16 @@ func TestExtractPolicy(t *testing.T) {
 		{
 			name:        "invalid json message",
 			msg:         []byte(`ngrok operates a global network where it accepts traffic to your upstream services from clients.`),
-			expectedErr: fmt.Errorf("invalid character 'g' in literal null (expecting 'u')"),
+			expectedErr: errors.New("invalid character 'g' in literal null (expecting 'u')"),
 		},
 		{
 			name:        "empty json message",
 			msg:         []byte(""),
-			expectedErr: fmt.Errorf("unexpected end of JSON input"),
+			expectedErr: errors.New("unexpected end of JSON input"),
 		},
 		{
 			name:        "nil json message",
-			expectedErr: fmt.Errorf("unexpected end of JSON input"),
+			expectedErr: errors.New("unexpected end of JSON input"),
 		},
 	}
 

--- a/pkg/managerdriver/edges.go
+++ b/pkg/managerdriver/edges.go
@@ -8,6 +8,7 @@ import (
 
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/annotations"
+	"github.com/ngrok/ngrok-operator/internal/errors"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -245,7 +246,7 @@ func (d *Driver) calculateHTTPSEdgesFromIngress(edgeMap map[string]ingressv1alph
 					case netv1.PathTypeImplementationSpecific:
 						matchType = "path_prefix" // Path Prefix seems like a sane default for most cases
 					default:
-						d.log.Error(fmt.Errorf("unknown path type"), "unknown path type", "pathType", *httpIngressPath.PathType)
+						d.log.Error(errors.New("unknown path type"), "unknown path type", "pathType", *httpIngressPath.PathType)
 						continue
 					}
 				}

--- a/pkg/managerdriver/translate_ingresses.go
+++ b/pkg/managerdriver/translate_ingresses.go
@@ -125,7 +125,7 @@ func (t *translator) ingressToIR(
 	for _, rule := range ingress.Spec.Rules {
 		ruleHostname := rule.Host
 		if ruleHostname == "" {
-			t.log.Error(fmt.Errorf("skipping converting ingress rule into cloud and agent endpoints because the rule.host is empty"),
+			t.log.Error(errors.New("skipping converting ingress rule into cloud and agent endpoints because the rule.host is empty"),
 				"empty host in ingress spec rule",
 				"ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
 			)
@@ -142,7 +142,7 @@ func (t *translator) ingressToIR(
 		if exists {
 			// If we already have a virtual host for this hostname, the traffic policy config must be the same as the one we are currently processing
 			if !reflect.DeepEqual(irVHost.TrafficPolicyObjRef, annotationTrafficPolicyRef) {
-				t.log.Error(fmt.Errorf("different traffic policy annotations provided for the same hostname"),
+				t.log.Error(errors.New("different traffic policy annotations provided for the same hostname"),
 					"when using the same hostname across multiple ingresses, ensure that they do not use different traffic policies provided via annotations",
 					"current ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
 					"hostname", ruleHostname,
@@ -151,7 +151,7 @@ func (t *translator) ingressToIR(
 			}
 			// They must have the same configuration for whether or not to pool endpoints
 			if irVHost.EndpointPoolingEnabled != endpointPoolingEnabled {
-				t.log.Error(fmt.Errorf("different endpoint pooling annotations provided for the same hostname"),
+				t.log.Error(errors.New("different endpoint pooling annotations provided for the same hostname"),
 					"when using the same hostname across multiple ingresses, ensure that they all enable or all disable endpoint pooling",
 					"current ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
 					"hostname", ruleHostname,
@@ -171,7 +171,7 @@ func (t *translator) ingressToIR(
 
 			// They must have the same default backend
 			if !reflect.DeepEqual(irVHost.DefaultDestination, defaultDestination) {
-				t.log.Error(fmt.Errorf("different ingress default backends provided for the same hostname"),
+				t.log.Error(errors.New("different ingress default backends provided for the same hostname"),
 					"when using the same hostname across multiple ingresses, ensure that they do not use different default backends. the existing default backend for the hostname will not be overwritten",
 					"current ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
 					"hostname", ruleHostname,
@@ -283,7 +283,7 @@ func (t *translator) ingressBackendToIR(ingress *netv1.Ingress, backend *netv1.I
 		}
 
 		if len(routeTrafficPolicy.OnTCPConnect) != 0 {
-			return nil, fmt.Errorf("traffic policies supplied as ingress backends may not contain any on_tcp_connect rules as there is no way to only run them for certain routes")
+			return nil, errors.New("traffic policies supplied as ingress backends may not contain any on_tcp_connect rules as there is no way to only run them for certain routes")
 		}
 
 		return &ir.IRDestination{
@@ -293,7 +293,7 @@ func (t *translator) ingressBackendToIR(ingress *netv1.Ingress, backend *netv1.I
 
 	// If the backend is not a traffic policy, then it must be a service
 	if backend.Service == nil {
-		return nil, fmt.Errorf("ingress backend is invalid. Not an NgrokTrafficPolicy or service")
+		return nil, errors.New("ingress backend is invalid. Not an NgrokTrafficPolicy or service")
 	}
 
 	serviceName := backend.Service.Name

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -175,7 +175,7 @@ func (t *translator) IRToEndpoints(irVHosts []*ir.IRVirtualHost) (cloudEndpoints
 	validateMappingStrategies(irVHosts)
 	for _, irVHost := range irVHosts {
 		if irVHost.TrafficPolicy == nil && len(irVHost.Routes) == 0 {
-			t.log.Error(fmt.Errorf("skipping generating endpoints for hostname with no valid traffic policy or routes"),
+			t.log.Error(errors.New("skipping generating endpoints for hostname with no valid traffic policy or routes"),
 				"hostname", string(irVHost.Listener.Hostname),
 				"generated from resources", irVHost.OwningResources,
 			)
@@ -387,7 +387,7 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, agentEndpoint
 
 	for _, irRoute := range irVHost.Routes {
 		if len(irRoute.Destinations) == 0 && len(irRoute.TrafficPolicies) == 0 {
-			t.log.Error(fmt.Errorf("generated route does not have a destination"), "skipping endpoint configuration generation for invalid route, other routes will continue to be processed",
+			t.log.Error(errors.New("generated route does not have a destination"), "skipping endpoint configuration generation for invalid route, other routes will continue to be processed",
 				"generated from resources", irVHost.OwningResources,
 				"hostname", string(irVHost.Listener.Hostname),
 				"match criteria", irRoute.HTTPMatchCriteria,

--- a/pkg/managerdriver/tunnels.go
+++ b/pkg/managerdriver/tunnels.go
@@ -11,6 +11,7 @@ import (
 	common "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/annotations"
+	"github.com/ngrok/ngrok-operator/internal/errors"
 	"github.com/ngrok/ngrok-operator/internal/ir"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -194,7 +195,7 @@ func (d *Driver) calculateTunnelsFromGateway(tunnels map[tunnelKey]ingressv1alph
 			}
 			gateway, exists := gatewayMap[gatewayKey]
 			if !exists {
-				d.log.Error(fmt.Errorf("HTTPRoute parent ref not found"), "the HTTPRoute lists a Gateway parent ref that does not exist",
+				d.log.Error(errors.New("HTTPRoute parent ref not found"), "the HTTPRoute lists a Gateway parent ref that does not exist",
 					"httproute", fmt.Sprintf("%s.%s", httproute.Name, httproute.Namespace),
 					"parentRef", fmt.Sprintf("%s.%s", string(parentRef.Name), refNamespace),
 				)

--- a/pkg/managerdriver/utils.go
+++ b/pkg/managerdriver/utils.go
@@ -363,7 +363,7 @@ func netv1PathTypeToIR(log logr.Logger, pathType *netv1.PathType) ir.IRPathMatch
 	case netv1.PathTypeExact:
 		return ir.IRPathType_Exact
 	default:
-		log.Error(fmt.Errorf("unknown path type, defaulting to prefix match"), "unknown path type", "pathType", *pathType)
+		log.Error(errors.New("unknown path type, defaulting to prefix match"), "unknown path type", "pathType", *pathType)
 		return ir.IRPathType_Prefix
 	}
 }

--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -137,7 +137,7 @@ func New(ctx context.Context, logger logr.Logger, opts TunnelDriverOpts) (*Tunne
 		ngrok.WithRestartHandler(func(_ context.Context, _ ngrok.Session) error {
 			sessionState := td.session.Load()
 			if sessionState != nil && sessionState.session != nil {
-				sessionState.healthErr = fmt.Errorf("ngrok session restarting")
+				sessionState.healthErr = errors.New("ngrok session restarting")
 				td.session.Store(sessionState)
 				logger.Info("ngrok session restarting")
 			}
@@ -173,7 +173,7 @@ func New(ctx context.Context, logger logr.Logger, opts TunnelDriverOpts) (*Tunne
 	}
 
 	td.session.Store(&sessionState{
-		readyErr: fmt.Errorf("attempting to connect"),
+		readyErr: errors.New("attempting to connect"),
 	})
 	connOpts = append(connOpts,
 		ngrok.WithConnectHandler(func(_ context.Context, sess ngrok.Session) {
@@ -188,7 +188,7 @@ func New(ctx context.Context, logger logr.Logger, opts TunnelDriverOpts) (*Tunne
 				// we have established session in the past, so record err only when it is going away
 				if err == nil {
 					td.session.Store(&sessionState{
-						healthErr: fmt.Errorf("session closed"),
+						healthErr: errors.New("session closed"),
 					})
 				}
 				return
@@ -198,7 +198,7 @@ func New(ctx context.Context, logger logr.Logger, opts TunnelDriverOpts) (*Tunne
 				// session is disconnecting, do not override error
 				if state.healthErr == nil {
 					td.session.Store(&sessionState{
-						healthErr: fmt.Errorf("session closed"),
+						healthErr: errors.New("session closed"),
 					})
 				}
 				return
@@ -252,7 +252,7 @@ func (td *TunnelDriver) getSession() (ngrok.Session, error) {
 	case state.readyErr != nil:
 		return nil, state.readyErr
 	default:
-		return nil, fmt.Errorf("unexpected state")
+		return nil, errors.New("unexpected state")
 	}
 }
 


### PR DESCRIPTION
Came up during review of #658. Figured we should fix it across the codebase and enable a linter versus just fixing it there.

## What

We aren't very consistent about using `errors.New` over `fmt.Errorf` and had a lot of places where we were using the latter. This enables the revive linter for this to prefer using `errors.New` in places it can be used.

## How
* Enable the revive linter `use-errors-new`
* Fix all the linter warnings for `fmt.Errorf`

## Breaking Changes
No
