### PR TITLE
Remove the setting the ready reason to reconciling as it makes the la…

### DIFF
--- a/internal/controller/agent/agent_endpoint_conditions.go
+++ b/internal/controller/agent/agent_endpoint_conditions.go
@@ -22,7 +22,6 @@ const (
 	ReasonUpstreamError      = "UpstreamError"
 	ReasonEndpointCreated    = "EndpointCreated"
 	ReasonConfigError        = "ConfigurationError"
-	ReasonReconciling        = "Reconciling"
 )
 
 // setReadyCondition sets the Ready condition based on the overall endpoint state
@@ -77,11 +76,6 @@ func setTrafficPolicyCondition(endpoint *ngrokv1alpha1.AgentEndpoint, applied bo
 	}
 
 	meta.SetStatusCondition(&endpoint.Status.Conditions, condition)
-}
-
-// setReconcilingCondition sets a temporary reconciling condition
-func setReconcilingCondition(endpoint *ngrokv1alpha1.AgentEndpoint, message string) {
-	setReadyCondition(endpoint, false, ReasonReconciling, message)
 }
 
 // calculateAgentEndpointReadyCondition calculates the overall Ready condition based on other conditions and domain status

--- a/internal/controller/agent/agent_endpoint_controller.go
+++ b/internal/controller/agent/agent_endpoint_controller.go
@@ -198,8 +198,6 @@ func (r *AgentEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func (r *AgentEndpointReconciler) update(ctx context.Context, endpoint *ngrokv1alpha1.AgentEndpoint) error {
-	// Set initial condition to reconciling
-	setReconcilingCondition(endpoint, "Reconciling AgentEndpoint")
 
 	// EnsureDomainExists checks if the domain exists, creates it if needed, and sets conditions/domainRef
 	domainResult, err := r.DomainManager.EnsureDomainExists(ctx, endpoint)


### PR DESCRIPTION
…st transition time change a lot

<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What

Stops setting this ready reason arbitrarily

## How

This currently sets this condition on each reconciliation
Because it's normally true and this sets it to false, it changes the last transition timestamp

## Breaking Changes
*Are there any breaking changes in this PR?*
