### PR TITLE
feat(helm): Allow multiple versions of the operator to be installed

### DIFF
--- a/helm/ngrok-operator/templates/controller-rbac.yaml
+++ b/helm/ngrok-operator/templates/controller-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: ngrok-operator-leader-election-role
+  name: {{ include "ngrok-operator.fullname" . }}-leader-election-role
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
@@ -40,7 +40,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ngrok-operator-proxy-role
+  name: {{ include "ngrok-operator.fullname" . }}-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -58,12 +58,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ngrok-operator-leader-election-rolebinding
+  name: {{ include "ngrok-operator.fullname" . }}-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: ngrok-operator-leader-election-role
+  name: {{ include "ngrok-operator.fullname" . }}-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: {{ template "ngrok-operator.serviceAccountName" . }}
@@ -72,11 +72,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ngrok-operator-manager-rolebinding
+  name: {{ include "ngrok-operator.fullname" . }}-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ngrok-operator-manager-role
+  name: {{ include "ngrok-operator.fullname" . }}-manager-role
 subjects:
 - kind: ServiceAccount
   name: {{ template "ngrok-operator.serviceAccountName" . }}
@@ -85,11 +85,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ngrok-operator-proxy-rolebinding
+  name: {{ include "ngrok-operator.fullname" . }}-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ngrok-operator-proxy-role
+  name: {{ include "ngrok-operator.fullname" . }}-proxy-role
 subjects:
 - kind: ServiceAccount
   name: {{ template "ngrok-operator.serviceAccountName" . }}

--- a/helm/ngrok-operator/templates/rbac/role.yaml
+++ b/helm/ngrok-operator/templates/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ngrok-operator-manager-role
+  name: '{{ include "ngrok-operator.fullname" . }}-manager-role'
 rules:
 - apiGroups:
   - ""

--- a/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -4,8 +4,8 @@ Should match all-options snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/controller-role: 296ecdbfe53f088211eff0c550f02d0b5e3e5c36722a2f3b3fb0d22e9ed89209
-        checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
+        checksum/controller-role: 8f200b2fa2211fba423622bd81f8205070b07b45812490f0c53ec9f5f824f6a5
+        checksum/rbac: d9cc65d2f7cff9b5157369f970cf16bc88fb14df6802d580e5cb7ef57b569bcd
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: RELEASE-NAME
@@ -26,8 +26,8 @@ Should match all-options snapshot:
       template:
         metadata:
           annotations:
-            checksum/controller-role: 296ecdbfe53f088211eff0c550f02d0b5e3e5c36722a2f3b3fb0d22e9ed89209
-            checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
+            checksum/controller-role: 8f200b2fa2211fba423622bd81f8205070b07b45812490f0c53ec9f5f824f6a5
+            checksum/rbac: d9cc65d2f7cff9b5157369f970cf16bc88fb14df6802d580e5cb7ef57b569bcd
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
             prometheus.io/path: /metrics
             prometheus.io/port: "8080"
@@ -121,7 +121,7 @@ Should match all-options snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      name: ngrok-operator-leader-election-role
+      name: RELEASE-NAME-ngrok-operator-leader-election-role
       namespace: NAMESPACE
     rules:
       - apiGroups:
@@ -159,7 +159,7 @@ Should match all-options snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
-      name: ngrok-operator-proxy-role
+      name: RELEASE-NAME-ngrok-operator-proxy-role
     rules:
       - apiGroups:
           - authentication.k8s.io
@@ -177,12 +177,12 @@ Should match all-options snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      name: ngrok-operator-leader-election-rolebinding
+      name: RELEASE-NAME-ngrok-operator-leader-election-rolebinding
       namespace: NAMESPACE
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
-      name: ngrok-operator-leader-election-role
+      name: RELEASE-NAME-ngrok-operator-leader-election-role
     subjects:
       - kind: ServiceAccount
         name: RELEASE-NAME-ngrok-operator
@@ -191,11 +191,11 @@ Should match all-options snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
-      name: ngrok-operator-manager-rolebinding
+      name: RELEASE-NAME-ngrok-operator-manager-rolebinding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: ngrok-operator-manager-role
+      name: RELEASE-NAME-ngrok-operator-manager-role
     subjects:
       - kind: ServiceAccount
         name: RELEASE-NAME-ngrok-operator
@@ -204,11 +204,11 @@ Should match all-options snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
-      name: ngrok-operator-proxy-rolebinding
+      name: RELEASE-NAME-ngrok-operator-proxy-rolebinding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: ngrok-operator-proxy-role
+      name: RELEASE-NAME-ngrok-operator-proxy-role
     subjects:
       - kind: ServiceAccount
         name: RELEASE-NAME-ngrok-operator
@@ -217,7 +217,7 @@ Should match all-options snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
-      name: ngrok-operator-manager-role
+      name: RELEASE-NAME-ngrok-operator-manager-role
     rules:
       - apiGroups:
           - ""
