### PR TITLE
:tada: Release helm chart 0.20.0 :tada:

### DIFF
--- a/helm/ngrok-operator/CHANGELOG.md
+++ b/helm/ngrok-operator/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the helm chart will be documented in this file. Please se
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.20.0
+**Full Changelog**: https://github.com/ngrok/ngrok-operator/compare/helm-chart-0.20.0-rc.1...helm-chart-0.20.0
+
+Warning: The ngrok-operator image version `0.18.0` and above include a breaking change due to the
+sunsetting of some ngrok platform features. Before you upgrade to this version of the image,
+please see https://github.com/ngrok/ngrok-operator/discussions/654.
+
+### Removed
+- [Breaking Change!] Remove Deprecated CRDs by @jonstacks in [#664](https://github.com/ngrok/ngrok-operator/pull/664).
+
 ## 0.20.0-rc.1
 **Full Changelog**: https://github.com/ngrok/ngrok-operator/compare/helm-chart-0.19.0...helm-chart-0.20.0-rc.1
 

--- a/helm/ngrok-operator/Chart.yaml
+++ b/helm/ngrok-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ngrok-operator
 description: The official ngrok Kubernetes Operator.
-version: 0.20.0-rc.1
+version: 0.20.0
 appVersion: 0.18.0
 keywords:
   - ngrok

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -13,7 +13,7 @@ Should match all-options snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.18.0
-        helm.sh/chart: ngrok-operator-0.20.0-rc.1
+        helm.sh/chart: ngrok-operator-0.20.0
       name: RELEASE-NAME-ngrok-operator-manager
       namespace: NAMESPACE
     spec:
@@ -613,7 +613,7 @@ Should match default snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.18.0
-        helm.sh/chart: ngrok-operator-0.20.0-rc.1
+        helm.sh/chart: ngrok-operator-0.20.0
       name: RELEASE-NAME-ngrok-operator-manager
       namespace: NAMESPACE
     spec:

--- a/helm/ngrok-operator/tests/__snapshot__/controller-pdb_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-pdb_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.18.0
-        helm.sh/chart: ngrok-operator-0.20.0-rc.1
+        helm.sh/chart: ngrok-operator-0.20.0
       name: test-release-ngrok-operator-controller-pdb
       namespace: test-namespace
     spec:

--- a/helm/ngrok-operator/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
@@ -10,6 +10,6 @@ Should match the snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.18.0
-        helm.sh/chart: ngrok-operator-0.20.0-rc.1
+        helm.sh/chart: ngrok-operator-0.20.0
       name: test-release-ngrok-operator
       namespace: test-namespace

--- a/helm/ngrok-operator/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -10,7 +10,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.18.0
-        helm.sh/chart: ngrok-operator-0.20.0-rc.1
+        helm.sh/chart: ngrok-operator-0.20.0
       name: ngrok
     spec:
       controller: k8s.ngrok.com/ingress-controller

--- a/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
@@ -12,7 +12,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.18.0
-        helm.sh/chart: ngrok-operator-0.20.0-rc.1
+        helm.sh/chart: ngrok-operator-0.20.0
       name: RELEASE-NAME-ngrok-operator-agent
       namespace: NAMESPACE
     spec:

--- a/helm/ngrok-operator/tests/agent/__snapshot__/service-account_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/service-account_test.yaml.snap
@@ -10,6 +10,6 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.18.0
-        helm.sh/chart: ngrok-operator-0.20.0-rc.1
+        helm.sh/chart: ngrok-operator-0.20.0
       name: test-release-ngrok-operator-agent
       namespace: test-namespace

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
@@ -12,7 +12,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.18.0
-        helm.sh/chart: ngrok-operator-0.20.0-rc.1
+        helm.sh/chart: ngrok-operator-0.20.0
       name: RELEASE-NAME-ngrok-operator-bindings-forwarder
       namespace: NAMESPACE
     spec:

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/service-account_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/service-account_test.yaml.snap
@@ -10,6 +10,6 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.18.0
-        helm.sh/chart: ngrok-operator-0.20.0-rc.1
+        helm.sh/chart: ngrok-operator-0.20.0
       name: test-release-ngrok-operator-bindings-forwarder
       namespace: test-namespace


### PR DESCRIPTION
## What

:warning: This Release includes a breaking change :warning: 

See https://github.com/ngrok/ngrok-operator/discussions/654 for more details.

* Uses Released version `0.18.0` of the ngrok-operator image.
  * Migrates internal endpoint logic to v2 of the ngrok-go SDK.
  * Removes support for TCPEdge, TLSEdge, and TCPEdge controllers.
* Creates a `0.20.0` release of the ngrok-operator helm chart which defaults to using the ngrok-operator `0.18.0` image.
  * Before upgrading, make sure that you are no longer using any of the CRDs mentioned in the above discussion as they have also been removed from the helm chart.

## How

Bump the Version and update the Changelog

## Breaking Changes
Yes, see the above linked discussion and notes

