### PR TITLE
Add pods to bindings forwarder manager cache and new field indexer for IP-based pod lookup

### DIFF
--- a/cmd/bindings-forwarder-manager.go
+++ b/cmd/bindings-forwarder-manager.go
@@ -32,12 +32,10 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/spf13/cobra"
-	v1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -113,9 +111,6 @@ func runController(_ context.Context, opts bindingsForwarderManagerOpts) error {
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
 				opts.namespace: {},
-			},
-			ByObject: map[client.Object]cache.ByObject{
-				&v1.Pod{}: {},
 			},
 		},
 		Metrics: server.Options{

--- a/internal/controller/bindings/forwarder_controller_test.go
+++ b/internal/controller/bindings/forwarder_controller_test.go
@@ -1,7 +1,6 @@
 package bindings
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -10,11 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
-	"github.com/ngrok/ngrok-operator/pkg/bindingsdriver"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
@@ -61,59 +58,28 @@ var _ = Describe("ForwarderReconciler field indexer integration", func() {
 	const ip = "10.2.2.2"
 
 	It("registers the pod IP field indexer in SetupWithManager and lists pods by IP", func() {
-		if cfg == nil {
-			Skip("envtest cfg not available; skipping integration-style test")
-		}
-
-		// Create a dedicated manager for this test so we can register the indexer
-		// before the cache starts and avoid interference from the package manager.
-		mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: k8sManager.GetScheme()})
-		Expect(err).ToNot(HaveOccurred())
-
-		fr := &ForwarderReconciler{
-			Client:                 mgr.GetClient(),
-			Log:                    logr.Discard(),
-			Scheme:                 mgr.GetScheme(),
-			Recorder:               mgr.GetEventRecorderFor("bindings-forwarder-controller-test"),
-			BindingsDriver:         bindingsdriver.New(),
-			KubernetesOperatorName: "test-op",
-		}
-		Expect(fr.SetupWithManager(mgr)).To(Succeed())
-
-		// start the manager
-		ctx2, cancel2 := context.WithCancel(context.Background())
-		defer cancel2()
-		go func() { _ = mgr.Start(ctx2) }()
-
-		// wait for cache to sync
-		Eventually(func() bool {
-			cctx, ccancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-			defer ccancel()
-			return mgr.GetCache().WaitForCacheSync(cctx)
-		}, 10*time.Second, 100*time.Millisecond).Should(BeTrue())
-
 		// create namespace and pod via mgr client so the manager's cache can observe them
-		ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace-" + rand.String(6)}}
-		Expect(mgr.GetClient().Create(ctx, ns)).To(Succeed())
+		ns := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-namespace-" + rand.String(6)},
+		}
+		Expect(k8sManager.GetClient().Create(ctx, ns)).To(Succeed())
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pod-" + rand.String(6), Namespace: ns.Name},
 			Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "test-container", Image: "nginx"}}},
 		}
-		Expect(mgr.GetClient().Create(ctx, pod)).To(Succeed())
+		Expect(k8sManager.GetClient().Create(ctx, pod)).To(Succeed())
 
-		// set Pod status explicitly so the field indexer (which indexes pod.Status.PodIP)
-		// can observe the IP.
-		got := &v1.Pod{}
-		// Use API reader to avoid cached client NotFound races immediately after Create
-		Expect(mgr.GetAPIReader().Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: pod.Name}, got)).To(Succeed())
-		got.Status = v1.PodStatus{PodIP: ip}
-		Expect(mgr.GetClient().Status().Update(ctx, got)).To(Succeed())
+		// set Pod status explicitly so the field indexer (which indexes pod.Status.PodIP) can observe the IP.
+		podRetrieved := &v1.Pod{}
+		Expect(k8sManager.GetAPIReader().Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: pod.Name}, podRetrieved)).To(Succeed())
+		podRetrieved.Status = v1.PodStatus{PodIP: ip}
+		Expect(k8sManager.GetClient().Status().Update(ctx, podRetrieved)).To(Succeed())
 
 		// Wait until the manager cache/indexer exposes the pod via the field index
 		Eventually(func() bool {
 			list := &v1.PodList{}
-			if err := mgr.GetClient().List(ctx, list, client.MatchingFields{"status.podIP": ip}); err != nil {
+			if err := k8sManager.GetClient().List(ctx, list, client.MatchingFields{"status.podIP": ip}); err != nil {
 				return false
 			}
 			return len(list.Items) > 0 && list.Items[0].Status.PodIP == ip

--- a/internal/controller/bindings/suite_test.go
+++ b/internal/controller/bindings/suite_test.go
@@ -35,6 +35,7 @@ import (
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/mocks/nmockapi"
 	"github.com/ngrok/ngrok-operator/internal/testutils"
+	"github.com/ngrok/ngrok-operator/pkg/bindingsdriver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -136,6 +137,18 @@ var _ = BeforeSuite(func() {
 		ClusterDomain: "cluster.local",
 	}
 	err = controllerReconciler.SetupWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Setup Forwarder controller
+	forwarderReconciler := &ForwarderReconciler{
+		Client:                 k8sManager.GetClient(),
+		Scheme:                 k8sManager.GetScheme(),
+		Log:                    logf.Log.WithName("forwarder-controller"),
+		Recorder:               k8sManager.GetEventRecorderFor("forwarder-controller"),
+		BindingsDriver:         bindingsdriver.New(),
+		KubernetesOperatorName: "test-op",
+	}
+	err = forwarderReconciler.SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Setup BoundEndpoint poller with very long interval (we'll trigger manually)


### PR DESCRIPTION


<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
[Project](https://linear.app/ngrok/project/traffic-policy-add-connclient-ipk8s-variable-ca8debff2918/overview): Traffic Policy - Add `conn.client_ip.k8s` variables
Milestone 1: Pod Identity Cache

## How
- Use built-in cache in controller-runtime manager kubernetes client for saving pods
- Add field indexer for IP-based policy lookup to use in the future

## Breaking Changes