@@ -421,8 +421,8 @@ Should match default snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/controller-role: 296ecdbfe53f088211eff0c550f02d0b5e3e5c36722a2f3b3fb0d22e9ed89209
-        checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
+        checksum/controller-role: 8f200b2fa2211fba423622bd81f8205070b07b45812490f0c53ec9f5f824f6a5
+        checksum/rbac: d9cc65d2f7cff9b5157369f970cf16bc88fb14df6802d580e5cb7ef57b569bcd
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: RELEASE-NAME
@@ -443,8 +443,8 @@ Should match default snapshot:
       template:
         metadata:
           annotations:
-            checksum/controller-role: 296ecdbfe53f088211eff0c550f02d0b5e3e5c36722a2f3b3fb0d22e9ed89209
-            checksum/rbac: 5d27f1783f54a2ab8e69f9bfce35eef2348fda3f6455526619973781d9549322
+            checksum/controller-role: 8f200b2fa2211fba423622bd81f8205070b07b45812490f0c53ec9f5f824f6a5
+            checksum/rbac: d9cc65d2f7cff9b5157369f970cf16bc88fb14df6802d580e5cb7ef57b569bcd
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
             prometheus.io/path: /metrics
             prometheus.io/port: "8080"
@@ -525,7 +525,7 @@ Should match default snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      name: ngrok-operator-leader-election-role
+      name: RELEASE-NAME-ngrok-operator-leader-election-role
       namespace: NAMESPACE
     rules:
       - apiGroups:
@@ -563,7 +563,7 @@ Should match default snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
-      name: ngrok-operator-proxy-role
+      name: RELEASE-NAME-ngrok-operator-proxy-role
     rules:
       - apiGroups:
           - authentication.k8s.io
@@ -581,12 +581,12 @@ Should match default snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      name: ngrok-operator-leader-election-rolebinding
+      name: RELEASE-NAME-ngrok-operator-leader-election-rolebinding
       namespace: NAMESPACE
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
-      name: ngrok-operator-leader-election-role
+      name: RELEASE-NAME-ngrok-operator-leader-election-role
     subjects:
       - kind: ServiceAccount
         name: RELEASE-NAME-ngrok-operator
@@ -595,11 +595,11 @@ Should match default snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
-      name: ngrok-operator-manager-rolebinding
+      name: RELEASE-NAME-ngrok-operator-manager-rolebinding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: ngrok-operator-manager-role
+      name: RELEASE-NAME-ngrok-operator-manager-role
     subjects:
       - kind: ServiceAccount
         name: RELEASE-NAME-ngrok-operator
@@ -608,11 +608,11 @@ Should match default snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
-      name: ngrok-operator-proxy-rolebinding
+      name: RELEASE-NAME-ngrok-operator-proxy-rolebinding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: ngrok-operator-proxy-role
+      name: RELEASE-NAME-ngrok-operator-proxy-role
     subjects:
       - kind: ServiceAccount
         name: RELEASE-NAME-ngrok-operator
@@ -621,7 +621,7 @@ Should match default snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
-      name: ngrok-operator-manager-role
+      name: RELEASE-NAME-ngrok-operator-manager-role
     rules:
       - apiGroups:
           - ""

--- a/helm/ngrok-operator/tests/__snapshot__/controller-rbac_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/controller-rbac_test.yaml.snap
@@ -3,7 +3,7 @@ Should match snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      name: ngrok-operator-leader-election-role
+      name: RELEASE-NAME-ngrok-operator-leader-election-role
       namespace: NAMESPACE
     rules:
       - apiGroups:
@@ -41,7 +41,7 @@ Should match snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
-      name: ngrok-operator-proxy-role
+      name: RELEASE-NAME-ngrok-operator-proxy-role
     rules:
       - apiGroups:
           - authentication.k8s.io
@@ -59,12 +59,12 @@ Should match snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      name: ngrok-operator-leader-election-rolebinding
+      name: RELEASE-NAME-ngrok-operator-leader-election-rolebinding
       namespace: NAMESPACE
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
-      name: ngrok-operator-leader-election-role
+      name: RELEASE-NAME-ngrok-operator-leader-election-role
     subjects:
       - kind: ServiceAccount
         name: RELEASE-NAME-ngrok-operator
@@ -73,11 +73,11 @@ Should match snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
-      name: ngrok-operator-manager-rolebinding
+      name: RELEASE-NAME-ngrok-operator-manager-rolebinding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: ngrok-operator-manager-role
+      name: RELEASE-NAME-ngrok-operator-manager-role
     subjects:
       - kind: ServiceAccount
         name: RELEASE-NAME-ngrok-operator
@@ -86,11 +86,11 @@ Should match snapshot:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
-      name: ngrok-operator-proxy-rolebinding
+      name: RELEASE-NAME-ngrok-operator-proxy-rolebinding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: ngrok-operator-proxy-role
+      name: RELEASE-NAME-ngrok-operator-proxy-role
     subjects:
       - kind: ServiceAccount
         name: RELEASE-NAME-ngrok-operator

