### PR TITLE
fix(devenv): Make sure that nix is running for post create

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,5 +1,28 @@
 #!/usr/bin/env bash
 
+# The following is copied from the nix-entrypoint.sh file set up by
+# the nix feature. This ensures that the nix daemon is running in the background
+# before we try to use any nix commands.
+# Attempt to start daemon
+set +e
+if ! pidof nix-daemon > /dev/null 2>&1; then
+    start_ok=false
+    if [ "$(id -u)" = "0" ]; then
+        ( . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; /nix/var/nix/profiles/default/bin/nix-daemon > /tmp/nix-daemon.log 2>&1 ) &
+        if [ "$?" = "0" ]; then
+            start_ok=true
+        fi
+    elif type sudo > /dev/null 2>&1; then
+        sudo -n sh -c '. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh; /nix/var/nix/profiles/default/bin/nix-daemon > /tmp/nix-daemon.log 2>&1' &
+        if [ "$?" = "0" ]; then
+            start_ok=true
+        fi
+    fi
+    if [ "${start_ok}" = "false" ]; then
+            echo -e 'Failed to start nix-daemon as root. Set multiUser to false in your feature configuration if you would\nprefer to run the container as a non-root. You may also start the daemon manually if you have sudo\ninstalled and configured for your user by running "sudo -c nix-daemon &"'
+    fi
+fi
+
 set -e
 
 direnv allow


### PR DESCRIPTION
## What
More devenv setup. This makes sure that the nix-daemon is running during the postCreate setup. This allows us direnv exec correctly and set up the environment for the user's first run

## How
Edit the post-create.sh file to make sure the nix-daemon is running

## Breaking Changes
No