### PR TITLE
feat(devenv): set k8sop description to codespace name

### DIFF
--- a/helm/ngrok-operator/templates/agent/deployment.yaml
+++ b/helm/ngrok-operator/templates/agent/deployment.yaml
@@ -77,7 +77,7 @@ spec:
         - agent-manager
         {{- include "ngrok-operator.manager.cliFeatureFlags" . | nindent 8 }}
         {{- if .Values.description }}
-        - --description={{ .Values.description | quote }}
+        - {{ printf "--description=%s" .Values.description | quote }}
         {{- end }}
         {{- if .Values.region }}
         - --region={{ .Values.region }}

--- a/helm/ngrok-operator/templates/bindings-forwarder/deployment.yaml
+++ b/helm/ngrok-operator/templates/bindings-forwarder/deployment.yaml
@@ -77,7 +77,7 @@ spec:
         - bindings-forwarder-manager
         - --release-name={{ .Release.Name }}
         {{- if .Values.description }}
-        - --description={{ .Values.description | quote }}
+        - {{ printf "--description=%s" .Values.description | quote }}
         {{- end }}
         - --zap-log-level={{ .Values.log.level }}
         - --zap-stacktrace-level={{ .Values.log.stacktraceLevel }}

--- a/helm/ngrok-operator/templates/controller-deployment.yaml
+++ b/helm/ngrok-operator/templates/controller-deployment.yaml
@@ -99,7 +99,7 @@ spec:
         - --bindings-ingress-endpoint={{ .Values.bindings.ingressEndpoint }}
         {{- end }}
         {{- if .Values.description }}
-        - --description={{ .Values.description | quote }}
+        - {{ printf "--description=%s" .Values.description | quote }}
         {{- end }}
         {{- if .Values.region }}
         - --region={{ .Values.region}}

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -58,7 +58,7 @@ Should match all-options snapshot:
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=true
                 - --disable-reference-grants=false
-                - --description="The official ngrok Kubernetes Operator."
+                - --description=The official ngrok Kubernetes Operator.
                 - --ingress-controller-name=k8s.ngrok.com/ingress-controller
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error
@@ -659,7 +659,7 @@ Should match default snapshot:
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=true
                 - --disable-reference-grants=false
-                - --description="The official ngrok Kubernetes Operator."
+                - --description=The official ngrok Kubernetes Operator.
                 - --ingress-controller-name=k8s.ngrok.com/ingress-controller
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error

--- a/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
@@ -53,7 +53,7 @@ Should match snapshot:
                 - --enable-feature-ingress=true
                 - --enable-feature-gateway=true
                 - --disable-reference-grants=false
-                - --description="The official ngrok Kubernetes Operator."
+                - --description=The official ngrok Kubernetes Operator.
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error
                 - --zap-encoder=json

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
@@ -51,7 +51,7 @@ Should match snapshot:
             - args:
                 - bindings-forwarder-manager
                 - --release-name=RELEASE-NAME
-                - --description="The official ngrok Kubernetes Operator."
+                - --description=The official ngrok Kubernetes Operator.
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error
                 - --zap-encoder=json

--- a/helm/ngrok-operator/tests/controller-deployment_test.yaml
+++ b/helm/ngrok-operator/tests/controller-deployment_test.yaml
@@ -163,7 +163,16 @@ tests:
   asserts:
   - contains:
       path: spec.template.spec.containers[0].args
-      content: --description="test description"
+      content: --description=test description
+- it: Should pass description when description has special characters
+  set:
+    description: 'lets-go: with spaces'
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: '--description=lets-go: with spaces'
 - it: Should support deprecated metaData to the deployment
   set:
     metaData:

--- a/tools/make/deploy.mk
+++ b/tools/make/deploy.mk
@@ -1,5 +1,9 @@
 ##@ Deploying
 
+ifneq ($(CODESPACE_NAME),)
+HELM_DESCRIPTION_FLAG = --set-string description="codespace: $(CODESPACE_NAME)"
+endif
+
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/api/main.go
@@ -19,7 +23,8 @@ deploy: _deploy-check-env-vars docker-build manifests _helm_setup kind-load-imag
 		--set log.format=console \
 		--set-string log.level="8" \
 		--set log.stacktraceLevel=panic \
-		--set metaData.env=local,metaData.from=makefile
+		--set metaData.env=local,metaData.from=makefile \
+		$(HELM_DESCRIPTION_FLAG)
 
 .PHONY: deploy_gateway
 deploy_gateway: _deploy-check-env-vars docker-build manifests _helm_setup kind-load-image ## Deploy controller to the K8s cluster specified in ~/.kube/config.
@@ -36,7 +41,8 @@ deploy_gateway: _deploy-check-env-vars docker-build manifests _helm_setup kind-l
 		--set-string log.level="8" \
 		--set log.stacktraceLevel=panic \
 		--set metaData.env=local,metaData.from=makefile \
-		--set useExperimentalGatewayApi=true
+		--set useExperimentalGatewayApi=true \
+		$(HELM_DESCRIPTION_FLAG)
 
 .PHONY: deploy_with_bindings
 deploy_with_bindings: _deploy-check-env-vars docker-build manifests _helm_setup kind-load-image ## Deploy controller to the K8s cluster specified in ~/.kube/config.
@@ -53,7 +59,8 @@ deploy_with_bindings: _deploy-check-env-vars docker-build manifests _helm_setup 
 		--set log.level=debug \
 		--set log.stacktraceLevel=panic \
 		--set metaData.env=local,metaData.from=makefile \
-		--set bindings.enabled=true
+		--set bindings.enabled=true \
+		$(HELM_DESCRIPTION_FLAG)
 
 .PHONY: deploy_for_e2e
 deploy_for_e2e: _deploy-check-env-vars docker-build manifests _helm_setup kind-load-image ## Deploy controller to the K8s cluster specified in ~/.kube.config.


### PR DESCRIPTION
## What

<img width="701" height="401" alt="image" src="https://github.com/user-attachments/assets/e2577c17-3846-4f70-a633-df0cf6adcb92" />

The description of the kubernetes operator is quoted. It shouldn't be. Also, I think it would be nice when developing in our codespace if it tells me the name of the codespace automatically.

## How
* Fixed the quoting bug for the description
* Automatically pass the codespace name in as part of the description

With the fix and enhancement

<img width="740" height="188" alt="image" src="https://github.com/user-attachments/assets/b8940919-2e00-4ffc-bc9f-b7337607a251" />

## Breaking Changes
Yes, depending on how you were passing the description in to account for this quoting, you may need to update the description you are passing.
