### PR TITLE
fix(ngrok): use ReconcileStatus for CloudEndpoint IsNotFound handling…

### DIFF
--- a/internal/controller/ngrok/cloudendpoint_controller.go
+++ b/internal/controller/ngrok/cloudendpoint_controller.go
@@ -247,7 +247,9 @@ func (r *CloudEndpointReconciler) update(ctx context.Context, clep *ngrokv1alpha
 		// Couldn't find endpoint by ID to update, so blank it out and create a new one
 		r.Recorder.Eventf(clep, nil, v1.EventTypeWarning, "EndpointNotFound", "Reconcile", fmt.Sprintf("Failed to update endpoint %s by ID because it was not found. Creating a new one", clep.Status.ID))
 		clep.Status.ID = ""
-		_ = r.Client.Status().Update(ctx, clep)
+		if err := r.controller.ReconcileStatus(ctx, clep, nil); err != nil {
+			return err
+		}
 		return r.create(ctx, clep)
 	}
 	if err != nil {


### PR DESCRIPTION
related: K8SOP-240

## What
CloudEndpoint bypassed `ReconcileStatus` and silently discarded the status update error when handling `ngrok.IsNotFound`. This was inconsistent with every other controller (IPPolicy, Domain, AgentEndpoint) and skipped error wrapping, event recording, and the 10-second requeue-on-conflict logic.

## How
Replaced `_ = r.Client.Status().Update(ctx, clep)` with `r.controller.ReconcileStatus(ctx, clep, nil)`, matching the standard pattern. Also documented the status update pattern in `specs/controllers/status-updates.md`.

## Breaking Changes
None