### PR TITLE
fix: skip redundant ngrok API updates for CloudEndpoint

### DIFF
--- a/internal/controller/ngrok/cloudendpoint_controller.go
+++ b/internal/controller/ngrok/cloudendpoint_controller.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -232,6 +233,28 @@ func (r *CloudEndpointReconciler) update(ctx context.Context, clep *ngrokv1alpha
 		return r.updateStatus(ctx, clep, nil, domainResult, err)
 	}
 
+	// Fetch current endpoint state from the ngrok API so we can compare
+	// before issuing an update. This avoids redundant API writes on every
+	// requeue cycle (e.g. while waiting for a domain to become ready).
+	currentEndpoint, err := r.NgrokClientset.Endpoints().Get(ctx, clep.Status.ID)
+	if ngrok.IsNotFound(err) {
+		r.Recorder.Eventf(clep, nil, v1.EventTypeWarning, "EndpointNotFound", "Reconcile", fmt.Sprintf("Failed to find endpoint %s by ID. Creating a new one", clep.Status.ID))
+		clep.Status.ID = ""
+		if err := r.controller.ReconcileStatus(ctx, clep, nil); err != nil {
+			return err
+		}
+		return r.create(ctx, clep)
+	}
+	if err != nil {
+		return r.updateStatus(ctx, clep, nil, domainResult, err)
+	}
+
+	// Skip the API update if nothing has changed
+	if !endpointNeedsUpdate(currentEndpoint, clep.Spec, policy) {
+		setCloudEndpointCreatedCondition(clep, true, ReasonCloudEndpointCreated, "CloudEndpoint updated successfully")
+		return r.updateStatus(ctx, clep, currentEndpoint, domainResult, nil)
+	}
+
 	updateParams := &ngrok.EndpointUpdate{
 		ID:             clep.Status.ID,
 		Url:            &clep.Spec.URL,
@@ -243,15 +266,6 @@ func (r *CloudEndpointReconciler) update(ctx context.Context, clep *ngrokv1alpha
 	}
 
 	ngrokClep, err := r.NgrokClientset.Endpoints().Update(ctx, updateParams)
-	if ngrok.IsNotFound(err) {
-		// Couldn't find endpoint by ID to update, so blank it out and create a new one
-		r.Recorder.Eventf(clep, nil, v1.EventTypeWarning, "EndpointNotFound", "Reconcile", fmt.Sprintf("Failed to update endpoint %s by ID because it was not found. Creating a new one", clep.Status.ID))
-		clep.Status.ID = ""
-		if err := r.controller.ReconcileStatus(ctx, clep, nil); err != nil {
-			return err
-		}
-		return r.create(ctx, clep)
-	}
 	if err != nil {
 		setCloudEndpointCreatedCondition(clep, false, ReasonCloudEndpointCreationFailed, fmt.Sprintf("Failed to update cloud endpoint: %v", err))
 		return r.updateStatus(ctx, clep, nil, domainResult, err)
@@ -342,6 +356,31 @@ func (r *CloudEndpointReconciler) findCloudEndpointsForDomain(ctx context.Contex
 		}
 	}
 	return requests
+}
+
+// endpointNeedsUpdate compares the current endpoint state from the ngrok API
+// against the desired state derived from the CloudEndpoint spec and the resolved
+// traffic policy. Returns true if an API update call is necessary.
+func endpointNeedsUpdate(current *ngrok.Endpoint, spec ngrokv1alpha1.CloudEndpointSpec, policy string) bool {
+	if current.URL != spec.URL {
+		return true
+	}
+	if current.Description != spec.Description {
+		return true
+	}
+	if current.Metadata != spec.Metadata {
+		return true
+	}
+	if current.TrafficPolicy != policy {
+		return true
+	}
+	if !slices.Equal(current.Bindings, spec.Bindings) {
+		return true
+	}
+	if spec.PoolingEnabled != nil && current.PoolingEnabled != *spec.PoolingEnabled {
+		return true
+	}
+	return false
 }
 
 // getTrafficPolicy returns the TrafficPolicy JSON string from either the name reference or inline policy

