### PR TITLE
fix(domains): Don't reserve domains for TCP addressess

### DIFF
--- a/internal/domain/manager.go
+++ b/internal/domain/manager.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"slices"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -153,7 +152,7 @@ func (m *Manager) checkSkippedDomains(ctx context.Context, endpoint ngrokv1alpha
 	}
 
 	// Skip TCP ngrok URLs
-	if parsedURL.Scheme == "tcp" && strings.HasSuffix(parsedURL.Hostname(), "tcp.ngrok.io") {
+	if parsedURL.Scheme == "tcp" {
 		msg := "Domain ready (TCP ngrok URL - no domain reservation needed)"
 		m.setDomainCondition(endpoint, true, ReasonDomainReady, msg)
 		endpoint.SetDomainRef(nil)


### PR DESCRIPTION
## What

We noticed that when creating a LoadBalancer TCP service, it was trying to reserve a domain incorrectly. This will just lead to a Domain CR that errors.

## How
Update the domain manager to skip all urls that start with `tcp://`

## Breaking Changes
No, this is fixing a bug.
