### PR TITLE
test: Fix flakey agent endpoint controller test

### DIFF
--- a/internal/controller/agent/agent_endpoint_controller_test.go
+++ b/internal/controller/agent/agent_endpoint_controller_test.go
@@ -1210,6 +1210,12 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 				g.Expect(cond.Reason).To(Equal(ReasonConfigError))
 			}, timeout, interval).Should(Succeed())
 
+			// Set up mock before creating the secret so it's ready when the secret-watch
+			// triggers the AgentEndpoint reconcile.
+			envMockDriver.SetEndpointResult(namespace+"/cert-watch-endpoint", &agent.EndpointResult{
+				URL: "tcp://cert-watch.tcp.ngrok.io:12345",
+			})
+
 			By("Creating the client certificate secret")
 			certSecret := &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1223,11 +1229,6 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 				},
 			}
 			Expect(k8sClient.Create(ctx, certSecret)).To(Succeed())
-
-			// Mock successful endpoint creation for when certificate becomes available
-			envMockDriver.SetEndpointResult(namespace+"/cert-watch-endpoint", &agent.EndpointResult{
-				URL: "tcp://cert-watch.tcp.ngrok.io:12345",
-			})
 
 			By("Waiting for controller to automatically reconcile AgentEndpoint when secret is created")
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
## What
Fix a race condition in the "should reconcile when client certificate secret is created after AgentEndpoint" test that caused it to flake intermittently.

## How

The mock driver result was being set after the certificate Secret was created in the test. Creating the secret fires a watch event that re-enqueues the `AgentEndpoint` for reconciliation. If the controller goroutine picked up that event and called into the mock driver before `SetEndpointResult` was called on the next line, the mock had no result registered so AssignedURL was never populated and the ConditionTrue assertion timed out.

 The fix is a one-line reorder: `SetEndpointResult` is now called before `k8sClient.Create(ctx, certSecret)`, which is consistent with every other tests in the file.

## Breaking Changes
None. Test-only change.