--- a/internal/controller/ngrok/cloudendpoint_controller_test.go
+++ b/internal/controller/ngrok/cloudendpoint_controller_test.go
@@ -778,6 +778,37 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 
+		It("should not call the ngrok API update while domain is not ready", func(ctx SpecContext) {
+			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-unnecessary-updates",
+					Namespace: namespace,
+				},
+				Spec: ngrokv1alpha1.CloudEndpointSpec{
+					URL: "http://no-update-spam.example.com",
+				},
+			}
+
+			By("Creating the CloudEndpoint")
+			Expect(k8sClient.Create(ctx, cloudEndpoint)).To(Succeed())
+
+			By("Waiting for the endpoint to be created (Status.ID set)")
+			kginkgo.EventuallyWithCloudEndpoint(ctx, cloudEndpoint, func(g Gomega, fetched *ngrokv1alpha1.CloudEndpoint) {
+				g.Expect(fetched.Status.ID).NotTo(BeEmpty())
+			})
+
+			By("Recording the update call count after initial creation")
+			mockEndpoints := mockClientset.Endpoints().(*nmockapi.EndpointsClient)
+			mockEndpoints.ResetUpdateCallCount()
+
+			By("Waiting several requeue cycles to verify no spurious API updates")
+			// The controller requeues every 10s when domain is not ready.
+			// Wait long enough for multiple requeue cycles to have fired.
+			Consistently(func() int {
+				return mockEndpoints.UpdateCallCount()
+			}, 5*time.Second, 500*time.Millisecond).Should(Equal(0))
+		})
+
 		It("should handle multiple Kubernetes-bound endpoints with different domains", func(ctx SpecContext) {
 			// Use different URLs to avoid pooling issues in mock
 			endpoints := []*ngrokv1alpha1.CloudEndpoint{

--- a/internal/controller/ngrok/cloudendpoint_controller_unit_test.go
+++ b/internal/controller/ngrok/cloudendpoint_controller_unit_test.go
@@ -1,0 +1,160 @@
+package ngrok
+
+import (
+	"testing"
+
+	"github.com/ngrok/ngrok-api-go/v7"
+	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndpointNeedsUpdate(t *testing.T) {
+	baseEndpoint := func() *ngrok.Endpoint {
+		return &ngrok.Endpoint{
+			URL:            "https://example.ngrok.app",
+			Description:    "Created by the ngrok-operator",
+			Metadata:       `{"owned-by":"ngrok-operator"}`,
+			TrafficPolicy:  `{"on_http_request":[]}`,
+			Bindings:       []string{"public"},
+			PoolingEnabled: false,
+		}
+	}
+
+	baseSpec := func() ngrokv1alpha1.CloudEndpointSpec {
+		return ngrokv1alpha1.CloudEndpointSpec{
+			URL:            "https://example.ngrok.app",
+			Description:    "Created by the ngrok-operator",
+			Metadata:       `{"owned-by":"ngrok-operator"}`,
+			Bindings:       []string{"public"},
+			PoolingEnabled: new(false),
+		}
+	}
+
+	basePolicy := `{"on_http_request":[]}`
+
+	tests := []struct {
+		name     string
+		endpoint *ngrok.Endpoint
+		spec     ngrokv1alpha1.CloudEndpointSpec
+		policy   string
+		want     bool
+	}{
+		{
+			name:     "no update needed when everything matches",
+			endpoint: baseEndpoint(),
+			spec:     baseSpec(),
+			policy:   basePolicy,
+			want:     false,
+		},
+		{
+			name:     "update needed when URL changes",
+			endpoint: baseEndpoint(),
+			spec: func() ngrokv1alpha1.CloudEndpointSpec {
+				s := baseSpec()
+				s.URL = "https://other.ngrok.app"
+				return s
+			}(),
+			policy: basePolicy,
+			want:   true,
+		},
+		{
+			name:     "update needed when description changes",
+			endpoint: baseEndpoint(),
+			spec: func() ngrokv1alpha1.CloudEndpointSpec {
+				s := baseSpec()
+				s.Description = "new description"
+				return s
+			}(),
+			policy: basePolicy,
+			want:   true,
+		},
+		{
+			name:     "update needed when metadata changes",
+			endpoint: baseEndpoint(),
+			spec: func() ngrokv1alpha1.CloudEndpointSpec {
+				s := baseSpec()
+				s.Metadata = `{"owned-by":"someone-else"}`
+				return s
+			}(),
+			policy: basePolicy,
+			want:   true,
+		},
+		{
+			name:     "update needed when traffic policy changes",
+			endpoint: baseEndpoint(),
+			spec:     baseSpec(),
+			policy:   `{"on_http_request":[{"actions":[]}]}`,
+			want:     true,
+		},
+		{
+			name:     "update needed when bindings change",
+			endpoint: baseEndpoint(),
+			spec: func() ngrokv1alpha1.CloudEndpointSpec {
+				s := baseSpec()
+				s.Bindings = []string{"internal"}
+				return s
+			}(),
+			policy: basePolicy,
+			want:   true,
+		},
+		{
+			name:     "update needed when pooling enabled changes",
+			endpoint: baseEndpoint(),
+			spec: func() ngrokv1alpha1.CloudEndpointSpec {
+				s := baseSpec()
+				s.PoolingEnabled = new(true)
+				return s
+			}(),
+			policy: basePolicy,
+			want:   true,
+		},
+		{
+			name:     "nil pooling enabled in spec skips comparison",
+			endpoint: baseEndpoint(),
+			spec: func() ngrokv1alpha1.CloudEndpointSpec {
+				s := baseSpec()
+				s.PoolingEnabled = nil
+				return s
+			}(),
+			policy: basePolicy,
+			want:   false,
+		},
+		{
+			name: "nil and empty bindings are equal",
+			endpoint: func() *ngrok.Endpoint {
+				e := baseEndpoint()
+				e.Bindings = nil
+				return e
+			}(),
+			spec: func() ngrokv1alpha1.CloudEndpointSpec {
+				s := baseSpec()
+				s.Bindings = nil
+				return s
+			}(),
+			policy: basePolicy,
+			want:   false,
+		},
+		{
+			name: "empty slice and nil bindings are equal",
+			endpoint: func() *ngrok.Endpoint {
+				e := baseEndpoint()
+				e.Bindings = []string{}
+				return e
+			}(),
+			spec: func() ngrokv1alpha1.CloudEndpointSpec {
+				s := baseSpec()
+				s.Bindings = nil
+				return s
+			}(),
+			policy: basePolicy,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := endpointNeedsUpdate(tt.endpoint, tt.spec, tt.policy)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/controller/ngrok/suite_test.go
+++ b/internal/controller/ngrok/suite_test.go
@@ -55,6 +55,8 @@ var (
 
 	// Mock clients for testing
 	mockClientset *nmockapi.Clientset
+
+	kginkgo *testutils.KGinkgo
 )
 
 const (
@@ -94,6 +96,8 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	kginkgo = testutils.NewKGinkgo(k8sClient)
 
 	// Create mock clientset
 	mockClientset = nmockapi.NewClientset()

--- a/internal/mocks/nmockapi/base_client.go
+++ b/internal/mocks/nmockapi/base_client.go
@@ -21,6 +21,9 @@ type baseClient[T any] struct {
 	getError    error
 	updateError error
 	listError   error
+
+	// Call counters for testing
+	updateCallCount int
 }
 
 func newBase[T any](idPrefix string) baseClient[T] {
@@ -59,6 +62,7 @@ func (m *baseClient[T]) Delete(ctx context.Context, id string) error {
 // This is useful for resetting the state of the client between tests, without allocating a new client.
 func (m *baseClient[T]) Reset() {
 	m.items = make(map[string]T)
+	m.updateCallCount = 0
 }
 
 func (m *baseClient[T]) newID() string {
@@ -110,4 +114,14 @@ func (m *baseClient[T]) ClearErrors() {
 	m.getError = nil
 	m.updateError = nil
 	m.listError = nil
+}
+
+// UpdateCallCount returns the number of times Update has been called
+func (m *baseClient[T]) UpdateCallCount() int {
+	return m.updateCallCount
+}
+
+// ResetUpdateCallCount resets the update call counter to zero
+func (m *baseClient[T]) ResetUpdateCallCount() {
+	m.updateCallCount = 0
 }

--- a/internal/mocks/nmockapi/endpoints_client.go
+++ b/internal/mocks/nmockapi/endpoints_client.go
@@ -35,14 +35,16 @@ func (m *EndpointsClient) Create(_ context.Context, item *ngrok.EndpointCreate) 
 
 	id := m.newID()
 	newEndpoint := &ngrok.Endpoint{
-		Description:   ptr.Deref(item.Description, ""),
-		Metadata:      ptr.Deref(item.Metadata, ""),
-		ID:            id,
-		URL:           item.URL,
-		Type:          item.Type,
-		TrafficPolicy: item.TrafficPolicy,
-		CreatedAt:     m.createdAt(),
-		URI:           fmt.Sprintf("https://mock-api.ngrok.com/endpoints/%s", id),
+		Description:    ptr.Deref(item.Description, ""),
+		Metadata:       ptr.Deref(item.Metadata, ""),
+		ID:             id,
+		URL:            item.URL,
+		Type:           item.Type,
+		TrafficPolicy:  item.TrafficPolicy,
+		Bindings:       item.Bindings,
+		PoolingEnabled: ptr.Deref(item.PoolingEnabled, false),
+		CreatedAt:      m.createdAt(),
+		URI:            fmt.Sprintf("https://mock-api.ngrok.com/endpoints/%s", id),
 	}
 
 	m.items[id] = newEndpoint
@@ -50,6 +52,7 @@ func (m *EndpointsClient) Create(_ context.Context, item *ngrok.EndpointCreate) 
 }
 
 func (m *EndpointsClient) Update(ctx context.Context, item *ngrok.EndpointUpdate) (*ngrok.Endpoint, error) {
+	m.updateCallCount++
 	if m.updateError != nil {
 		return nil, m.updateError
 	}
@@ -70,6 +73,12 @@ func (m *EndpointsClient) Update(ctx context.Context, item *ngrok.EndpointUpdate
 	}
 	if item.TrafficPolicy != nil {
 		existingItem.TrafficPolicy = *item.TrafficPolicy
+	}
+	if item.Bindings != nil {
+		existingItem.Bindings = item.Bindings
+	}
+	if item.PoolingEnabled != nil {
+		existingItem.PoolingEnabled = *item.PoolingEnabled
 	}
 
 	m.items[item.ID] = existingItem


### PR DESCRIPTION

## What

The update path unconditionally called the ngrok API to update the endpoint on every reconciliation, even when nothing had changed. This was most visible when a domain was not ready: the controller requeues every 10 seconds, generating unnecessary API write calls for the lifetime of the unready domain.


## How

Fetch the current endpoint via Get before issuing an Update and compare the API state against the desired spec. The Update call is now skipped entirely when the endpoint already matches. This also moves the not-found detection from after Update to after Get, catching missing endpoints earlier.

## Breaking Changes

No