### PR TITLE
Fix e2e tests to run on merge queue and fix the tests chart dep building

### DIFF
--- a/tools/make/test.mk
+++ b/tools/make/test.mk
@@ -53,7 +53,7 @@ UNINSTALL_NAMESPACE := uninstall-test
 SCENARIO ?= delete-policy-bundled-crds
 
 .PHONY: e2e-uninstall
-e2e-uninstall: ## Run uninstall e2e test. Usage: make e2e-uninstall SCENARIO=<scenario> [DEBUG=1]
+e2e-uninstall: _helm_setup ## Run uninstall e2e test. Usage: make e2e-uninstall SCENARIO=<scenario> [DEBUG=1]
 	chainsaw test $(UNINSTALL_TEST_DIR)/$(SCENARIO) \
 		--namespace $(UNINSTALL_NAMESPACE) \
 		--cleanup-timeout 2m \


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What

I noticed the e2e tests are not running in the merge queue 
<img width="892" height="737" alt="image" src="https://github.com/user-attachments/assets/616f5a87-5660-49d1-851d-ab883af85221" />
https://github.com/dorny/paths-filter/issues/280

The tests did run on main but failed with this

```
Error: An error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies: found in Chart.yaml, but missing in charts/ directory: common, ngrok-crds
```


## How

- add the merge_group event to CI 
- add a helm setup command

Reproduced the error locally be rm -rf my chart folder and saw the same error. 

## Breaking Changes
*Are there any breaking changes in this PR?*
