### PR TITLE
Add description and metadata annotations to ingress and gateway

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -53,6 +53,20 @@ const (
 	//
 	URLAnnotation = "k8s.ngrok.com/url"
 	URLKey        = "url"
+
+	// MetadataAnnotation allows setting ngrok metadata on the endpoint created from this resource.
+	// The value must be a JSON object string, e.g. '{"env":"prod","team":"platform"}'.
+	// This metadata is merged with the operator-level default metadata; keys in this annotation take precedence.
+	// When multiple Ingress/HTTPRoute objects share the same endpoint, the metadata from the
+	// alphabetically-first resource (by namespace/name) takes precedence per key.
+	MetadataAnnotation = "k8s.ngrok.com/metadata"
+	MetadataKey        = "metadata"
+
+	// DescriptionAnnotation sets a human-readable description on the endpoint created from this resource.
+	// When multiple resources share the same endpoint, the description from the alphabetically-first
+	// resource (by namespace/name) is used; if none is set, the operator default is used.
+	DescriptionAnnotation = "k8s.ngrok.com/description"
+	DescriptionKey        = "description"
 )
 
 type MappingStrategy string
@@ -134,4 +148,30 @@ func ExtractURL(obj client.Object) (string, error) {
 // an error.
 func ExtractComputedURL(obj client.Object) (string, error) {
 	return parser.GetStringAnnotation(ComputedURLKey, obj)
+}
+
+// ExtractMetadata extracts the ngrok metadata JSON string from the annotation "k8s.ngrok.com/metadata".
+// Returns ("", nil) if the annotation is not set.
+func ExtractMetadata(obj client.Object) (string, error) {
+	val, err := parser.GetStringAnnotation(MetadataKey, obj)
+	if err != nil {
+		if errors.IsMissingAnnotations(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return val, nil
+}
+
+// ExtractDescription extracts the description string from the annotation "k8s.ngrok.com/description".
+// Returns ("", nil) if the annotation is not set.
+func ExtractDescription(obj client.Object) (string, error) {
+	val, err := parser.GetStringAnnotation(DescriptionKey, obj)
+	if err != nil {
+		if errors.IsMissingAnnotations(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return val, nil
 }

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -57,7 +57,7 @@ const (
 	// MetadataAnnotation allows setting ngrok metadata on the endpoint created from this resource.
 	// The value must be a JSON object string, e.g. '{"env":"prod","team":"platform"}'.
 	// This metadata is merged with the operator-level default metadata; keys in this annotation take precedence.
-	// When multiple Ingress/HTTPRoute objects share the same endpoint, the metadata from the
+	// When multiple annotated resources share the same endpoint, the metadata from the
 	// alphabetically-first resource (by namespace/name) takes precedence per key.
 	MetadataAnnotation = "k8s.ngrok.com/metadata"
 	MetadataKey        = "metadata"

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -221,3 +221,81 @@ func TestExtractUseBindings(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    string
+	}{
+		{
+			name:        "annotation not present returns empty string",
+			annotations: nil,
+			expected:    "",
+		},
+		{
+			name:        "valid JSON object",
+			annotations: map[string]string{"k8s.ngrok.com/metadata": `{"env":"prod","team":"platform"}`},
+			expected:    `{"env":"prod","team":"platform"}`,
+		},
+		{
+			name:        "non-JSON string is returned as-is (validation is caller's concern)",
+			annotations: map[string]string{"k8s.ngrok.com/metadata": "not-json"},
+			expected:    "not-json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-ingress",
+					Namespace:   "default",
+					Annotations: tc.annotations,
+				},
+			}
+			got, err := annotations.ExtractMetadata(obj)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestExtractDescription(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    string
+	}{
+		{
+			name:        "annotation not present returns empty string",
+			annotations: nil,
+			expected:    "",
+		},
+		{
+			name:        "description is returned unchanged",
+			annotations: map[string]string{"k8s.ngrok.com/description": "My production service"},
+			expected:    "My production service",
+		},
+		{
+			name:        "multi-word description",
+			annotations: map[string]string{"k8s.ngrok.com/description": "My production service v2"},
+			expected:    "My production service v2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-ingress",
+					Namespace:   "default",
+					Annotations: tc.annotations,
+				},
+			}
+			got, err := annotations.ExtractDescription(obj)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -3,6 +3,7 @@ package ir
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -494,24 +495,22 @@ func MergeMetadata(base, override string) string {
 		return base
 	}
 
-	var b map[string]interface{}
+	var b map[string]any
 	if base != "" {
 		// Ignore parse errors — treat invalid base as empty object
 		_ = json.Unmarshal([]byte(base), &b)
 	}
 	if b == nil {
-		b = map[string]interface{}{}
+		b = map[string]any{}
 	}
 
-	var o map[string]interface{}
+	var o map[string]any
 	if err := json.Unmarshal([]byte(override), &o); err != nil {
 		// Override is not valid JSON; return base unchanged
 		return base
 	}
 
-	for k, v := range o {
-		b[k] = v
-	}
+	maps.Copy(b, o)
 
 	out, err := json.Marshal(b)
 	if err != nil {

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -95,7 +95,7 @@ type IRVirtualHost struct {
 	Metadata string
 
 	// Description to set on any created CloudEndpoints/AgentEndpoints.
-	// Sourced from the k8s.ngrok.com/description annotation on the resource; falls back to operator default.
+	// Sourced from the k8s.ngrok.com/description annotation on the resource.
 	Description string
 
 	// Bindings to set on generated Endpoints

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -1,6 +1,7 @@
 package ir
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
@@ -89,8 +90,13 @@ type IRVirtualHost struct {
 	// Currently only used for debug/error logs, but can be added to generated resource statuses
 	OwningResources []OwningResource
 
-	// Metadata to set on any created CloudEndpoints/AgentEndpoints
+	// Metadata to set on any created CloudEndpoints/AgentEndpoints.
+	// This is a JSON object string merged from the operator default and the resource annotation.
 	Metadata string
+
+	// Description to set on any created CloudEndpoints/AgentEndpoints.
+	// Sourced from the k8s.ngrok.com/description annotation on the resource; falls back to operator default.
+	Description string
 
 	// Bindings to set on generated Endpoints
 	Bindings []string
@@ -478,4 +484,38 @@ func (h *IRUpstream) AddOwningResource(new OwningResource) {
 		return
 	}
 	h.OwningResources = append(h.OwningResources, new)
+}
+
+// MergeMetadata merges two JSON object strings. Keys present in override take precedence over base.
+// If override is empty, base is returned unchanged.
+// If base is empty or invalid JSON, override is returned (or an empty object if both are invalid).
+func MergeMetadata(base, override string) string {
+	if override == "" {
+		return base
+	}
+
+	var b map[string]interface{}
+	if base != "" {
+		// Ignore parse errors — treat invalid base as empty object
+		_ = json.Unmarshal([]byte(base), &b)
+	}
+	if b == nil {
+		b = map[string]interface{}{}
+	}
+
+	var o map[string]interface{}
+	if err := json.Unmarshal([]byte(override), &o); err != nil {
+		// Override is not valid JSON; return base unchanged
+		return base
+	}
+
+	for k, v := range o {
+		b[k] = v
+	}
+
+	out, err := json.Marshal(b)
+	if err != nil {
+		return base
+	}
+	return string(out)
 }

--- a/internal/ir/ir_test.go
+++ b/internal/ir/ir_test.go
@@ -1,9 +1,11 @@
 package ir
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSortRoutes(t *testing.T) {
@@ -444,6 +446,74 @@ func TestAddOwningResource(t *testing.T) {
 			upstream := &IRUpstream{OwningResources: tc.initial}
 			upstream.AddOwningResource(tc.newResource)
 			assert.Equal(t, tc.expectedFinal, upstream.OwningResources, "unexpected result in test case: %s", tc.name)
+		})
+	}
+}
+
+func TestMergeMetadata(t *testing.T) {
+	testCases := []struct {
+		name     string
+		base     string
+		override string
+		wantKeys map[string]interface{} // expected keys in merged result
+		wantRaw  string                 // when we want exact raw equality (empty string cases)
+	}{
+		{
+			name:     "empty override returns base unchanged",
+			base:     `{"owned-by":"ngrok-operator"}`,
+			override: "",
+			wantKeys: map[string]interface{}{"owned-by": "ngrok-operator"},
+		},
+		{
+			name:     "empty base returns override",
+			base:     "",
+			override: `{"env":"prod"}`,
+			wantKeys: map[string]interface{}{"env": "prod"},
+		},
+		{
+			name:     "both empty returns empty string",
+			base:     "",
+			override: "",
+			wantRaw:  "",
+		},
+		{
+			name:     "override keys take precedence over base",
+			base:     `{"owned-by":"ngrok-operator","env":"dev"}`,
+			override: `{"env":"prod"}`,
+			wantKeys: map[string]interface{}{"owned-by": "ngrok-operator", "env": "prod"},
+		},
+		{
+			name:     "base and override are merged - no overlap",
+			base:     `{"owned-by":"ngrok-operator"}`,
+			override: `{"team":"platform","region":"us-east-1"}`,
+			wantKeys: map[string]interface{}{"owned-by": "ngrok-operator", "team": "platform", "region": "us-east-1"},
+		},
+		{
+			name:     "invalid override JSON returns base unchanged",
+			base:     `{"owned-by":"ngrok-operator"}`,
+			override: `not-valid-json`,
+			wantKeys: map[string]interface{}{"owned-by": "ngrok-operator"},
+		},
+		{
+			name:     "invalid base JSON is treated as empty object",
+			base:     `not-valid-json`,
+			override: `{"env":"prod"}`,
+			wantKeys: map[string]interface{}{"env": "prod"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := MergeMetadata(tc.base, tc.override)
+
+			if tc.wantRaw != "" || (tc.base == "" && tc.override == "") {
+				assert.Equal(t, tc.wantRaw, result)
+				return
+			}
+
+			var got map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(result), &got), "result should be valid JSON: %s", result)
+			assert.Equal(t, tc.wantKeys, got)
 		})
 	}
 }

--- a/internal/ir/ir_test.go
+++ b/internal/ir/ir_test.go
@@ -455,20 +455,20 @@ func TestMergeMetadata(t *testing.T) {
 		name     string
 		base     string
 		override string
-		wantKeys map[string]interface{} // expected keys in merged result
-		wantRaw  string                 // when we want exact raw equality (empty string cases)
+		wantKeys map[string]any // expected keys in merged result
+		wantRaw  string         // when we want exact raw equality (empty string cases)
 	}{
 		{
 			name:     "empty override returns base unchanged",
 			base:     `{"owned-by":"ngrok-operator"}`,
 			override: "",
-			wantKeys: map[string]interface{}{"owned-by": "ngrok-operator"},
+			wantKeys: map[string]any{"owned-by": "ngrok-operator"},
 		},
 		{
 			name:     "empty base returns override",
 			base:     "",
 			override: `{"env":"prod"}`,
-			wantKeys: map[string]interface{}{"env": "prod"},
+			wantKeys: map[string]any{"env": "prod"},
 		},
 		{
 			name:     "both empty returns empty string",
@@ -480,25 +480,25 @@ func TestMergeMetadata(t *testing.T) {
 			name:     "override keys take precedence over base",
 			base:     `{"owned-by":"ngrok-operator","env":"dev"}`,
 			override: `{"env":"prod"}`,
-			wantKeys: map[string]interface{}{"owned-by": "ngrok-operator", "env": "prod"},
+			wantKeys: map[string]any{"owned-by": "ngrok-operator", "env": "prod"},
 		},
 		{
 			name:     "base and override are merged - no overlap",
 			base:     `{"owned-by":"ngrok-operator"}`,
 			override: `{"team":"platform","region":"us-east-1"}`,
-			wantKeys: map[string]interface{}{"owned-by": "ngrok-operator", "team": "platform", "region": "us-east-1"},
+			wantKeys: map[string]any{"owned-by": "ngrok-operator", "team": "platform", "region": "us-east-1"},
 		},
 		{
 			name:     "invalid override JSON returns base unchanged",
 			base:     `{"owned-by":"ngrok-operator"}`,
 			override: `not-valid-json`,
-			wantKeys: map[string]interface{}{"owned-by": "ngrok-operator"},
+			wantKeys: map[string]any{"owned-by": "ngrok-operator"},
 		},
 		{
 			name:     "invalid base JSON is treated as empty object",
 			base:     `not-valid-json`,
 			override: `{"env":"prod"}`,
-			wantKeys: map[string]interface{}{"env": "prod"},
+			wantKeys: map[string]any{"env": "prod"},
 		},
 	}
 
@@ -511,7 +511,7 @@ func TestMergeMetadata(t *testing.T) {
 				return
 			}
 
-			var got map[string]interface{}
+			var got map[string]any
 			require.NoError(t, json.Unmarshal([]byte(result), &got), "result should be valid JSON: %s", result)
 			assert.Equal(t, tc.wantKeys, got)
 		})

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-metadata-description-annotations.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-metadata-description-annotations.yaml
@@ -1,0 +1,113 @@
+# Tests that k8s.ngrok.com/metadata and k8s.ngrok.com/description annotations on a Gateway
+# are propagated to the generated CloudEndpoint.
+# Uses endpoints-verbose strategy to always produce a CloudEndpoint.
+input:
+  gatewayClasses:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: GatewayClass
+    metadata:
+      name: ngrok
+    spec:
+      controllerName: ngrok.com/gateway-controller
+  gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: test-gateway
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+        k8s.ngrok.com/metadata: '{"team":"platform","env":"staging"}'
+        k8s.ngrok.com/description: "Platform staging gateway"
+    spec:
+      gatewayClassName: ngrok
+      listeners:
+        - name: test-hostname
+          hostname: "test-hostname.ngrok.io"
+          port: 443
+          protocol: HTTPS
+  httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: test-route
+      namespace: default
+    spec:
+      hostnames:
+      - test-hostname.ngrok.io
+      parentRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+      rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /app
+        backendRefs:
+          - group: ""
+            kind: Service
+            name: test-service-1
+            port: 8080
+            weight: 1
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: test-gateway.default-test-hostname.ngrok.io
+      namespace: default
+    spec:
+      url: "https://test-hostname.ngrok.io"
+      metadata: '{"env":"staging","team":"platform"}'
+      description: "Platform staging gateway"
+      trafficPolicy:
+        policy:
+          on_http_request:
+          - name: Generated-Route
+            expressions:
+            - "req.url.path.startsWith('/app')"
+            actions:
+            - type: forward-internal
+              config:
+                url: "https://e3b0c-test-service-1-default-8080.internal"
+          - name: Fallback-404
+            actions:
+            - type: custom-response
+              config:
+                status_code: 404
+                content: "No route was found for this ngrok Endpoint"
+                headers:
+                  content-type: text/plain
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-test-service-1-default-8080.internal"
+      metadata: '{"env":"staging","team":"platform"}'
+      description: "Platform staging gateway"
+      upstream:
+        url: "http://test-service-1.default:8080"

--- a/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations-conflict.yaml
@@ -1,0 +1,152 @@
+# Tests that when two Ingresses share the same hostname and have different k8s.ngrok.com/metadata
+# and k8s.ngrok.com/description annotations, the alphabetically-first resource (by namespace/name)
+# wins. Here ingress-aaa comes before ingress-bbb, so its annotations are used.
+# endpoints-verbose is set on both ingresses to ensure a CloudEndpoint is always produced,
+# making the expected output deterministic regardless of service iteration order.
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ingress-aaa
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+        k8s.ngrok.com/metadata: '{"owner":"team-a"}'
+        k8s.ngrok.com/description: "Team A description"
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: shared-host.ngrok.io
+          http:
+            paths:
+              - path: /a
+                pathType: Prefix
+                backend:
+                  service:
+                    name: service-a
+                    port:
+                      number: 8080
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ingress-bbb
+      namespace: default
+      annotations:
+        k8s.ngrok.com/mapping-strategy: "endpoints-verbose"
+        k8s.ngrok.com/metadata: '{"owner":"team-b"}'
+        k8s.ngrok.com/description: "Team B description"
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: shared-host.ngrok.io
+          http:
+            paths:
+              - path: /b
+                pathType: Prefix
+                backend:
+                  service:
+                    name: service-b
+                    port:
+                      number: 9090
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: service-a
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: service-b
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 9090
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies:
+expected:
+  cloudEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: CloudEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: shared-host.ngrok.io
+      namespace: default
+    spec:
+      url: "https://shared-host.ngrok.io"
+      metadata: '{"owner":"team-a"}'
+      description: "Team A description"
+      trafficPolicy:
+        policy:
+          on_http_request:
+          - name: Generated-Route
+            expressions:
+            - "req.url.path.startsWith('/a')"
+            actions:
+            - type: forward-internal
+              config:
+                url: "https://e3b0c-service-a-default-8080.internal"
+          - name: Generated-Route
+            expressions:
+            - "req.url.path.startsWith('/b')"
+            actions:
+            - type: forward-internal
+              config:
+                url: "https://e3b0c-service-b-default-9090.internal"
+          - name: Fallback-404
+            actions:
+            - type: custom-response
+              config:
+                status_code: 404
+                content: "No route was found for this ngrok Endpoint"
+                headers:
+                  content-type: text/plain
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-service-a-default-8080
+      namespace: default
+    spec:
+      url: "https://e3b0c-service-a-default-8080.internal"
+      metadata: '{"owner":"team-a"}'
+      description: "Team A description"
+      upstream:
+        url: "http://service-a.default:8080"
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-service-b-default-9090
+      namespace: default
+    spec:
+      url: "https://e3b0c-service-b-default-9090.internal"
+      metadata: '{"owner":"team-a"}'
+      description: "Team A description"
+      upstream:
+        url: "http://service-b.default:9090"

--- a/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations-default-backend.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations-default-backend.yaml
@@ -1,0 +1,105 @@
+# Tests that k8s.ngrok.com/metadata and k8s.ngrok.com/description annotations are propagated
+# to the generated AgentEndpoint when the upstream comes from a defaultBackend (not a rule path).
+# This exercises the buildAgentEndpoint call for the default-backend code path.
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: test-ingress
+      namespace: default
+      annotations:
+        k8s.ngrok.com/metadata: '{"env":"prod","team":"platform"}'
+        k8s.ngrok.com/description: "My production service"
+    spec:
+      ingressClassName: ngrok
+      defaultBackend:
+        service:
+          name: test-service-1
+          port:
+            number: 8080
+      rules:
+        - host: test-ingress.ngrok.io
+          http:
+            paths:
+              - path: /app
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-1
+                    port:
+                      number: 8080
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies:
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://test-ingress.ngrok.io"
+      metadata: '{"env":"prod","team":"platform"}'
+      description: "My production service"
+      upstream:
+        url: "http://test-service-1.default:8080"
+      trafficPolicy:
+        inline:
+          on_http_request:
+          - name: Initialize-Local-Service-Match
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: false
+          - name: Generated-Local-Service-Route
+            expressions:
+            - req.url.path.startsWith('/app')
+            - vars.request_matched_local_svc == false
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: true
+          - name: Generated-Route-Default-Backend
+            expressions:
+            - vars.request_matched_local_svc == false
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: true
+          - name: Fallback-404
+            expressions:
+            - vars.request_matched_local_svc == false
+            actions:
+            - type: custom-response
+              config:
+                status_code: 404
+                content: "No route was found for this ngrok Endpoint"
+                headers:
+                  content-type: text/plain

--- a/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations.yaml
@@ -1,0 +1,92 @@
+# Tests that k8s.ngrok.com/metadata and k8s.ngrok.com/description annotations on an Ingress
+# are propagated to the generated AgentEndpoint (collapsed path, single upstream).
+# The resource annotation metadata is merged with the operator-level default (empty in tests).
+input:
+  ingressClasses:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller
+  ingresses:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: test-ingress
+      namespace: default
+      annotations:
+        k8s.ngrok.com/metadata: '{"env":"prod","team":"platform"}'
+        k8s.ngrok.com/description: "My production service"
+    spec:
+      ingressClassName: ngrok
+      rules:
+        - host: test-ingress.ngrok.io
+          http:
+            paths:
+              - path: /app
+                pathType: Prefix
+                backend:
+                  service:
+                    name: test-service-1
+                    port:
+                      number: 8080
+  services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: test-service-1
+      namespace: default
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: http
+      type: ClusterIP
+  trafficPolicies:
+expected:
+  cloudEndpoints: []
+  agentEndpoints:
+  - apiVersion: ngrok.k8s.ngrok.com/v1alpha1
+    kind: AgentEndpoint
+    metadata:
+      labels:
+        k8s.ngrok.com/controller-name: test-manager-name
+        k8s.ngrok.com/controller-namespace: test-manager-namespace
+      name: e3b0c-test-service-1-default-8080
+      namespace: default
+    spec:
+      url: "https://test-ingress.ngrok.io"
+      metadata: '{"env":"prod","team":"platform"}'
+      description: "My production service"
+      upstream:
+        url: "http://test-service-1.default:8080"
+      trafficPolicy:
+        inline:
+          on_http_request:
+          - name: Initialize-Local-Service-Match
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: false
+          - name: Generated-Local-Service-Route
+            expressions:
+            - req.url.path.startsWith('/app')
+            - vars.request_matched_local_svc == false
+            actions:
+            - type: set-vars
+              config:
+                vars:
+                - request_matched_local_svc: true
+          - name: Fallback-404
+            expressions:
+            - vars.request_matched_local_svc == false
+            actions:
+            - type: custom-response
+              config:
+                status_code: 404
+                content: "No route was found for this ngrok Endpoint"
+                headers:
+                  content-type: text/plain

--- a/pkg/managerdriver/translate_gatewayapi.go
+++ b/pkg/managerdriver/translate_gatewayapi.go
@@ -170,6 +170,20 @@ func (t *translator) findMatchingVHostsForXRoute(
 			)
 			continue
 		}
+
+		gatewayMetadata, err := annotations.ExtractMetadata(gateway)
+		if err != nil {
+			t.log.Error(err, "failed to read k8s.ngrok.com/metadata annotation for gateway",
+				"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+			)
+		}
+
+		gatewayDescription, err := annotations.ExtractDescription(gateway)
+		if err != nil {
+			t.log.Error(err, "failed to read k8s.ngrok.com/description annotation for gateway",
+				"gateway", fmt.Sprintf("%s.%s", gateway.Name, gateway.Namespace),
+			)
+		}
 		upstreamClientCertRefs := []ir.IRObjectRef{}
 		if gateway.Spec.BackendTLS != nil && gateway.Spec.BackendTLS.ClientCertificateRef != nil {
 			certRef := gateway.Spec.BackendTLS.ClientCertificateRef
@@ -282,7 +296,8 @@ func (t *translator) findMatchingVHostsForXRoute(
 						EndpointPoolingEnabled: useEndpointPooling,
 						TrafficPolicy:          annotationTrafficPolicy,
 						TrafficPolicyObjRef:    tpObjRef,
-						Metadata:               t.defaultGatewayMetadata,
+						Metadata:               ir.MergeMetadata(t.defaultGatewayMetadata, gatewayMetadata),
+						Description:            gatewayDescription,
 						Bindings:               bindings,
 						ClientCertRefs:         upstreamClientCertRefs,
 						MappingStrategy:        mappingStrategy,

--- a/pkg/managerdriver/translate_ingresses.go
+++ b/pkg/managerdriver/translate_ingresses.go
@@ -69,6 +69,20 @@ func (t *translator) ingressesToIR() []*ir.IRVirtualHost {
 			continue
 		}
 
+		resourceMetadata, err := annotations.ExtractMetadata(ingress)
+		if err != nil {
+			t.log.Error(err, "failed to read k8s.ngrok.com/metadata annotation for ingress",
+				"ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
+			)
+		}
+
+		resourceDescription, err := annotations.ExtractDescription(ingress)
+		if err != nil {
+			t.log.Error(err, "failed to read k8s.ngrok.com/description annotation for ingress",
+				"ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
+			)
+		}
+
 		t.ingressToIR(
 			ingress,
 			defaultDestination,
@@ -79,6 +93,8 @@ func (t *translator) ingressesToIR() []*ir.IRVirtualHost {
 			tpObjRef,
 			bindings,
 			mappingStrategy,
+			resourceMetadata,
+			resourceDescription,
 		)
 	}
 
@@ -103,6 +119,8 @@ func (t *translator) ingressToIR(
 	annotationTrafficPolicyRef *ir.OwningResource,
 	bindings []string,
 	mappingStrategy ir.IRMappingStrategy,
+	resourceMetadata string,
+	resourceDescription string,
 ) {
 	for _, rule := range ingress.Spec.Rules {
 		ruleHostname := rule.Host
@@ -161,7 +179,22 @@ func (t *translator) ingressToIR(
 				continue
 			}
 
-			// The current and existing configurations match, add the new owning ingress reference and keep going
+			// The current and existing configurations match, add the new owning ingress reference and keep going.
+			// Warn if this ingress has annotation values that differ from what was already set on the vhost;
+			// the first-processed resource's values win for both metadata and description.
+			mergedMetadata := ir.MergeMetadata(t.defaultIngressMetadata, resourceMetadata)
+			if mergedMetadata != "" && irVHost.Metadata != "" && mergedMetadata != irVHost.Metadata {
+				t.log.Info("multiple ingresses sharing the same hostname have different k8s.ngrok.com/metadata annotations; the metadata from the first-processed ingress will be used",
+					"current ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
+					"hostname", ruleHostname,
+				)
+			}
+			if resourceDescription != "" && irVHost.Description != "" && resourceDescription != irVHost.Description {
+				t.log.Info("multiple ingresses sharing the same hostname have different k8s.ngrok.com/description annotations; the description from the first-processed ingress will be used",
+					"current ingress", fmt.Sprintf("%s.%s", ingress.Name, ingress.Namespace),
+					"hostname", ruleHostname,
+				)
+			}
 			irVHost.AddOwningResource(owningResource)
 		} else {
 			// Make a deep copy of the ingress traffic policy so that we don't taint it for subsequent rules
@@ -191,7 +224,8 @@ func (t *translator) ingressToIR(
 				Routes:                 []*ir.IRRoute{},
 				DefaultDestination:     defaultDestination,
 				EndpointPoolingEnabled: endpointPoolingEnabled,
-				Metadata:               t.defaultIngressMetadata,
+				Metadata:               ir.MergeMetadata(t.defaultIngressMetadata, resourceMetadata),
+				Description:            resourceDescription,
 				Bindings:               bindings,
 				MappingStrategy:        mappingStrategy,
 			}

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -505,7 +505,8 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, agentEndpoint
 						irVHost,
 						irService,
 						t.clusterDomain,
-						irVHost.Metadata)
+						irVHost.Metadata,
+						irVHost.Description)
 					if err != nil {
 						t.log.Error(err, "failed to build AgentEndpoint",
 							"hostname", irVHost.Listener.Hostname,
@@ -724,7 +725,8 @@ func (t *translator) buildDefaultDestinationPolicy(irVHost *ir.IRVirtualHost, ag
 				irVHost,
 				irService,
 				t.clusterDomain,
-				t.defaultIngressMetadata,
+				irVHost.Metadata,
+				irVHost.Description,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to build AgentEndpoint. upstream generated from resources: %v, err: %w", upstream.OwningResources, err)
@@ -808,6 +810,7 @@ func buildCloudEndpoint(irVHost *ir.IRVirtualHost) (*ngrokv1alpha1.CloudEndpoint
 			URL:            publicURL,
 			PoolingEnabled: irVHost.EndpointPoolingEnabled,
 			Metadata:       irVHost.Metadata,
+			Description:    irVHost.Description,
 			Bindings:       irVHost.Bindings,
 		},
 	}, nil
@@ -819,6 +822,7 @@ func buildAgentEndpoint(
 	irService ir.IRService,
 	clusterDomain string,
 	metadata string,
+	description string,
 ) (*ngrokv1alpha1.AgentEndpoint, error) {
 	bindings := []string{}
 	var url string
@@ -852,8 +856,9 @@ func buildAgentEndpoint(
 			Annotations: irVHost.AnnotationsToAdd,
 		},
 		Spec: ngrokv1alpha1.AgentEndpointSpec{
-			URL:      url,
-			Metadata: metadata,
+			URL:         url,
+			Metadata:    metadata,
+			Description: description,
 			Upstream: ngrokv1alpha1.EndpointUpstream{
 				URL:      agentEndpointUpstreamURL(irService.Name, irService.Namespace, clusterDomain, irService.Port, irService.Scheme),
 				Protocol: irService.Protocol,

--- a/pkg/managerdriver/translator_test.go
+++ b/pkg/managerdriver/translator_test.go
@@ -40,6 +40,7 @@ func TestBuildInternalAgentEndpoint(t *testing.T) {
 		irService              ir.IRService
 		clusterDomain          string
 		metadata               string
+		description            string
 		expectedName           string
 		expectedURL            string
 		expectedUpstream       string
@@ -128,7 +129,7 @@ func TestBuildInternalAgentEndpoint(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := buildAgentEndpoint(tc.irVirtualHost, tc.irService, tc.clusterDomain, tc.metadata)
+			result, err := buildAgentEndpoint(tc.irVirtualHost, tc.irService, tc.clusterDomain, tc.metadata, tc.description)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedName, result.Name, "unexpected name for test case: %s", tc.name)
 			assert.Equal(t, tc.irService.Namespace, result.Namespace, "unexpected namespace for test case: %s", tc.name)


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
<h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Add<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">k8s.ngrok.com/metadata</code><span> </span>and<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">k8s.ngrok.com/description</code><span> </span>annotations</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Allows per-resource metadata and description to be set on Ingress and Gateway resources, which get propagated to the CloudEndpoints and AgentEndpoints created from them.</p><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">New annotations</h3><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">k8s.ngrok.com/metadata</code></strong><span> </span>— a JSON object string that is merged with the operator-level default metadata. Keys in the annotation take precedence over the operator default.</li><li><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">k8s.ngrok.com/description</code></strong><span> </span>— a human-readable description string set on the generated endpoint.</li></ul><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(0, 12, 24); border-color: rgb(69, 69, 69); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-yaml" style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">metadata:
  annotations:
    k8s.ngrok.com/metadata: '{"env":"prod","team":"platform"}'
    k8s.ngrok.com/description: "My production service"
</code></pre></div><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Merge behaviour</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Metadata is merged (not replaced) with the operator-level default using <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ir.MergeMetadata</code>. For example, if the operator default is <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">{"owned-by":"ngrok-operator"}</code> and the annotation is <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">{"env":"prod"}</code>, the result is <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">{"owned-by":"ngrok-operator","env":"prod"}</code>. Annotation keys win on conflict.</p><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Aggregation behaviour (multiple Ingresses sharing a hostname)</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Multiple Ingress objects can map to a single endpoint. When their annotations differ:</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>The<span> </span><strong>alphabetically-first resource</strong><span> </span>(sorted by<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">namespace/name</code>, which is the store's iteration order) wins for both metadata and description.</li><li>A log warning is emitted when a later ingress has conflicting annotation values that are being dropped.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This matches the existing precedence behaviour for other shared-hostname conflicts (traffic policy, pooling, etc.).</p><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What was changed</h3>

- internal/annotations/annotations.go: New MetadataAnnotation, DescriptionAnnotation constants and ExtractMetadata, ExtractDescription helpers
- internal/ir/ir.go: New Description field on IRVirtualHost; new MergeMetadata(base, override string) string helper
- pkg/managerdriver/translate_ingresses.go: Read both annotations per-ingress; set on new vhosts; warn on conflict when aggregating
- pkg/managerdriver/translate_gatewayapi.go: Same for Gateway resources
- pkg/managerdriver/translator.go: Thread Description through buildCloudEndpoint and buildAgentEndpoint; fix default-backend path to use irVHost.Metadata instead of raw operator default

<h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Tests added</h3><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">TestExtractMetadata</code>,<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">TestExtractDescription</code><span> </span>in<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">internal/annotations/annotations_test.go</code></li><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">TestMergeMetadata</code><span> </span>(7 cases) in<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">internal/ir/ir_test.go</code></li><li>4 new golden test cases in<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pkg/managerdriver/testdata/translator/</code>:<ul style="padding-inline-start: 2em;"><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ingress-metadata-description-annotations.yaml</code><span> </span>— basic propagation via collapsed AgentEndpoint</li><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ingress-metadata-description-annotations-default-backend.yaml</code><span> </span>— propagation via the default backend code path</li><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ingress-metadata-description-annotations-conflict.yaml</code><span> </span>— two ingresses sharing a hostname; first alphabetically wins</li><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">gwapi-gateway-metadata-description-annotations.yaml</code><span> </span>— Gateway annotation propagation to CloudEndpoint + internal AgentEndpoint</li></ul></li></ul><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Known limitations / follow-ups</h3><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(6, 6, 33); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>HTTPRoute/TCPRoute/TLSRoute-level annotations are not yet supported; annotations are read from the Gateway only.</li><li>Service controller support is not included in this PR.</li></ul>

## Breaking Changes
*Are there any breaking changes in this PR?*