--- a/tools/make/deploy.mk
+++ b/tools/make/deploy.mk
@@ -63,7 +63,7 @@ deploy_with_bindings: _deploy-check-env-vars docker-build manifests _helm_setup 
 		$(HELM_DESCRIPTION_FLAG)
 
 .PHONY: deploy_for_e2e
-deploy_for_e2e: _deploy-check-env-vars docker-build manifests _helm_setup kind-load-image ## Deploy controller to the K8s cluster specified in ~/.kube.config.
+deploy_for_e2e: _deploy-check-env-vars docker-build manifests _helm_setup kind-load-image ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	helm upgrade $(HELM_RELEASE_NAME) $(HELM_CHART_DIR) --install \
 		--namespace $(KUBE_NAMESPACE) \
 		--create-namespace \
@@ -85,7 +85,52 @@ deploy_for_e2e: _deploy-check-env-vars docker-build manifests _helm_setup kind-l
 		--set bindings.serviceLabels.label1="val1"
 
 .PHONY: deploy_multi_namespace
+## 1. We want to install the CRDs only once at the beginning
+## 2. We want to make a namespace-a and namespace-b
+## 3. We want to install the helm chart twice, watching only the namespace belonging to each one
 deploy_multi_namespace: _deploy-check-env-vars docker-build manifests _helm_setup kind-load-image ## Deploy multiple copies of the controller to the K8s cluster specified in ~/.kube/config.
+	helm upgrade ngrok-operator-crds $(CRD_CHART_DIR) --install \
+		--kube-context=kind-$(KIND_CLUSTER_NAME) \
+	    --namespace kube-system \
+		--create-namespace
+
+	helm upgrade ngrok-operator-a $(HELM_CHART_DIR) --install \
+		--kube-context=kind-$(KIND_CLUSTER_NAME) \
+		--namespace namespace-a \
+		--create-namespace \
+		--set installCRDs=false \
+		--set image.repository=$(IMG) \
+		--set image.tag="latest" \
+		--set ingress.controllerName="k8s.ngrok.com/ingress-controller-a" \
+		--set ingress.ingressClass.name="ngrok-a" \
+		--set ingress.watchNamespace="namespace-a" \
+		--set watchNamespace=namespace-a \
+		--set credentials.apiKey=$(NGROK_API_KEY) \
+		--set credentials.authtoken=$(NGROK_AUTHTOKEN) \
+		--set log.format=console \
+		--set-string log.level="8" \
+		--set log.stacktraceLevel=panic \
+		--set metaData.env=local,metaData.from=makefile \
+		$(HELM_DESCRIPTION_FLAG)
+
+	helm upgrade ngrok-operator-b $(HELM_CHART_DIR) --install \
+		--kube-context=kind-$(KIND_CLUSTER_NAME) \
+		--namespace namespace-b \
+		--create-namespace \
+		--set installCRDs=false \
+		--set ingress.controllerName="k8s.ngrok.com/ingress-controller-b" \
+		--set ingress.ingressClass.name="ngrok-b" \
+		--set ingress.watchNamespace="namespace-b" \
+		--set image.repository=$(IMG) \
+		--set image.tag="latest" \
+		--set watchNamespace=namespace-b \
+		--set credentials.apiKey=$(NGROK_API_KEY) \
+		--set credentials.authtoken=$(NGROK_AUTHTOKEN) \
+		--set log.format=console \
+		--set-string log.level="8" \
+		--set log.stacktraceLevel=panic \
+		--set metaData.env=local,metaData.from=makefile \
+		$(HELM_DESCRIPTION_FLAG)
 
 .PHONY: kind-load-image
 kind-load-image: ## Load the locally built image into the kind cluster.

--- a/tools/make/generate.mk
+++ b/tools/make/generate.mk
@@ -10,7 +10,7 @@ generate-mocks:
 
 .PHONY: manifests
 manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	controller-gen rbac:roleName=ngrok-operator-manager-role crd webhook paths="$(CONTROLLER_GEN_PATHS)" \
+	controller-gen rbac:roleName='"{{ include \"ngrok-operator.fullname\" . }}-manager-role"' crd webhook paths="$(CONTROLLER_GEN_PATHS)" \
 		output:crd:artifacts:config=$(CRD_TEMPLATES_DIR) \
 		output:rbac:artifacts:config=$(HELM_TEMPLATES_DIR)/rbac
 


### PR DESCRIPTION
## What

We've broken out the CRDs into their own chart. With that work, this allows multiple versions of the ngrok-operator to be installed in the same cluster by first installing the CRDs and then installing the ngrok-operator chart twice with `installCRDs: false` for both the the helm installs.

## How

A few of the RBAC resources did not include the release name. This fixes it so that the `Role`s, `RoleBinding`s, `ClusterRole`s, and `ClusterRoleBinding`s have the release name included.

I've tested this by using the new make command: `make deploy_multi_namespace`. The eventual goal(not in this PR) is to have this path tested in CI as well.

## Breaking Changes
No.
