### PR TITLE
deps: Update go to 1.24.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.24.6 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.9 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756696532,
-        "narHash": "sha256-6FWagzm0b7I/IGigOv9pr6LL7NQ86mextfE8g8Q6HBg=",
+        "lastModified": 1760504863,
+        "narHash": "sha256-h13YFQMi91nXkkRoJMIfezorz5SbD6849jw5L0fjK4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58dcbf1ec551914c3756c267b8b9c8c86baa1b2f",
+        "rev": "82c2e0d6dde50b17ae366d2aa36f224dc19af469",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ngrok/ngrok-operator
 
-go 1.24.4
+go 1.24.9
 
 require (
 	github.com/docker/docker v28.3.3+incompatible


### PR DESCRIPTION
## What

Updates nix dependencies. Notably, go 1.24.9

## How

`nix flake update`

## Breaking Changes
No