### PR TITLE
ci: consolidate nix setup and drop nix develop --command wrappers

### DIFF
--- a/.github/actions/build-and-test/action.yaml
+++ b/.github/actions/build-and-test/action.yaml
@@ -34,15 +34,15 @@ runs:
 
     - name: Build
       shell: bash
-      run: nix develop --command make build
+      run: make build
 
     - name: Test
       shell: bash
-      run: nix develop --command make test
+      run: make test
 
     - name: Build the Docker image
       shell: bash
-      run: nix develop --command make docker-build
+      run: make docker-build
 
     - name: Deploy controller to local cluster
       shell: bash
@@ -57,7 +57,7 @@ runs:
         kubectl create ns e2e || true
 
         # deploy ngrok-op for e2e tests
-        nix develop --command make deploy_for_e2e
+        make deploy_for_e2e
 
     - name: Check if operator is up
       shell: bash
@@ -71,7 +71,7 @@ runs:
     - name: Run e2e tests
       shell: bash
       if: ${{ inputs.run-e2e == 'true' }}
-      run: nix develop --command make e2e-tests
+      run: make e2e-tests
 
     # best effort to remove ngrok k8s resources from cluster
     # this allows our finalizers to delete upstream ngrok API resources too
@@ -80,4 +80,4 @@ runs:
       shell: bash
       if: ${{ always() && inputs.run-e2e == 'true' }}
       run: |
-        nix develop --command make e2e-clean
+        make e2e-clean

--- a/.github/actions/nix-setup/action.yaml
+++ b/.github/actions/nix-setup/action.yaml
@@ -1,0 +1,26 @@
+name: Action - Nix Setup
+description: "Sets up Nix with caching and puts tools in PATH for use in later steps"
+
+runs:
+  using: "composite"
+  steps:
+  - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+  - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+  - name: Install direnv
+    shell: bash
+    run: |
+      DIRENV_VERSION="2.37.1"
+      DIRENV_SHA256="1f1b93dd6f38523fde26dfac96151ef9d31a374e3005cd3345fb93555ae0c9b5"
+      curl -sfL "https://github.com/direnv/direnv/releases/download/v${DIRENV_VERSION}/direnv.linux-amd64" -o /tmp/direnv
+      echo "${DIRENV_SHA256}  /tmp/direnv" | sha256sum -c
+      chmod +x /tmp/direnv
+      mkdir -p "$HOME/.local/bin"
+      mv /tmp/direnv "$HOME/.local/bin/direnv"
+      echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      export PATH="$HOME/.local/bin:$PATH"
+  - name: Allow direnv and export environment variables
+    shell: bash
+    run: |
+      direnv allow .
+      direnv export gha >> "$GITHUB_ENV"
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,10 +40,10 @@ jobs:
       (needs.changes.outputs.make == 'true')
     steps:
     - uses: actions/checkout@v6
-    - uses: nixbuild/nix-quick-install-action@v34
-    - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+    - name: Setup Nix
+      uses: ./.github/actions/nix-setup
     - name: Generate manifests
-      run: nix develop --command make manifests
+      run: make manifests
     - name: Fail if there are uncommited manifest changes
       run: |
         git diff --exit-code
@@ -59,10 +59,10 @@ jobs:
       (needs.changes.outputs.make == 'true')
     steps:
     - uses: actions/checkout@v6
-    - uses: nixbuild/nix-quick-install-action@v34
-    - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+    - name: Setup Nix
+      uses: ./.github/actions/nix-setup
     - name: Lint
-      run: nix develop --command make lint
+      run: make lint
 
   go-mod-tidy:
     name: Go Mod Tidy Check
@@ -73,9 +73,9 @@ jobs:
       (needs.changes.outputs.go == 'true')
     steps:
     - uses: actions/checkout@v6
-    - uses: nixbuild/nix-quick-install-action@v34
-    - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
-    - run: nix develop --command go mod tidy
+    - name: Setup Nix
+      uses: ./.github/actions/nix-setup
+    - run: go mod tidy
     - run: git diff --exit-code go.mod
     - run: git diff --exit-code go.sum
 
@@ -90,10 +90,10 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v6
-    - uses: nixbuild/nix-quick-install-action@v34
-    - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+    - name: Setup Nix
+      uses: ./.github/actions/nix-setup
     - name: Run go fix
-      run: nix develop --command make go-fix
+      run: make go-fix
     - name: Fail if there are uncommitted changes
       run: git diff --exit-code
 
@@ -152,8 +152,8 @@ jobs:
       pull-requests: read
     steps:
     - uses: actions/checkout@v6
-    - uses: nixbuild/nix-quick-install-action@v34
-    - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+    - name: Setup Nix
+      uses: ./.github/actions/nix-setup
     - uses: "./.github/actions/build-and-test"
       with:
         # this workflow is for incoming PRs, so we want to skip e2e tests
