### PR TITLE
chore: Clean up test pointer functions

### DIFF
--- a/internal/ir/ir_test.go
+++ b/internal/ir/ir_test.go
@@ -7,18 +7,6 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// --- Helper functions to create pointers ---
-func stringPtr(s string) *string {
-	return &s
-}
-
-func pathTypePtr(pt IRPathMatchType) *IRPathMatchType {
-	return &pt
-}
-
-func methodPtr(m IRMethodMatch) *IRMethodMatch {
-	return &m
-}
 func TestSortRoutes(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -30,28 +18,28 @@ func TestSortRoutes(t *testing.T) {
 			routes: []*IRRoute{
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/foo"),
-						PathType: pathTypePtr(IRPathType_Prefix),
+						Path:     ptr.To("/foo"),
+						PathType: ptr.To(IRPathType_Prefix),
 					},
 				},
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/bar"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/bar"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 			},
 			expectedOrder: []*IRRoute{
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/bar"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/bar"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/foo"),
-						PathType: pathTypePtr(IRPathType_Prefix),
+						Path:     ptr.To("/foo"),
+						PathType: ptr.To(IRPathType_Prefix),
 					},
 				},
 			},
@@ -61,28 +49,28 @@ func TestSortRoutes(t *testing.T) {
 			routes: []*IRRoute{
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/longer"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/longer"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/short"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/short"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 			},
 			expectedOrder: []*IRRoute{
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/longer"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/longer"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/short"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/short"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 			},
@@ -92,28 +80,28 @@ func TestSortRoutes(t *testing.T) {
 			routes: []*IRRoute{
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/b"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/b"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/a"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/a"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 			},
 			expectedOrder: []*IRRoute{
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/a"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/a"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/b"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/b"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 			},
@@ -177,7 +165,7 @@ func TestSortRoutes(t *testing.T) {
 			routes: []*IRRoute{
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Method: methodPtr(IRMethodMatch_Get),
+						Method: ptr.To(IRMethodMatch_Get),
 					},
 				},
 				{
@@ -187,7 +175,7 @@ func TestSortRoutes(t *testing.T) {
 			expectedOrder: []*IRRoute{
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Method: methodPtr(IRMethodMatch_Get),
+						Method: ptr.To(IRMethodMatch_Get),
 					},
 				},
 				{
@@ -201,15 +189,15 @@ func TestSortRoutes(t *testing.T) {
 				// Route A: has path "/a", exact, no headers, no query, no method.
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/a"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/a"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 				// Route B: has path "/a", exact, with headers.
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/a"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/a"),
+						PathType: ptr.To(IRPathType_Exact),
 						Headers: []IRHeaderMatch{
 							{Name: "X", Value: "1", ValueType: IRStringValueType_Exact},
 						},
@@ -226,7 +214,7 @@ func TestSortRoutes(t *testing.T) {
 				// Route D: no path, no headers, with method.
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Method: methodPtr(IRMethodMatch_Get),
+						Method: ptr.To(IRMethodMatch_Get),
 					},
 				},
 				// Route E: no path, no headers, no method.
@@ -243,8 +231,8 @@ func TestSortRoutes(t *testing.T) {
 				// Route B: has path "/a", exact, with headers.
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/a"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/a"),
+						PathType: ptr.To(IRPathType_Exact),
 						Headers: []IRHeaderMatch{
 							{Name: "X", Value: "1", ValueType: IRStringValueType_Exact},
 						},
@@ -253,8 +241,8 @@ func TestSortRoutes(t *testing.T) {
 				// Route A: has path "/a", exact, no headers.
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Path:     stringPtr("/a"),
-						PathType: pathTypePtr(IRPathType_Exact),
+						Path:     ptr.To("/a"),
+						PathType: ptr.To(IRPathType_Exact),
 					},
 				},
 				// Then, among routes with no path, route with headers (C)
@@ -268,7 +256,7 @@ func TestSortRoutes(t *testing.T) {
 				// Then, route with method (D)
 				{
 					HTTPMatchCriteria: &IRHTTPMatch{
-						Method: methodPtr(IRMethodMatch_Get),
+						Method: ptr.To(IRMethodMatch_Get),
 					},
 				},
 				// Then, route with nothing (E)

--- a/pkg/managerdriver/translator_test.go
+++ b/pkg/managerdriver/translator_test.go
@@ -33,10 +33,6 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func stringPtr(input string) *string {
-	return &input
-}
-
 func TestBuildInternalAgentEndpoint(t *testing.T) {
 	testCases := []struct {
 		name                   string
@@ -205,7 +201,7 @@ func TestBuildCloudEndpoint(t *testing.T) {
 			testName: "Name prefix",
 			irVHost: &ir.IRVirtualHost{
 				Bindings:               []string{"public"},
-				NamePrefix:             stringPtr("prefix"),
+				NamePrefix:             ptr.To("prefix"),
 				Namespace:              "foo",
 				Metadata:               "test-metadata",
 				EndpointPoolingEnabled: true,
@@ -370,14 +366,6 @@ func TestBuildDefaultDestinationPolicy(t *testing.T) {
 }
 
 func TestGatewayMethodToIR(t *testing.T) {
-	methodPtr := func(v gatewayv1.HTTPMethod) *gatewayv1.HTTPMethod {
-		return &v
-	}
-
-	irPtr := func(v ir.IRMethodMatch) *ir.IRMethodMatch {
-		return &v
-	}
-
 	testCases := []struct {
 		name     string
 		input    *gatewayv1.HTTPMethod
@@ -390,48 +378,48 @@ func TestGatewayMethodToIR(t *testing.T) {
 		},
 		{
 			name:     "GET",
-			input:    methodPtr(gatewayv1.HTTPMethodGet),
-			expected: irPtr(ir.IRMethodMatch_Get),
+			input:    ptr.To(gatewayv1.HTTPMethodGet),
+			expected: ptr.To(ir.IRMethodMatch_Get),
 		},
 		{
 			name:     "HEAD",
-			input:    methodPtr(gatewayv1.HTTPMethodHead),
-			expected: irPtr(ir.IRMethodMatch_Head),
+			input:    ptr.To(gatewayv1.HTTPMethodHead),
+			expected: ptr.To(ir.IRMethodMatch_Head),
 		},
 		{
 			name:     "POST",
-			input:    methodPtr(gatewayv1.HTTPMethodPost),
-			expected: irPtr(ir.IRMethodMatch_Post),
+			input:    ptr.To(gatewayv1.HTTPMethodPost),
+			expected: ptr.To(ir.IRMethodMatch_Post),
 		},
 		{
 			name:     "PUT",
-			input:    methodPtr(gatewayv1.HTTPMethodPut),
-			expected: irPtr(ir.IRMethodMatch_Put),
+			input:    ptr.To(gatewayv1.HTTPMethodPut),
+			expected: ptr.To(ir.IRMethodMatch_Put),
 		},
 		{
 			name:     "DELETE",
-			input:    methodPtr(gatewayv1.HTTPMethodDelete),
-			expected: irPtr(ir.IRMethodMatch_Delete),
+			input:    ptr.To(gatewayv1.HTTPMethodDelete),
+			expected: ptr.To(ir.IRMethodMatch_Delete),
 		},
 		{
 			name:     "CONNECT",
-			input:    methodPtr(gatewayv1.HTTPMethodConnect),
-			expected: irPtr(ir.IRMethodMatch_Connect),
+			input:    ptr.To(gatewayv1.HTTPMethodConnect),
+			expected: ptr.To(ir.IRMethodMatch_Connect),
 		},
 		{
 			name:     "OPTIONS",
-			input:    methodPtr(gatewayv1.HTTPMethodOptions),
-			expected: irPtr(ir.IRMethodMatch_Options),
+			input:    ptr.To(gatewayv1.HTTPMethodOptions),
+			expected: ptr.To(ir.IRMethodMatch_Options),
 		},
 		{
 			name:     "TRACE",
-			input:    methodPtr(gatewayv1.HTTPMethodTrace),
-			expected: irPtr(ir.IRMethodMatch_Trace),
+			input:    ptr.To(gatewayv1.HTTPMethodTrace),
+			expected: ptr.To(ir.IRMethodMatch_Trace),
 		},
 		{
 			name:     "PATCH",
-			input:    methodPtr(gatewayv1.HTTPMethodPatch),
-			expected: irPtr(ir.IRMethodMatch_Patch),
+			input:    ptr.To(gatewayv1.HTTPMethodPatch),
+			expected: ptr.To(ir.IRMethodMatch_Patch),
 		},
 	}
 


### PR DESCRIPTION
## What

Doing some code cleanup

## How

We don't need to make custom functions for creating pointers. k8s utils generic [ptr.To](https://pkg.go.dev/k8s.io/utils/ptr#To) handles this nicely

## Breaking Changes
No, this only impacts tests