### PR TITLE
chore(helm): Migrate to bitnami OCI library chart

### DIFF
--- a/helm/ngrok-operator/Chart.lock
+++ b/helm/ngrok-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 2.22.0
-digest: sha256:3c3a2f2c075dd8282147f1a611979a67dd40ce82a27698e16b3315eb9a94d059
-generated: "2024-08-09T14:49:27.42058351-05:00"
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.31.4
+digest: sha256:fc442e77200e1914dd46fe26490dcf62f44caa51db673c2f8e67d5319cd4c163
+generated: "2025-09-16T12:41:24.213248873-05:00"

--- a/helm/ngrok-operator/Chart.yaml
+++ b/helm/ngrok-operator/Chart.yaml
@@ -15,7 +15,7 @@ sources:
 icon: https://charts.ngrok.com/assets/ngrok-favicon.svg
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x


### PR DESCRIPTION
## What

Migrate off `https://charts.bitnami.com/bitnami` and to their OCI repository.

## How

Migrate from bitnami's current helm chart repository to their OCI repository. Also, update the version of the library chart.

## Breaking Changes
No
