### PR TITLE
fix(ci): Fix PR Size Labeler action

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Apply size label
-      uses: ngrok/pr-size-labeler@d5a95a01bbe2eca3f692d0809edb0aeb56c3bd18
+      uses: ngrok/pr-size-labeler@77827af3431595c474d738acf7cfcee30c86edc1 # v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What

I discovered our PR size labeler action didn't support the pull_request_target event. Its been updated to support that event type. Now we just need to update the action.

## How

Use latest main commit

## Breaking Changes
No, CI only
