### PR TITLE
Fix/k8sop 252 misc quick wins

### DIFF
--- a/api/ingress/v1alpha1/ippolicy_types.go
+++ b/api/ingress/v1alpha1/ippolicy_types.go
@@ -49,9 +49,6 @@ type IPPolicyRuleStatus struct {
 	Action string `json:"action,omitempty"`
 }
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // IPPolicySpec defines the desired state of IPPolicy
 type IPPolicySpec struct {
 	// Description is a human-readable description of the object in the ngrok API/Dashboard
@@ -66,8 +63,6 @@ type IPPolicySpec struct {
 
 // IPPolicyStatus defines the observed state of IPPolicy
 type IPPolicyStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
 	ID string `json:"id,omitempty"`
 
 	// Conditions represent the latest available observations of the IP policy's state

--- a/api/ngrok/v1alpha1/cloudendpoint_types.go
+++ b/api/ngrok/v1alpha1/cloudendpoint_types.go
@@ -89,7 +89,7 @@ type CloudEndpointStatus struct {
 	// +nullable
 	DomainRef *K8sObjectRefOptionalNamespace `json:"domainRef"`
 
-	// Conditions describe the current conditions of the AgentEndpoint.
+	// Conditions describe the current conditions of the CloudEndpoint.
 	//
 	// +listType=map
 	// +listMapKey=type

--- a/api/ngrok/v1alpha1/ngroktrafficpolicy_types.go
+++ b/api/ngrok/v1alpha1/ngroktrafficpolicy_types.go
@@ -30,14 +30,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // NgrokTrafficPolicySpec defines the desired state of NgrokTrafficPolicy
 type NgrokTrafficPolicySpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
 	// The raw json encoded policy that was applied to the ngrok API
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields

--- a/helm/ngrok-crds/templates/ingress.k8s.ngrok.com_ippolicies.yaml
+++ b/helm/ngrok-crds/templates/ingress.k8s.ngrok.com_ippolicies.yaml
@@ -165,9 +165,6 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               id:
-                description: |-
-                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
                 type: string
               rules:
                 items:

--- a/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_cloudendpoints.yaml
+++ b/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_cloudendpoints.yaml
@@ -128,7 +128,7 @@ spec:
             description: CloudEndpointStatus defines the observed state of CloudEndpoint
             properties:
               conditions:
-                description: Conditions describe the current conditions of the AgentEndpoint.
+                description: Conditions describe the current conditions of the CloudEndpoint.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/internal/controller/bindings/port_allocator.go
+++ b/internal/controller/bindings/port_allocator.go
@@ -53,7 +53,7 @@ func (pb *portBitmap) IsSet(port uint16) bool {
 	pb.mu.Lock()
 	defer pb.mu.Unlock()
 	if port < pb.start {
-		panic(fmt.Sprintf("portBitmap.Set called with port before start of port range; port=%v, start=%v", port, pb.start))
+		panic(fmt.Sprintf("portBitmap.IsSet called with port before start of port range; port=%v, start=%v", port, pb.start))
 	}
 	return pb.ports.IsSet(uint64(port - pb.start))
 }
@@ -63,7 +63,7 @@ func (pb *portBitmap) Unset(port uint16) {
 	pb.mu.Lock()
 	defer pb.mu.Unlock()
 	if port < pb.start {
-		panic(fmt.Sprintf("portBitmap.Set called with port before start of port range; port=%v, start=%v", port, pb.start))
+		panic(fmt.Sprintf("portBitmap.Unset called with port before start of port range; port=%v, start=%v", port, pb.start))
 	}
 	if err := pb.ports.Unset(uint64(port - pb.start)); err != nil {
 		panic(fmt.Sprintf("error unsetting port %d: %s", port, err))

--- a/internal/controller/ingress/domain_controller.go
+++ b/internal/controller/ingress/domain_controller.go
@@ -241,7 +241,7 @@ func (r *DomainReconciler) findReservedDomainByHostname(ctx context.Context, dom
 			return domain, nil
 		}
 	}
-	return nil, nil
+	return nil, iter.Err()
 }
 
 // updateStatus updates the status fields of the domain resource only if any values have changed

--- a/internal/controller/ingress/domain_controller_test.go
+++ b/internal/controller/ingress/domain_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ngrok/ngrok-api-go/v7"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
+	"github.com/ngrok/ngrok-operator/internal/mocks/nmockapi"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -903,6 +904,22 @@ var _ = Describe("DomainReconciler", func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(foundDomain.Status.ID).ToNot(BeEmpty(), "non-internal domain should be created in ngrok")
 			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("findReservedDomainByHostname", func() {
+		It("should propagate iterator errors", func() {
+			ctx := context.Background()
+			iterErr := errors.New("API pagination failure")
+			mockClient := nmockapi.NewDomainClient()
+			mockClient.SetListError(iterErr)
+
+			r := &DomainReconciler{
+				DomainsClient: mockClient,
+			}
+			result, err := r.findReservedDomainByHostname(ctx, "any-domain.example.com")
+			Expect(result).To(BeNil())
+			Expect(err).To(MatchError(iterErr))
 		})
 	})
 

--- a/internal/healthcheck/channel_health_checker.go
+++ b/internal/healthcheck/channel_health_checker.go
@@ -55,7 +55,7 @@ func (chc *ChannelHealthChecker) Ready(_ context.Context, _ *http.Request) error
 }
 
 func (chc *ChannelHealthChecker) Alive(_ context.Context, _ *http.Request) error {
-	chc.readyMu.Lock()
-	defer chc.readyMu.Unlock()
+	chc.aliveMu.Lock()
+	defer chc.aliveMu.Unlock()
 	return chc.aliveErr
 }

--- a/internal/healthcheck/channel_health_checker_test.go
+++ b/internal/healthcheck/channel_health_checker_test.go
@@ -60,22 +60,18 @@ func TestAliveDataRace(t *testing.T) {
 	var wg sync.WaitGroup
 	const iterations = 1000
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+	wg.Go(func() {
+		for range iterations {
 			aliveChan <- errors.New("not alive")
 			aliveChan <- nil
 		}
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < iterations*2; i++ {
+	wg.Go(func() {
+		for range iterations * 2 {
 			_ = chc.Alive(context.Background(), nil)
 		}
-	}()
+	})
 
 	wg.Wait()
 }

--- a/internal/healthcheck/channel_health_checker_test.go
+++ b/internal/healthcheck/channel_health_checker_test.go
@@ -1,7 +1,9 @@
 package healthcheck
 
 import (
+	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -45,4 +47,33 @@ func TestChannelHealthChecker(t *testing.T) {
 	// After closing the channels, the last error should still be returned
 	assert.Error(t, chc.Ready(ctx, nil), "Expected Ready check to return last error after channel close")
 	assert.Error(t, chc.Alive(ctx, nil), "Expected Alive check to return last error after channel close")
+}
+
+func TestAliveDataRace(t *testing.T) {
+	aliveChan := make(chan error)
+	readyChan := make(chan error)
+
+	chc := NewChannelHealthChecker(readyChan, aliveChan)
+
+	var wg sync.WaitGroup
+	const iterations = 1000
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			aliveChan <- errors.New("not alive")
+			aliveChan <- nil
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations*2; i++ {
+			_ = chc.Alive(context.Background(), nil)
+		}
+	}()
+
+	wg.Wait()
 }

--- a/internal/healthcheck/channel_health_checker_test.go
+++ b/internal/healthcheck/channel_health_checker_test.go
@@ -50,6 +50,8 @@ func TestChannelHealthChecker(t *testing.T) {
 }
 
 func TestAliveDataRace(t *testing.T) {
+	t.Parallel()
+
 	aliveChan := make(chan error)
 	readyChan := make(chan error)
 

--- a/internal/mocks/nmockapi/base_client.go
+++ b/internal/mocks/nmockapi/base_client.go
@@ -43,7 +43,7 @@ func (m *baseClient[T]) Get(_ context.Context, id string) (T, error) {
 
 func (m *baseClient[T]) List(_ *ngrok.Paging) ngrok.Iter[T] {
 	items := slices.Collect(maps.Values(m.items))
-	return NewIter(items, nil)
+	return NewIter(items, m.listError)
 }
 
 func (m *baseClient[T]) Delete(ctx context.Context, id string) error {

--- a/pkg/managerdriver/translate_gatewayapi.go
+++ b/pkg/managerdriver/translate_gatewayapi.go
@@ -179,7 +179,7 @@ func (t *translator) findMatchingVHostsForXRoute(
 			}
 
 			if !t.isRefToNamespaceAllowed(gateway.Namespace, "gateway.networking.k8s.io", "Gateway", string(certRef.Name), string(*certRef.Namespace), "", "Secret") {
-				t.log.Error(fmt.Errorf("reference to Secret %q is not allowed without a valid ReferenceGrant", fmt.Sprintf("%s.%s", certRef.Name, refNamespace)),
+				t.log.Error(fmt.Errorf("reference to Secret %q is not allowed without a valid ReferenceGrant", fmt.Sprintf("%s.%s", certRef.Name, *certRef.Namespace)),
 					"Gateway backendTLS.clientCertificateRef is invalid without a ReferenceGrant",
 				)
 				continue


### PR DESCRIPTION
related: K8SOP-240

## What
Six small, low-risk fixes across scattered files — data race, swallowed errors, wrong error messages, and doc cleanup.

- **Bug 1.1:** `ChannelHealthChecker.Alive()` acquired `readyMu` but read `aliveErr` (written under `aliveMu`). Data race from copy-paste error.
- **Bug 1.3:** `findReservedDomainByHostname` returned `(nil, nil)` after iteration instead of `(nil, iter.Err())`, swallowing API pagination errors and potentially creating duplicate domains.
- **Bug 1.8:** Gateway translation error message used `refNamespace` (parentRef's namespace) instead of `certRef.Namespace`.
- **Bug 1.9:** Port allocator `Unset` method panic messages said "Set called" instead of "Unset called".
- **Bug 1.10:** Kubebuilder scaffolding comments ("EDIT THIS FILE!", "INSERT ADDITIONAL SPEC FIELDS") left in public API types.
- **Bug 1.11:** CloudEndpoint status comment incorrectly said "AgentEndpoint".

## How
- 1.1: `readyMu` → `aliveMu` in Alive()
- 1.3: `return nil, nil` → `return nil, iter.Err()`
- 1.8: Corrected variable reference in error format string
- 1.9: Updated panic message strings
- 1.10: Removed scaffolding comments from NgrokTrafficPolicy and IPPolicy types
- 1.11: Fixed comment text

Tests added: `TestAliveDataRace` (concurrent race detector test), `findReservedDomainByHostname/should propagate iterator errors`

## Breaking Changes
None