### PR TITLE
:tada: Release helm chart 0.21.1 :tada:

### DIFF
--- a/helm/ngrok-operator/CHANGELOG.md
+++ b/helm/ngrok-operator/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the helm chart will be documented in this file. Please se
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.1
+**Full Changelog**: https://github.com/ngrok/ngrok-operator/compare/helm-chart-0.21.0...helm-chart-0.21.1
+
+- Update ngrok-operator image version to `0.19.1`
+- Update Helm chart version to `0.21.1`
+
+### Added
+
+- feat(helm): Add support for setting pod terminationGracePeriodSeconds by @jonstacks in [#701](https://github.com/ngrok/ngrok-operator/pull/701)
+
+
 ## 0.21.1-rc.1
 **Full Changelog**: https://github.com/ngrok/ngrok-operator/compare/helm-chart-0.21.0...helm-chart-0.21.1-rc.1
 

--- a/helm/ngrok-operator/Chart.yaml
+++ b/helm/ngrok-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ngrok-operator
 description: The official ngrok Kubernetes Operator.
-version: 0.21.1-rc.1
+version: 0.21.1
 appVersion: 0.19.1
 keywords:
   - ngrok

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -13,7 +13,7 @@ Should match all-options snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.19.1
-        helm.sh/chart: ngrok-operator-0.21.1-rc.1
+        helm.sh/chart: ngrok-operator-0.21.1
       name: RELEASE-NAME-ngrok-operator-manager
       namespace: NAMESPACE
     spec:
@@ -614,7 +614,7 @@ Should match default snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.19.1
-        helm.sh/chart: ngrok-operator-0.21.1-rc.1
+        helm.sh/chart: ngrok-operator-0.21.1
       name: RELEASE-NAME-ngrok-operator-manager
       namespace: NAMESPACE
     spec:

--- a/helm/ngrok-operator/tests/__snapshot__/controller-pdb_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-pdb_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.19.1
-        helm.sh/chart: ngrok-operator-0.21.1-rc.1
+        helm.sh/chart: ngrok-operator-0.21.1
       name: test-release-ngrok-operator-controller-pdb
       namespace: test-namespace
     spec:

--- a/helm/ngrok-operator/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
@@ -10,6 +10,6 @@ Should match the snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.19.1
-        helm.sh/chart: ngrok-operator-0.21.1-rc.1
+        helm.sh/chart: ngrok-operator-0.21.1
       name: test-release-ngrok-operator
       namespace: test-namespace

--- a/helm/ngrok-operator/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -10,7 +10,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.19.1
-        helm.sh/chart: ngrok-operator-0.21.1-rc.1
+        helm.sh/chart: ngrok-operator-0.21.1
       name: ngrok
     spec:
       controller: k8s.ngrok.com/ingress-controller

--- a/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
@@ -12,7 +12,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.19.1
-        helm.sh/chart: ngrok-operator-0.21.1-rc.1
+        helm.sh/chart: ngrok-operator-0.21.1
       name: RELEASE-NAME-ngrok-operator-agent
       namespace: NAMESPACE
     spec:

--- a/helm/ngrok-operator/tests/agent/__snapshot__/service-account_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/service-account_test.yaml.snap
@@ -10,6 +10,6 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.19.1
-        helm.sh/chart: ngrok-operator-0.21.1-rc.1
+        helm.sh/chart: ngrok-operator-0.21.1
       name: test-release-ngrok-operator-agent
       namespace: test-namespace

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
@@ -12,7 +12,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.19.1
-        helm.sh/chart: ngrok-operator-0.21.1-rc.1
+        helm.sh/chart: ngrok-operator-0.21.1
       name: RELEASE-NAME-ngrok-operator-bindings-forwarder
       namespace: NAMESPACE
     spec:

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/service-account_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/service-account_test.yaml.snap
@@ -10,6 +10,6 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.19.1
-        helm.sh/chart: ngrok-operator-0.21.1-rc.1
+        helm.sh/chart: ngrok-operator-0.21.1
       name: test-release-ngrok-operator-bindings-forwarder
       namespace: test-namespace


### PR DESCRIPTION
## What

Promotes the `0.21.1-rc.1` RC to `0.21.1`

## How

Bump the helm chart version

## Breaking Changes
Yes, there are changes to how domains work in conjunction with endpoints. See #705 for details

> - makes the bindings string array only allow 1 value via the kube api {ngrok api only allows 1)
> - agentendpoints and cloudendpoints with kubernetes bindings no longer get domains created or domainRef status fields
> - agentendpoints and cloudendpoints now get created even if their domains are not ready. The big bug is that the condition changes made them not get created if the domain isn't ready. 
> - this meant endpoints with invalid domains that won't get certs but could still be used over http wouldn't get created
> - kubernetes bound endpoints created via CRDs also got domain CRs created for their k8s bound domain. These won't go ready since their TLD is the k8s namespace and not a domain that is owned. 