@@ -173,12 +173,12 @@ jobs:
     if: needs.changes.outputs.charts == 'true'
     steps:
     - uses: actions/checkout@v6
-    - uses: nixbuild/nix-quick-install-action@v34
-    - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+    - name: Setup Nix
+      uses: ./.github/actions/nix-setup
     - name: Lint Helm Chart
-      run: nix develop --command make helm-lint
+      run: make helm-lint
     - name: Helm Unit Tests
-      run: nix develop --command make helm-test
+      run: make helm-test
 
   e2e:
     runs-on: ubuntu-latest
@@ -212,8 +212,8 @@ jobs:
       )
     steps:
     - uses: actions/checkout@v6
-    - uses: nixbuild/nix-quick-install-action@v34
-    - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+    - name: Setup Nix
+      uses: ./.github/actions/nix-setup
     - uses: "./.github/actions/build-and-test"
       with:
         run-e2e: true
@@ -248,17 +248,17 @@ jobs:
       )
     steps:
     - uses: actions/checkout@v6
-    - uses: nixbuild/nix-quick-install-action@v34
-    - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+    - name: Setup Nix
+      uses: ./.github/actions/nix-setup
     - name: Create Kind Cluster
-      run: nix develop --command make kind-create
+      run: make kind-create
     - name: Deploy
-      run: nix develop --command make deploy_multi_namespace
+      run: make deploy_multi_namespace
       env:
         NGROK_API_KEY: ${{ secrets.NGROK_CI_API_KEY }}
         NGROK_AUTHTOKEN: ${{ secrets.NGROK_CI_AUTHTOKEN }}
     - name: Test
-      run: nix develop --command make e2e-tests-multi-ns
+      run: make e2e-tests-multi-ns
     - name: Cleanup
       if: always()
       run: |
@@ -297,15 +297,15 @@ jobs:
       )
     steps:
     - uses: actions/checkout@v6
-    - uses: nixbuild/nix-quick-install-action@v34
-    - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+    - name: Setup Nix
+      uses: ./.github/actions/nix-setup
     - name: Create Kind Cluster
-      run: nix develop --command make kind-create
+      run: make kind-create
     - name: Run Uninstall E2E Tests
       env:
         NGROK_API_KEY: ${{ secrets.NGROK_CI_API_KEY }}
         NGROK_AUTHTOKEN: ${{ secrets.NGROK_CI_AUTHTOKEN }}
-      run: nix develop --command make e2e-uninstall-all
+      run: make e2e-uninstall-all
     - name: Cleanup
       if: always()
-      run: nix develop --command make e2e-clean-uninstall
+      run: make e2e-clean-uninstall

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,23 +24,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
-
-      - name: Setup Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c # main commit
-
-      - name: Install direnv
-        run: |
-          curl -sfL https://direnv.net/install.sh | bash
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          export PATH="$HOME/.local/bin:$PATH"
-
-      - name: Allow direnv and export environment variables
-        shell: bash
-        run: |
-          direnv allow .
-          direnv export gha >> "$GITHUB_ENV"
+      - name: Setup Nix
+        uses: ./.github/actions/nix-setup
 
       - name: Verify environment
         run: make preflight

--- a/.github/workflows/generate-full-install-manifests.yaml
+++ b/.github/workflows/generate-full-install-manifests.yaml
@@ -8,11 +8,6 @@ on:
     - alex/single-manifest-file
     # paths:
     # - 'helm/**/*'
-  # pull_request_target:
-  #   branches:
-  #   - main
-  #   paths:
-  #   - 'helm/**/*'
 permissions:
   contents: write
 jobs:
@@ -27,12 +22,10 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
-      - name: Setup Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+      - name: Setup nix
+        uses: ./.github/actions/nix-setup
       - name: Run helm template
-        run: nix develop --command make manifest-bundle
+        run: make manifest-bundle
       - name: Push changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -53,6 +53,9 @@ jobs:
           # Fetch entire history. Required for chart-releaser to work.
           fetch-depth: 0
 
+      - name: Setup Nix
+        uses: ./.github/actions/nix-setup
+
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
@@ -63,14 +66,8 @@ jobs:
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --dearmor --output keyring.gpg
           echo "${{ secrets.GPG_PASSWORD }}" > gpg-password.txt
 
-      - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
-
-      - name: Setup Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c # main commit
-
       - name: Setup Helm
-        run: nix develop --command make _helm_setup
+        run: make _helm_setup
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0


### PR DESCRIPTION
## What

While working on our setup up Copilot Agent, I found that we can use `direnv export gha` to put all of our nix provided tools on the path. I also noticed that we were installing nix and the cache action in many places. This makes it harder to update the versions of these actions across all of our workflows.


## How
* Consolidate install nix, setup up the cache, and downloading and using direnv to a single place and use it in our other workflows.
* Since we are now using `direnv export gha`, we no longer need to use `nix develop --command` across our actions

## Breaking Changes
No, this should only impact CI
