### PR TITLE
fix(lb-services): Fix too frequent reconciles for lb-services

### DIFF
--- a/internal/controller/service/controller_test.go
+++ b/internal/controller/service/controller_test.go
@@ -32,6 +32,7 @@ import (
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/annotations"
 	"github.com/ngrok/ngrok-operator/internal/controller"
+	"github.com/ngrok/ngrok-operator/internal/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -260,9 +261,12 @@ var _ = Describe("ServiceController", func() {
 						err := k8sClient.Get(ctx, client.ObjectKeyFromObject(svc), fetched)
 						g.Expect(err).NotTo(HaveOccurred())
 
-						By("By checking the service status is updated")
+						By("checking the service status is updated")
 						g.Expect(fetched.Status.LoadBalancer.Ingress).NotTo(BeEmpty())
 						g.Expect(fetched.Status.LoadBalancer.Ingress[0].Hostname).NotTo(BeEmpty())
+
+						By("verifying the resource version does not change unnecessarily")
+						kginkgo.ConsistentlyExpectResourceVersionNotToChange(ctx, svc, testutils.WithTimeout(10*time.Second))
 					}, timeout, interval).Should(Succeed())
 				})
 


### PR DESCRIPTION
## What

The change in #693 to fix a bug with Cloud/Agent Endpoint changes not triggering re-reconciles had the adverse affect of watching for all changes on cloud/agent endpoints and re-conciling too frequently. We now use a better predicate filter on the service to determine if it needs to be updated.

## How

The status update was also not deterministic since the cloud and agent endpoint status are different. We now correctly determine the right object to use for status update.

In addition, we now also guard against trying to update the status if it is already up to date.

## Breaking Changes
No
