### PR TITLE
feat(helm): Add support for setting pod terminationGracePeriodSeconds

### DIFF
--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -83,6 +83,7 @@ To uninstall the chart:
 | `tolerations`                        | Tolerations for manager pod(s)                                                                                                                 | `[]`     |
 | `topologySpreadConstraints`          | Topology Spread Constraints for manager pod(s)                                                                                                 | `[]`     |
 | `priorityClassName`                  | Priority class for pod scheduling                                                                                                              | `""`     |
+| `terminationGracePeriodSeconds`      | The amount of time to wait for the pod to gracefully terminate                                                                                 | `30`     |
 | `lifecycle`                          | an object containing lifecycle configuration                                                                                                   | `{}`     |
 | `podDisruptionBudget.create`         | Enable a Pod Disruption Budget creation                                                                                                        | `false`  |
 | `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable                                                                                 | `""`     |
@@ -131,18 +132,19 @@ To uninstall the chart:
 
 ### Agent configuration
 
-| Name                               | Description                                                         | Value  |
-| ---------------------------------- | ------------------------------------------------------------------- | ------ |
-| `agent.priorityClassName`          | Priority class for pod scheduling.                                  | `""`   |
-| `agent.replicaCount`               | The number of agents to run.                                        | `1`    |
-| `agent.serviceAccount.create`      | Specifies whether a ServiceAccount should be created for the agent. | `true` |
-| `agent.serviceAccount.name`        | The name of the ServiceAccount to use for the agent.                | `""`   |
-| `agent.serviceAccount.annotations` | Additional annotations to add to the agent ServiceAccount           | `{}`   |
-| `agent.resources.limits`           | The resources limits for the container                              | `{}`   |
-| `agent.resources.requests`         | The requested resources for the container                           | `{}`   |
-| `agent.tolerations`                | Tolerations for the agent pod(s)                                    | `[]`   |
-| `agent.nodeSelector`               | Node labels for the agent pod(s)                                    | `{}`   |
-| `agent.topologySpreadConstraints`  | Topology Spread Constraints for the agent pod(s)                    | `[]`   |
+| Name                                  | Description                                                          | Value  |
+| ------------------------------------- | -------------------------------------------------------------------- | ------ |
+| `agent.priorityClassName`             | Priority class for pod scheduling.                                   | `""`   |
+| `agent.replicaCount`                  | The number of agents to run.                                         | `1`    |
+| `agent.serviceAccount.create`         | Specifies whether a ServiceAccount should be created for the agent.  | `true` |
+| `agent.serviceAccount.name`           | The name of the ServiceAccount to use for the agent.                 | `""`   |
+| `agent.serviceAccount.annotations`    | Additional annotations to add to the agent ServiceAccount            | `{}`   |
+| `agent.resources.limits`              | The resources limits for the container                               | `{}`   |
+| `agent.resources.requests`            | The requested resources for the container                            | `{}`   |
+| `agent.terminationGracePeriodSeconds` | The amount of time to wait for the agent pod to gracefully terminate | `30`   |
+| `agent.tolerations`                   | Tolerations for the agent pod(s)                                     | `[]`   |
+| `agent.nodeSelector`                  | Node labels for the agent pod(s)                                     | `{}`   |
+| `agent.topologySpreadConstraints`     | Topology Spread Constraints for the agent pod(s)                     | `[]`   |
 
 ### Kubernetes Gateway feature configuration
 
@@ -154,19 +156,20 @@ To uninstall the chart:
 
 ### Kubernetes Bindings feature configuration
 
-| Name                                            | Description                                                                                                   | Value                                     |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `bindings.enabled`                              | Whether to enable the Endpoint Bindings feature                                                               | `false`                                   |
-| `bindings.endpointSelectors`                    | List of cel expressions used to filter which kubernetes-bound endpoints should be projected into this cluster | `["true"]`                                |
-| `bindings.serviceAnnotations`                   | Annotations to add to projected services bound to an endpoint                                                 | `{}`                                      |
-| `bindings.serviceLabels`                        | Labels to add to projected services bound to an endpoint                                                      | `{}`                                      |
-| `bindings.ingressEndpoint`                      | The hostname of the ingress endpoint for the bindings                                                         | `kubernetes-binding-ingress.ngrok.io:443` |
-| `bindings.forwarder.replicaCount`               | The number of bindings forwarders to run.                                                                     | `1`                                       |
-| `bindings.forwarder.resources.limits`           | The resources limits for the container                                                                        | `{}`                                      |
-| `bindings.forwarder.resources.requests`         | The requested resources for the container                                                                     | `{}`                                      |
-| `bindings.forwarder.serviceAccount.create`      | Specifies whether a ServiceAccount should be created for the bindings forwarder pod(s).                       | `true`                                    |
-| `bindings.forwarder.serviceAccount.name`        | The name of the ServiceAccount to use for the bindings forwarder pod(s).                                      | `""`                                      |
-| `bindings.forwarder.serviceAccount.annotations` | Additional annotations to add to the bindings-forwarder ServiceAccount                                        | `{}`                                      |
-| `bindings.forwarder.tolerations`                | Tolerations for the bindings forwarder pod(s)                                                                 | `[]`                                      |
-| `bindings.forwarder.nodeSelector`               | Node labels for the bindings forwarder pod(s)                                                                 | `{}`                                      |
-| `bindings.forwarder.topologySpreadConstraints`  | Topology Spread Constraints for the bindings forwarder pod(s)                                                 | `[]`                                      |
+| Name                                               | Description                                                                                                   | Value                                     |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `bindings.enabled`                                 | Whether to enable the Endpoint Bindings feature                                                               | `false`                                   |
+| `bindings.endpointSelectors`                       | List of cel expressions used to filter which kubernetes-bound endpoints should be projected into this cluster | `["true"]`                                |
+| `bindings.serviceAnnotations`                      | Annotations to add to projected services bound to an endpoint                                                 | `{}`                                      |
+| `bindings.serviceLabels`                           | Labels to add to projected services bound to an endpoint                                                      | `{}`                                      |
+| `bindings.ingressEndpoint`                         | The hostname of the ingress endpoint for the bindings                                                         | `kubernetes-binding-ingress.ngrok.io:443` |
+| `bindings.forwarder.replicaCount`                  | The number of bindings forwarders to run.                                                                     | `1`                                       |
+| `bindings.forwarder.resources.limits`              | The resources limits for the container                                                                        | `{}`                                      |
+| `bindings.forwarder.resources.requests`            | The requested resources for the container                                                                     | `{}`                                      |
+| `bindings.forwarder.serviceAccount.create`         | Specifies whether a ServiceAccount should be created for the bindings forwarder pod(s).                       | `true`                                    |
+| `bindings.forwarder.serviceAccount.name`           | The name of the ServiceAccount to use for the bindings forwarder pod(s).                                      | `""`                                      |
+| `bindings.forwarder.serviceAccount.annotations`    | Additional annotations to add to the bindings-forwarder ServiceAccount                                        | `{}`                                      |
+| `bindings.forwarder.terminationGracePeriodSeconds` | The amount of time to wait for the bindings forwarder pod to gracefully terminate                             | `30`                                      |
+| `bindings.forwarder.tolerations`                   | Tolerations for the bindings forwarder pod(s)                                                                 | `[]`                                      |
+| `bindings.forwarder.nodeSelector`                  | Node labels for the bindings forwarder pod(s)                                                                 | `{}`                                      |
+| `bindings.forwarder.topologySpreadConstraints`     | Topology Spread Constraints for the bindings forwarder pod(s)                                                 | `[]`                                      |

--- a/helm/ngrok-operator/templates/agent/deployment.yaml
+++ b/helm/ngrok-operator/templates/agent/deployment.yaml
@@ -39,6 +39,9 @@ spec:
       {{- if $agent.priorityClassName }}
       priorityClassName: {{ $agent.priorityClassName | quote }}
       {{- end }}
+      {{- if $agent.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $agent.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/ngrok-operator/templates/bindings-forwarder/deployment.yaml
+++ b/helm/ngrok-operator/templates/bindings-forwarder/deployment.yaml
@@ -39,6 +39,9 @@ spec:
       {{- if $forwarder.priorityClassName }}
       priorityClassName: {{ $forwarder.priorityClassName | quote }}
       {{- end }}
+      {{- if $forwarder.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $forwarder.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/ngrok-operator/templates/controller-deployment.yaml
+++ b/helm/ngrok-operator/templates/controller-deployment.yaml
@@ -38,6 +38,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -113,6 +113,7 @@ Should match all-options snapshot:
                 - mountPath: /test-volume
                   name: test-volume
           serviceAccountName: RELEASE-NAME-ngrok-operator
+          terminationGracePeriodSeconds: 30
           volumes:
             - emptyDir: {}
               name: test-volume
@@ -703,6 +704,7 @@ Should match default snapshot:
               securityContext:
                 allowPrivilegeEscalation: false
           serviceAccountName: RELEASE-NAME-ngrok-operator
+          terminationGracePeriodSeconds: 30
   2: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role

--- a/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
@@ -96,6 +96,7 @@ Should match snapshot:
               securityContext:
                 allowPrivilegeEscalation: false
           serviceAccountName: RELEASE-NAME-ngrok-operator-agent
+          terminationGracePeriodSeconds: 30
   2: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole

--- a/helm/ngrok-operator/tests/agent/deployment_test.yaml
+++ b/helm/ngrok-operator/tests/agent/deployment_test.yaml
@@ -90,6 +90,21 @@ tests:
   - equal:
       path: spec.template.spec.containers[0].resources
       value: *resources
+- it: Sets terminationGracePeriodSeconds by default
+  template: agent/deployment.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.terminationGracePeriodSeconds
+      value: 30
+- it: Allows overriding terminationGracePeriodSeconds for the agent
+  set:
+    agent:
+      terminationGracePeriodSeconds: 45
+  template: agent/deployment.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.terminationGracePeriodSeconds
+      value: 45
 - it: Should set the default domain reclaim policy arg
   set:
     defaultDomainReclaimPolicy: "Retain"

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
@@ -93,3 +93,4 @@ Should match snapshot:
               securityContext:
                 allowPrivilegeEscalation: false
           serviceAccountName: RELEASE-NAME-ngrok-operator-bindings-forwarder
+          terminationGracePeriodSeconds: 30

--- a/helm/ngrok-operator/tests/bindings-forwarder/deployment_test.yaml
+++ b/helm/ngrok-operator/tests/bindings-forwarder/deployment_test.yaml
@@ -104,3 +104,20 @@ tests:
   - equal:
       path: spec.template.spec.containers[0].resources
       value: *resources
+- it: Sets terminationGracePeriodSeconds by default
+  template: bindings-forwarder/deployment.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.terminationGracePeriodSeconds
+      value: 30
+- it: Allows overriding terminationGracePeriodSeconds for the bindings forwarder
+  set:
+    bindings:
+      enabled: true
+      forwarder:
+        terminationGracePeriodSeconds: 75
+  template: bindings-forwarder/deployment.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.terminationGracePeriodSeconds
+      value: 75

--- a/helm/ngrok-operator/tests/controller-deployment_test.yaml
+++ b/helm/ngrok-operator/tests/controller-deployment_test.yaml
@@ -376,6 +376,22 @@ tests:
   - equal:
       path: spec.template.spec.priorityClassName
       value: high-priority
+- it: Sets terminationGracePeriodSeconds by default
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - equal:
+      path: spec.template.spec.terminationGracePeriodSeconds
+      value: 30
+- it: Allows overriding terminationGracePeriodSeconds
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  set:
+    terminationGracePeriodSeconds: 120
+  asserts:
+  - equal:
+      path: spec.template.spec.terminationGracePeriodSeconds
+      value: 120
 - it: Adds .Values.podLabels to the controller deployment podspec
   set:
     podLabels:

--- a/helm/ngrok-operator/values.schema.json
+++ b/helm/ngrok-operator/values.schema.json
@@ -166,6 +166,11 @@
             "description": "Priority class for pod scheduling",
             "default": ""
         },
+        "terminationGracePeriodSeconds": {
+            "type": "number",
+            "description": "The amount of time to wait for the pod to gracefully terminate",
+            "default": 30
+        },
         "lifecycle": {
             "type": "object",
             "description": "an object containing lifecycle configuration",
@@ -381,6 +386,11 @@
                         }
                     }
                 },
+                "terminationGracePeriodSeconds": {
+                    "type": "number",
+                    "description": "The amount of time to wait for the agent pod to gracefully terminate",
+                    "default": 30
+                },
                 "tolerations": {
                     "type": "array",
                     "description": "Tolerations for the agent pod(s)",
@@ -490,6 +500,11 @@
                                     "default": {}
                                 }
                             }
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "type": "number",
+                            "description": "The amount of time to wait for the bindings forwarder pod to gracefully terminate",
+                            "default": 30
                         },
                         "tolerations": {
                             "type": "array",

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -121,6 +121,12 @@ topologySpreadConstraints: []
 ##
 priorityClassName: ""
 
+## @param terminationGracePeriodSeconds The amount of time to wait for the pod to gracefully terminate
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+## Increase this value to give the operator more time to clean up finalizers during shutdown
+##
+terminationGracePeriodSeconds: 30
+
 ## @param lifecycle an object containing lifecycle configuration
 ## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 ##
@@ -292,6 +298,12 @@ agent:
     name: ""
     annotations: {}
 
+  ## @param agent.terminationGracePeriodSeconds The amount of time to wait for the agent pod to gracefully terminate
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+  ## Increase this value to give the operator more time to clean up finalizers during shutdown
+  ##
+  terminationGracePeriodSeconds: 30
+
   ## @param agent.tolerations Tolerations for the agent pod(s)
   tolerations: []
 
@@ -366,6 +378,12 @@ bindings:
       create: true
       name: ""
       annotations: {}
+
+    ## @param bindings.forwarder.terminationGracePeriodSeconds The amount of time to wait for the bindings forwarder pod to gracefully terminate
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+    ## Increase this value to give the operator more time to clean up finalizers during shutdown
+    ##
+    terminationGracePeriodSeconds: 30
 
     ## @param bindings.forwarder.tolerations Tolerations for the bindings forwarder pod(s)
     tolerations: []


### PR DESCRIPTION
## What

Allows configuring the `terminationGracerPeriodSeconds` for each pod type.

## How

* Update the `values.yaml` to add `terminationGracePeriodSeconds` to each pod type.
* Add tests
* Re-generate README for helm chart

## Breaking Changes

No. We now generate `terminationGracePeriodSeconds` in the deployments podspecs. It defaults to `30` which is the Kubernetes default, so there should be no effective change.
