### PR TITLE
feat(ci): Add PR size labels

### DIFF
--- a/.github/pr-size-labeler.yml
+++ b/.github/pr-size-labeler.yml
@@ -1,0 +1,25 @@
+labels:
+- name: size/XS
+  color: '009900'
+  min-lines: 0
+  description: 'Denotes a PR that changes 0-9 lines'
+- name: size/S
+  color: '0077bb'
+  min-lines: 10
+  description: 'Denotes a PR that changes 10-29 lines'
+- name: size/M
+  color: 'eebb00'
+  min-lines: 30
+  description: 'Denotes a PR that changes 30-99 lines'
+- name: size/L
+  color: 'ee9900'
+  min-lines: 100
+  description: 'Denotes a PR that changes 100-499 lines'
+- name: size/XL
+  color: 'ee5500'
+  min-lines: 500
+  description: 'Denotes a PR that changes 500-999 lines'
+- name: size/XXL
+  color: 'ee0000'
+  min-lines: 1000
+  description: 'Denotes a PR that changes 1000+ lines'

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,0 +1,25 @@
+name: Pull Request Labeler
+on:
+  pull_request_target:
+    types:
+    - opened
+    - edited
+    - reopened
+    - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  size-labeler:
+    name: Size
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Apply size label
+      uses: ngrok/pr-size-labeler@d5a95a01bbe2eca3f692d0809edb0aeb56c3bd18
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## What

Helps us quickly triage Pull Requests based on their size.

## How

Add size labels to PRs

## Breaking Changes

No, CI only