### PR TITLE
change gh workspace post-create.sh to wait for nix to be ready

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -23,6 +23,16 @@ if ! pidof nix-daemon > /dev/null 2>&1; then
     fi
 fi
 
+# Wait for nix-daemon to be ready (up to 30 seconds)
+echo "Waiting for nix-daemon to be ready..."
+for i in $(seq 1 30); do
+    if nix --version > /dev/null 2>&1; then
+        echo "nix-daemon is ready"
+        break
+    fi
+    sleep 1
+done
+
 set -e
 
 direnv allow


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What

I've been trying to setup codespaces using my dotfiles to use this as my daily driver but i've been having some issues. 

```
2025-12-05 01:14:05.989Z: Running the postCreateCommand from devcontainer.json...

2025-12-05 01:14:05.989Z: .devcontainer/post-create.sh
2025-12-05 01:14:13.251Z: direnv: loading /workspaces/ngrok-operator/.envrc
2025-12-05 01:14:13.260Z: direnv: using flake
2025-12-05 01:14:29.463Z: 
[K2025-12-05 01:14:29.475Z: 
[Kerror:
       … This command may have been run as non-root in a single-user Nix installation,
       or the Nix daemon may have crashed.

       error: opening lock file '/nix/var/nix/db/big-lock': Permission denied
2025-12-05 01:14:29.478Z: 
[K2025-12-05 01:14:29.618Z: 
[K2025-12-05 01:14:29.684Z: 
[K2025-12-05 01:14:29.830Z: make[1]: Entering directory '/workspaces/ngrok-operator'
2025-12-05 01:14:29.834Z: bash: line 1: go: command not found
2025-12-05 01:14:29.910Z: mkdir -p /workspaces/ngrok-operator/bin
2025-12-05 01:14:29.913Z: bash: line 1: go: command not found
2025-12-05 01:14:29.926Z: bash: line 1: go: command not found
2025-12-05 01:14:29.927Z: Downloading sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
2025-12-05 01:14:29.928Z: bash: line 1: go: command not found
2025-12-05 01:14:29.929Z: make[1]: *** [tools/make/tools.mk:29: /workspaces/ngrok-operator/bin/controller-gen-v0.14.0] Error 127
make[1]: Leaving directory '/workspaces/ngrok-operator'
2025-12-05 01:14:29.930Z: make: *** [Makefile:23: _run] Error 2
2025-12-05 01:14:29.945Z: postCreateCommand from devcontainer.json failed with exit code 2. Skipping any further user-provided commands.

2025-12-05 01:14:29.955Z: Error: Command failed: /bin/sh -c .devcontainer/post-create.sh
2025-12-05 01:14:29.977Z:     at E (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:235:157)
2025-12-05 01:14:29.977Z:     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2025-12-05 01:14:29.977Z:     at async Promise.allSettled (index 0)
2025-12-05 01:14:29.977Z:     at async b9 (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:237:119)
2025-12-05 01:14:29.977Z:     at async ND (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:226:4668)
2025-12-05 01:14:29.977Z:     at async RD (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:226:4013)
2025-12-05 01:14:29.977Z:     at async MD (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:226:3217)
2025-12-05 01:14:29.977Z:     at async Zg (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:226:2623)
2025-12-05 01:14:29.977Z:     at async m6 (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:467:1526)
2025-12-05 01:14:29.978Z: {"outcome":"error","message":"Command failed: /bin/sh -c .devcontainer/post-create.sh","description":"postCreateCommand from devcontainer.json failed.","containerId":"3a9ebb025e568a1fe72fd5e87d46cad83bdea55f136f8e62b2bb67b80cae1386"}
2025-12-05 01:14:29.978Z:     at async ax (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:467:960)
2025-12-05 01:14:29.978Z: devcontainer process exited with exit code 1
```

Which causes a bunch of downstream setup failures. 

## How

This sets up a sleep to wait for nix to respond correctly before proceeding. To test i've  been launching a codespace off main and off this branch and when i open my iterm ssh with it i check if my alias for `k` kubectl works. 

main

```
❯ k get pods
kubectl not found in PATH
❯ kubectl get pods
zsh: command not found: kubectl
```

this branch

```
❯ k get pods
No resources found in default namespace.
```

I'm guessing this might be related to me using the smallest instance type

## Breaking Changes
*Are there any breaking changes in this PR?*
