### PR TITLE
Wait for gateway to be deleted before continuing the test to solve ra…

### DIFF
--- a/internal/controller/gateway/httproute_controller_test.go
+++ b/internal/controller/gateway/httproute_controller_test.go
@@ -107,7 +107,7 @@ var _ = Describe("HTTPRoute controller", Ordered, func() {
 
 			When("the gateway does not exist", func() {
 				BeforeEach(func(ctx SpecContext) {
-					Expect(k8sClient.Delete(ctx, gw)).To(Succeed())
+					DeleteGatewayAndWaitForDeletion(ctx, gw, timeout, interval)
 				})
 
 				It("Should not accept the HTTPRoute", func(ctx SpecContext) {


### PR DESCRIPTION
…ce condition

<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
I've been having the tests here flake on me in PRs, specifically the gateway httproute controller test seems to fail sometimes
https://gist.github.com/alex-bezek/283f44728e74b06a91e5649479dd47da

## How

In the output log you can see a gateway has both a deletion timestamp and a finalizer still 
`deletionTimestamp":"2025-09-12T00:55:17Z","deletionGracePeriodSeconds":0,"finalizers":["k8s.ngrok.com/finalizer"]`
this means something started the delete but it hasn't reconciled yet. 

I think the issue is that a beforeEach higher up creates the gateway and then for this sub test for when it doesn't exist we do a beforeEach to delete the gateway. But this doesn't wait for it to be done and is async, so sometimes the tests can attempt to attach the httproute and it finds the gateway still causing the test to fail. 

I couldn't really reproduce this locally, i ran the tests over and over again but didn't reproduce it. 