### PR TITLE
fix: correct namespace comparison in secretReferencedByGateway

### DIFF
--- a/internal/controller/gateway/gateway_controller.go
+++ b/internal/controller/gateway/gateway_controller.go
@@ -471,7 +471,7 @@ func secretReferencedByGateway(secret *v1.Secret, c client.Client) bool {
 					certRef.Namespace = &certNs
 				}
 				if string(certRef.Name) == secret.Name &&
-					string(*certRef.Namespace) == secret.Name &&
+					string(*certRef.Namespace) == secret.Namespace &&
 					secret.Type == v1.SecretTypeTLS {
 					return true
 				}


### PR DESCRIPTION
# What

Fix a bug in `secretReferencedByGateway` where TLS secrets referenced by Gateway listeners were not being correctly matched. The function was comparing `certRef.Namespace` to `secret.Name` instead of `secret.Namespace`, causing secret change events to not trigger Gateway reconciliation unless the secret's name happened to equal its namespace.

## How

Changed the comparison on line 474 from `secret.Name` to `secret.Namespace` to match the correct implementation used for `BackendTLS.ClientCertificateRef` on line 459. Added a test case to verify that `secretReferencedByGateway` correctly returns `true` when a TLS secret is referenced by a Gateway listener in the same namespace.

## Breaking Changes

No breaking changes. This is a bug fix that corrects existing behavior.
