### PR TITLE
Updating proto to match ngrok-private, adding PodIdentity

### DIFF
--- a/internal/controller/bindings/forwarder_controller.go
+++ b/internal/controller/bindings/forwarder_controller.go
@@ -217,7 +217,7 @@ func (r *ForwarderReconciler) update(ctx context.Context, epb *bindingsv1alpha1.
 
 		// Upgrade the connection to a binding connection
 		resp, err := mux.UpgradeToBindingConnection(log, ngrokConn, host, port)
-		log = log.WithValues("endpoint.id", resp.EndpointID, "proto", resp.Proto)
+		log = log.WithValues("endpoint.id", resp.EndpointId, "proto", resp.Proto)
 		if err != nil {
 			log.Error(err, "failed to upgrade connection")
 			return err

--- a/internal/pb_agent/conn_header.pb.go
+++ b/internal/pb_agent/conn_header.pb.go
@@ -3,11 +3,11 @@
 package pb_agent
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -18,21 +18,19 @@ const (
 )
 
 type ConnRequest struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Port          int64                  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	PodIdentity   *PodIdentity           `protobuf:"bytes,3,opt,name=pod_identity,json=podIdentity,proto3" json:"pod_identity,omitempty"`
 	unknownFields protoimpl.UnknownFields
-
-	Host string `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
-	Port int64  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ConnRequest) Reset() {
 	*x = ConnRequest{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_agent_conn_header_proto_msgTypes[0]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
+	mi := &file_agent_conn_header_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
 }
 
 func (x *ConnRequest) String() string {
@@ -43,7 +41,7 @@ func (*ConnRequest) ProtoMessage() {}
 
 func (x *ConnRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_agent_conn_header_proto_msgTypes[0]
-	if protoimpl.UnsafeEnabled && x != nil {
+	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
 			ms.StoreMessageInfo(mi)
@@ -72,26 +70,106 @@ func (x *ConnRequest) GetPort() int64 {
 	return 0
 }
 
-type ConnResponse struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
-	unknownFields protoimpl.UnknownFields
+func (x *ConnRequest) GetPodIdentity() *PodIdentity {
+	if x != nil {
+		return x.PodIdentity
+	}
+	return nil
+}
 
+type PodIdentity struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Uid           string                 `protobuf:"bytes,1,opt,name=uid,proto3" json:"uid,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace     string                 `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Labels        map[string]string      `protobuf:"bytes,4,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Annotations   map[string]string      `protobuf:"bytes,5,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PodIdentity) Reset() {
+	*x = PodIdentity{}
+	mi := &file_agent_conn_header_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PodIdentity) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PodIdentity) ProtoMessage() {}
+
+func (x *PodIdentity) ProtoReflect() protoreflect.Message {
+	mi := &file_agent_conn_header_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PodIdentity.ProtoReflect.Descriptor instead.
+func (*PodIdentity) Descriptor() ([]byte, []int) {
+	return file_agent_conn_header_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *PodIdentity) GetUid() string {
+	if x != nil {
+		return x.Uid
+	}
+	return ""
+}
+
+func (x *PodIdentity) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *PodIdentity) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *PodIdentity) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
+func (x *PodIdentity) GetAnnotations() map[string]string {
+	if x != nil {
+		return x.Annotations
+	}
+	return nil
+}
+
+type ConnResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
 	// only set on success
-	EndpointID string `protobuf:"bytes,1,opt,name=endpoint_id,json=endpointId,proto3" json:"endpoint_id,omitempty"`
+	EndpointId string `protobuf:"bytes,1,opt,name=endpoint_id,json=endpointId,proto3" json:"endpoint_id,omitempty"`
 	Proto      string `protobuf:"bytes,2,opt,name=proto,proto3" json:"proto,omitempty"`
 	// only set on error
-	ErrorCode    string `protobuf:"bytes,3,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"`
-	ErrorMessage string `protobuf:"bytes,4,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	ErrorCode     string `protobuf:"bytes,3,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"`
+	ErrorMessage  string `protobuf:"bytes,4,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ConnResponse) Reset() {
 	*x = ConnResponse{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_agent_conn_header_proto_msgTypes[1]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
+	mi := &file_agent_conn_header_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
 }
 
 func (x *ConnResponse) String() string {
@@ -101,8 +179,8 @@ func (x *ConnResponse) String() string {
 func (*ConnResponse) ProtoMessage() {}
 
 func (x *ConnResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_conn_header_proto_msgTypes[1]
-	if protoimpl.UnsafeEnabled && x != nil {
+	mi := &file_agent_conn_header_proto_msgTypes[2]
+	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
 			ms.StoreMessageInfo(mi)
@@ -114,12 +192,12 @@ func (x *ConnResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnResponse.ProtoReflect.Descriptor instead.
 func (*ConnResponse) Descriptor() ([]byte, []int) {
-	return file_agent_conn_header_proto_rawDescGZIP(), []int{1}
+	return file_agent_conn_header_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *ConnResponse) GetEndpointID() string {
+func (x *ConnResponse) GetEndpointId() string {
 	if x != nil {
-		return x.EndpointID
+		return x.EndpointId
 	}
 	return ""
 }
@@ -147,49 +225,62 @@ func (x *ConnResponse) GetErrorMessage() string {
 
 var File_agent_conn_header_proto protoreflect.FileDescriptor
 
-var file_agent_conn_header_proto_rawDesc = []byte{
-	0x0a, 0x17, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x2f, 0x63, 0x6f, 0x6e, 0x6e, 0x5f, 0x68, 0x65, 0x61,
-	0x64, 0x65, 0x72, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x05, 0x61, 0x67, 0x65, 0x6e, 0x74,
-	0x22, 0x35, 0x0a, 0x0b, 0x43, 0x6f, 0x6e, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12,
-	0x12, 0x0a, 0x04, 0x68, 0x6f, 0x73, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x68,
-	0x6f, 0x73, 0x74, 0x12, 0x12, 0x0a, 0x04, 0x70, 0x6f, 0x72, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28,
-	0x03, 0x52, 0x04, 0x70, 0x6f, 0x72, 0x74, 0x22, 0x89, 0x01, 0x0a, 0x0c, 0x43, 0x6f, 0x6e, 0x6e,
-	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x65, 0x6e, 0x64, 0x70,
-	0x6f, 0x69, 0x6e, 0x74, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x65,
-	0x6e, 0x64, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x49, 0x64, 0x12, 0x14, 0x0a, 0x05, 0x70, 0x72, 0x6f,
-	0x74, 0x6f, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12,
-	0x1d, 0x0a, 0x0a, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x63, 0x6f, 0x64, 0x65, 0x18, 0x03, 0x20,
-	0x01, 0x28, 0x09, 0x52, 0x09, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x43, 0x6f, 0x64, 0x65, 0x12, 0x23,
-	0x0a, 0x0d, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x18,
-	0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0c, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x4d, 0x65, 0x73, 0x73,
-	0x61, 0x67, 0x65, 0x42, 0x1b, 0x5a, 0x19, 0x67, 0x6f, 0x2e, 0x6e, 0x67, 0x72, 0x6f, 0x6b, 0x2e,
-	0x63, 0x6f, 0x6d, 0x2f, 0x6c, 0x69, 0x62, 0x2f, 0x70, 0x62, 0x5f, 0x61, 0x67, 0x65, 0x6e, 0x74,
-	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
-}
+const file_agent_conn_header_proto_rawDesc = "" +
+	"\n" +
+	"\x17agent/conn_header.proto\x12\x05agent\"l\n" +
+	"\vConnRequest\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\x03R\x04port\x125\n" +
+	"\fpod_identity\x18\x03 \x01(\v2\x12.agent.PodIdentityR\vpodIdentity\"\xcb\x02\n" +
+	"\vPodIdentity\x12\x10\n" +
+	"\x03uid\x18\x01 \x01(\tR\x03uid\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1c\n" +
+	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x126\n" +
+	"\x06labels\x18\x04 \x03(\v2\x1e.agent.PodIdentity.LabelsEntryR\x06labels\x12E\n" +
+	"\vannotations\x18\x05 \x03(\v2#.agent.PodIdentity.AnnotationsEntryR\vannotations\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
+	"\x10AnnotationsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x89\x01\n" +
+	"\fConnResponse\x12\x1f\n" +
+	"\vendpoint_id\x18\x01 \x01(\tR\n" +
+	"endpointId\x12\x14\n" +
+	"\x05proto\x18\x02 \x01(\tR\x05proto\x12\x1d\n" +
+	"\n" +
+	"error_code\x18\x03 \x01(\tR\terrorCode\x12#\n" +
+	"\rerror_message\x18\x04 \x01(\tR\ferrorMessageB\x1bZ\x19go.ngrok.com/lib/pb_agentb\x06proto3"
 
 var (
 	file_agent_conn_header_proto_rawDescOnce sync.Once
-	file_agent_conn_header_proto_rawDescData = file_agent_conn_header_proto_rawDesc
+	file_agent_conn_header_proto_rawDescData []byte
 )
 
 func file_agent_conn_header_proto_rawDescGZIP() []byte {
 	file_agent_conn_header_proto_rawDescOnce.Do(func() {
-		file_agent_conn_header_proto_rawDescData = protoimpl.X.CompressGZIP(file_agent_conn_header_proto_rawDescData)
+		file_agent_conn_header_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_agent_conn_header_proto_rawDesc), len(file_agent_conn_header_proto_rawDesc)))
 	})
 	return file_agent_conn_header_proto_rawDescData
 }
 
-var file_agent_conn_header_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_agent_conn_header_proto_goTypes = []interface{}{
+var file_agent_conn_header_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_agent_conn_header_proto_goTypes = []any{
 	(*ConnRequest)(nil),  // 0: agent.ConnRequest
-	(*ConnResponse)(nil), // 1: agent.ConnResponse
+	(*PodIdentity)(nil),  // 1: agent.PodIdentity
+	(*ConnResponse)(nil), // 2: agent.ConnResponse
+	nil,                  // 3: agent.PodIdentity.LabelsEntry
+	nil,                  // 4: agent.PodIdentity.AnnotationsEntry
 }
 var file_agent_conn_header_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	1, // 0: agent.ConnRequest.pod_identity:type_name -> agent.PodIdentity
+	3, // 1: agent.PodIdentity.labels:type_name -> agent.PodIdentity.LabelsEntry
+	4, // 2: agent.PodIdentity.annotations:type_name -> agent.PodIdentity.AnnotationsEntry
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_agent_conn_header_proto_init() }
@@ -197,39 +288,13 @@ func file_agent_conn_header_proto_init() {
 	if File_agent_conn_header_proto != nil {
 		return
 	}
-	if !protoimpl.UnsafeEnabled {
-		file_agent_conn_header_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} { //nolint:staticcheck
-			switch v := v.(*ConnRequest); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_agent_conn_header_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} { //nolint:staticcheck
-			switch v := v.(*ConnResponse); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: file_agent_conn_header_proto_rawDesc,
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agent_conn_header_proto_rawDesc), len(file_agent_conn_header_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
@@ -238,7 +303,6 @@ func file_agent_conn_header_proto_init() {
 		MessageInfos:      file_agent_conn_header_proto_msgTypes,
 	}.Build()
 	File_agent_conn_header_proto = out.File
-	file_agent_conn_header_proto_rawDesc = nil
 	file_agent_conn_header_proto_goTypes = nil
 	file_agent_conn_header_proto_depIdxs = nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
#K8SOP-202

## What
Project: Traffic Policy - Add `conn.client_id.k8s` variables
Milestone 2: Extend Proto

- Updating proto to match `ngrok-private` which adds PodIdentity: [link](https://github.com/ngrok-private/ngrok/blob/main/go/lib/pb_agent/conn_header.pb.go)

## How
- Copy and paste file from `ngrok-private`
- Updated use of `EndpointID` to `EndpointId` because that was changed in proto

## Breaking Changes

