### PR TITLE
Propagate domain conditions to ingress and gateway objects

### DIFF
--- a/internal/controller/gateway/gateway_controller.go
+++ b/internal/controller/gateway/gateway_controller.go
@@ -381,6 +381,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				obj.GetObjectKind().GroupVersionKind().Kind,
 				r.Driver,
 				r.Client,
+				managerdriver.WithEventRecorder(r.Recorder),
 			),
 		)
 	}

--- a/internal/controller/ingress/ingress_controller.go
+++ b/internal/controller/ingress/ingress_controller.go
@@ -40,7 +40,8 @@ func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	for _, obj := range storedResources {
 		builder = builder.Watches(
 			obj,
-			managerdriver.NewControllerEventHandler(obj.GetObjectKind().GroupVersionKind().Kind, r.Driver, r.Client))
+			managerdriver.NewControllerEventHandler(obj.GetObjectKind().GroupVersionKind().Kind, r.Driver, r.Client,
+				managerdriver.WithEventRecorder(r.Recorder)))
 	}
 
 	return builder.Complete(r)

--- a/pkg/managerdriver/controller-handler.go
+++ b/pkg/managerdriver/controller-handler.go
@@ -4,12 +4,18 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/store"
 )
 
@@ -22,20 +28,36 @@ var _ handler.EventHandler = &ControllerEventHandler{}
 // It is used to simply watch some resources and keep their values updated in the store.
 // It is used to keep various crds like edges/tunnels/domains, and core resources like ingress classes, updated.
 type ControllerEventHandler struct {
-	client client.Client
-	driver *Driver
-	store  store.Storer
-	log    logr.Logger
+	client   client.Client
+	driver   *Driver
+	store    store.Storer
+	log      logr.Logger
+	recorder record.EventRecorder
+}
+
+// ControllerEventHandlerOpt is a functional option for configuring ControllerEventHandler
+type ControllerEventHandlerOpt func(*ControllerEventHandler)
+
+// WithEventRecorder configures the handler to propagate error events from child resources
+// (like Domain) up to parent resources (like Ingress/Gateway)
+func WithEventRecorder(recorder record.EventRecorder) ControllerEventHandlerOpt {
+	return func(h *ControllerEventHandler) {
+		h.recorder = recorder
+	}
 }
 
 // NewControllerEventHandler creates a new ControllerEventHandler
-func NewControllerEventHandler(resourceName string, d *Driver, client client.Client) *ControllerEventHandler {
-	return &ControllerEventHandler{
+func NewControllerEventHandler(resourceName string, d *Driver, c client.Client, opts ...ControllerEventHandlerOpt) *ControllerEventHandler {
+	h := &ControllerEventHandler{
 		driver: d,
-		client: client,
+		client: c,
 		store:  d.store,
 		log:    d.log.WithValues("ControllerEventHandlerFor", resourceName),
 	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
 }
 
 // Create is called in response to an create event - e.g. Edge Creation.
@@ -56,6 +78,11 @@ func (e *ControllerEventHandler) Update(ctx context.Context, evt event.UpdateEve
 		e.log.Error(err, "error syncing after object update", "object", evt.ObjectNew)
 		return
 	}
+
+	// Propagate errors from downstream resources to source Ingress/Gateway objects
+	if e.recorder != nil {
+		e.propagateErrorsToSources(evt.ObjectNew)
+	}
 }
 
 // Delete is called in response to a delete event - e.g. Edge Deleted.
@@ -73,4 +100,65 @@ func (e *ControllerEventHandler) Generic(_ context.Context, evt event.GenericEve
 		e.log.Error(err, "error updating object in generic", "object", evt.Object)
 		return
 	}
+}
+
+// propagateErrorsToSources checks if the updated object has error conditions and emits
+// events on source Ingress/Gateway resources that created this object.
+func (e *ControllerEventHandler) propagateErrorsToSources(obj client.Object) {
+	domain, ok := obj.(*ingressv1alpha1.Domain)
+	if !ok {
+		// Future: handle other types like CloudEndpoint, AgentEndpoint
+		return
+	}
+
+	readyCond := meta.FindStatusCondition(domain.Status.Conditions, "Ready")
+	if readyCond == nil {
+		return
+	}
+
+	// Find and emit events to source Ingresses
+	for _, ing := range e.findIngressesForDomain(domain.Spec.Domain) {
+		e.recorder.Eventf(ing, corev1.EventTypeWarning, readyCond.Reason,
+			"Domain %q: %s", domain.Spec.Domain, readyCond.Message)
+	}
+
+	// Find and emit events to source Gateways
+	for _, gw := range e.findGatewaysForDomain(domain.Spec.Domain) {
+		e.recorder.Eventf(gw, corev1.EventTypeWarning, readyCond.Reason,
+			"Domain %q: %s", domain.Spec.Domain, readyCond.Message)
+	}
+}
+
+// findIngressesForDomain returns all Ingresses that reference the given domain name
+func (e *ControllerEventHandler) findIngressesForDomain(domainName string) []*netv1.Ingress {
+	var result []*netv1.Ingress
+	for _, ing := range e.store.ListNgrokIngressesV1() {
+		if ing == nil {
+			continue
+		}
+		for _, rule := range ing.Spec.Rules {
+			if rule.Host == domainName {
+				result = append(result, ing)
+				break
+			}
+		}
+	}
+	return result
+}
+
+// findGatewaysForDomain returns all Gateways that reference the given domain name
+func (e *ControllerEventHandler) findGatewaysForDomain(domainName string) []*gatewayv1.Gateway {
+	var result []*gatewayv1.Gateway
+	for _, gw := range e.store.ListGateways() {
+		if gw == nil {
+			continue
+		}
+		for _, listener := range gw.Spec.Listeners {
+			if listener.Hostname != nil && string(*listener.Hostname) == domainName {
+				result = append(result, gw)
+				break
+			}
+		}
+	}
+	return result
 }


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:




How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #217

## What

We noted that a common error case is when a free user tries to setup their first ingress object, if they haven't found out about their 1 free reserved domain, they may try to use their own custom host and it will fail to be created because they can't reserve additional domains and need to use their free one instead.

However, no information is expressed on the ingress object. The operator sees this ingress object and creates a Domain CRD that would have status conditions and events saying `Domain "tinyllama-free-account-domain-test.ngrok.app": HTTP 400: Only accounts on paid plans can reserve domains. Your account can't reserve domains. Upgrade to a paid plan at: https://dashboard.ngrok.com/billing/choose-a-plan [ERR_NGROK_401] Operation ID: op_36OOAJkG4M2Iu8OegrXO0FKJ0k3` . But you have to know to look for that CRD or to list all events.

Instead we would like this information to be more discoverable on the ingress object. 

## How

Ingress doesn't have conditions on its status, so we can only really use events to relay information. 

The below approach is 1 idea. This hooks into the managerdriver ControllerEventHandler functionality that watches other resources. When the status of a domain is updated with a new condition, we can turn that into an event we push to the ingress object. The intention is for this to be extensible to other resources like conditions on the Cloud and Agent endpoints as well (the agent endpoints however require a different way to find what ingress/gateway objects spawned them). 

## Alternative Approaches

This is getting condition updates and pushing them as events. Alternatively, we could try to make the Domain events work as a multi-event emitter. The events about the errors are emitted by our base controller though https://github.com/ngrok/ngrok-operator/blob/main/internal/controller/base_controller.go#L84 so we would need some abstract way to lookup other resources to event to as well. 

Looking for some feedback on this approach before i go too deep. 