### PR TITLE
Release helm chart 0.23.0-rc.2

### DIFF
--- a/helm/ngrok-operator/CHANGELOG.md
+++ b/helm/ngrok-operator/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the helm chart will be documented in this file. Please se
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.23.0-rc.2
+**Full Changelog**: https://github.com/ngrok/ngrok-operator/compare/helm-chart-ngrok-operator-0.23.0-rc.1...helm-chart-ngrok-operator-0.23.0-rc.2
+
+- Update Helm chart version to `0.23.0-rc.2`
+
+### Fixed
+- Grant `events.k8s.io` events permissions to the agent, api-manager, and bindings-forwarder roles. The new controller-runtime `GetEventRecorder` API writes to the `events.k8s.io` API group, which the RBAC overhaul did not cover.
+
 ## 0.23.0-rc.1
 **Full Changelog**: https://github.com/ngrok/ngrok-operator/compare/helm-chart-ngrok-operator-0.22.2...helm-chart-ngrok-operator-0.23.0-rc.1
 

--- a/helm/ngrok-operator/Chart.yaml
+++ b/helm/ngrok-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ngrok-operator
 description: The official ngrok Kubernetes Operator.
-version: 0.23.0-rc.1
+version: 0.23.0-rc.2
 appVersion: 0.21.0-rc.1
 keywords:
   - ngrok

--- a/helm/ngrok-operator/templates/agent/role.yaml
+++ b/helm/ngrok-operator/templates/agent/role.yaml
@@ -19,6 +19,14 @@ rules:
   - create
   - patch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - ""
   resources:
   - secrets

--- a/helm/ngrok-operator/templates/api-manager/role.yaml
+++ b/helm/ngrok-operator/templates/api-manager/role.yaml
@@ -31,6 +31,14 @@ rules:
   - create
   - patch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - ""
   resources:
   - secrets

--- a/helm/ngrok-operator/templates/bindings-forwarder/role.yaml
+++ b/helm/ngrok-operator/templates/bindings-forwarder/role.yaml
@@ -13,6 +13,14 @@ rules:
   - create
   - patch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - ""
   resources:
   - secrets

--- a/helm/ngrok-operator/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -10,7 +10,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: ngrok
     spec:
       controller: k8s.ngrok.com/ingress-controller

--- a/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/deployment_test.yaml.snap
@@ -4,7 +4,7 @@ Should match snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/rbac: bd0eb0e29988bae5a2d5fb6e38463bf1a0c18109b9e510e1155a3f78c28b3a7f
+        checksum/rbac: 7ad5685f36276669f1d58bba694549ec85c1bfec764282ab94079943fba927e7
       labels:
         app.kubernetes.io/component: agent
         app.kubernetes.io/instance: RELEASE-NAME
@@ -12,7 +12,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-agent
       namespace: NAMESPACE
     spec:
@@ -27,7 +27,7 @@ Should match snapshot:
       template:
         metadata:
           annotations:
-            checksum/rbac: bd0eb0e29988bae5a2d5fb6e38463bf1a0c18109b9e510e1155a3f78c28b3a7f
+            checksum/rbac: 7ad5685f36276669f1d58bba694549ec85c1bfec764282ab94079943fba927e7
             prometheus.io/path: /metrics
             prometheus.io/port: "8080"
             prometheus.io/scrape: "true"
@@ -113,6 +113,14 @@ Should match snapshot:
         verbs:
           - create
           - patch
+      - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
       - apiGroups:
           - ""
         resources:

--- a/helm/ngrok-operator/tests/agent/__snapshot__/rbac_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/rbac_test.yaml.snap
@@ -42,6 +42,14 @@ should match snapshot in default mode:
           - create
           - patch
       - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
+      - apiGroups:
           - ""
         resources:
           - secrets
@@ -151,6 +159,14 @@ should match snapshot in namespaced mode:
         verbs:
           - create
           - patch
+      - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
       - apiGroups:
           - ""
         resources:

--- a/helm/ngrok-operator/tests/agent/__snapshot__/serviceaccount_test.yaml.snap
+++ b/helm/ngrok-operator/tests/agent/__snapshot__/serviceaccount_test.yaml.snap
@@ -10,6 +10,6 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: test-release-ngrok-operator-agent
       namespace: test-namespace

--- a/helm/ngrok-operator/tests/api-manager/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/api-manager/__snapshot__/deployment_test.yaml.snap
@@ -4,7 +4,7 @@ Should match all-options snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/controller-role: 1ff679f46694c76aaa92fa4bb95702cac95184fe57af4f7df91d3f846f01d355
+        checksum/controller-role: 18de8d67bbc1881a800608b62cea791017495436ba47c64ee35572a56aa1c77f
         checksum/rbac: 133c53d32600d926996f00745a08c48b776ffd5eb0a899e65f9bc0326702d9c0
       labels:
         app.kubernetes.io/component: controller
@@ -13,7 +13,7 @@ Should match all-options snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-manager
       namespace: NAMESPACE
     spec:
@@ -26,7 +26,7 @@ Should match all-options snapshot:
       template:
         metadata:
           annotations:
-            checksum/controller-role: 1ff679f46694c76aaa92fa4bb95702cac95184fe57af4f7df91d3f846f01d355
+            checksum/controller-role: 18de8d67bbc1881a800608b62cea791017495436ba47c64ee35572a56aa1c77f
             checksum/rbac: 133c53d32600d926996f00745a08c48b776ffd5eb0a899e65f9bc0326702d9c0
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
             prometheus.io/path: /metrics
@@ -195,6 +195,14 @@ Should match all-options snapshot:
         verbs:
           - create
           - patch
+      - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
       - apiGroups:
           - ""
         resources:
@@ -555,7 +563,7 @@ Should match default snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/controller-role: 1ff679f46694c76aaa92fa4bb95702cac95184fe57af4f7df91d3f846f01d355
+        checksum/controller-role: 18de8d67bbc1881a800608b62cea791017495436ba47c64ee35572a56aa1c77f
         checksum/rbac: 133c53d32600d926996f00745a08c48b776ffd5eb0a899e65f9bc0326702d9c0
       labels:
         app.kubernetes.io/component: controller
@@ -564,7 +572,7 @@ Should match default snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-manager
       namespace: NAMESPACE
     spec:
@@ -577,7 +585,7 @@ Should match default snapshot:
       template:
         metadata:
           annotations:
-            checksum/controller-role: 1ff679f46694c76aaa92fa4bb95702cac95184fe57af4f7df91d3f846f01d355
+            checksum/controller-role: 18de8d67bbc1881a800608b62cea791017495436ba47c64ee35572a56aa1c77f
             checksum/rbac: 133c53d32600d926996f00745a08c48b776ffd5eb0a899e65f9bc0326702d9c0
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
             prometheus.io/path: /metrics
@@ -733,6 +741,14 @@ Should match default snapshot:
         verbs:
           - create
           - patch
+      - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
       - apiGroups:
           - ""
         resources:

--- a/helm/ngrok-operator/tests/api-manager/__snapshot__/pdb_test.yaml.snap
+++ b/helm/ngrok-operator/tests/api-manager/__snapshot__/pdb_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: test-release-ngrok-operator-controller-pdb
       namespace: test-namespace
     spec:

--- a/helm/ngrok-operator/tests/api-manager/__snapshot__/rbac_test.yaml.snap
+++ b/helm/ngrok-operator/tests/api-manager/__snapshot__/rbac_test.yaml.snap
@@ -25,6 +25,14 @@ should match snapshot in default mode:
           - create
           - patch
       - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
+      - apiGroups:
           - ""
         resources:
           - secrets
@@ -418,6 +426,14 @@ should match snapshot in namespaced mode:
         verbs:
           - create
           - patch
+      - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
       - apiGroups:
           - ""
         resources:

--- a/helm/ngrok-operator/tests/api-manager/__snapshot__/serviceaccount_test.yaml.snap
+++ b/helm/ngrok-operator/tests/api-manager/__snapshot__/serviceaccount_test.yaml.snap
@@ -10,6 +10,6 @@ Should match the snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: test-release-ngrok-operator
       namespace: test-namespace

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/deployment_test.yaml.snap
@@ -4,7 +4,7 @@ Should match snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/rbac: 78d86b8df7cf34afbde6a5e0649fdf64a209c1475379c8325f660a0377ceeefd
+        checksum/rbac: 2b5a37e7ad063bb138ca1acc4a11ca0da8991d66311c333da4b2bba7584535fe
       labels:
         app.kubernetes.io/component: bindings-forwarder
         app.kubernetes.io/instance: RELEASE-NAME
@@ -12,7 +12,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-bindings-forwarder
       namespace: NAMESPACE
     spec:
@@ -27,7 +27,7 @@ Should match snapshot:
       template:
         metadata:
           annotations:
-            checksum/rbac: 78d86b8df7cf34afbde6a5e0649fdf64a209c1475379c8325f660a0377ceeefd
+            checksum/rbac: 2b5a37e7ad063bb138ca1acc4a11ca0da8991d66311c333da4b2bba7584535fe
             prometheus.io/path: /metrics
             prometheus.io/port: "8080"
             prometheus.io/scrape: "true"

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/rbac_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/rbac_test.yaml.snap
@@ -14,6 +14,14 @@ Should match snapshot:
           - create
           - patch
       - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
+      - apiGroups:
           - ""
         resources:
           - secrets

--- a/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/serviceaccount_test.yaml.snap
+++ b/helm/ngrok-operator/tests/bindings-forwarder/__snapshot__/serviceaccount_test.yaml.snap
@@ -10,6 +10,6 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: test-release-ngrok-operator-bindings-forwarder
       namespace: test-namespace

--- a/helm/ngrok-operator/tests/rbac/__snapshot__/crd-access_test.yaml.snap
+++ b/helm/ngrok-operator/tests/rbac/__snapshot__/crd-access_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-agentendpoint-editor-role
     rules:
       - apiGroups:
@@ -42,7 +42,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-agentendpoint-viewer-role
     rules:
       - apiGroups:
@@ -70,7 +70,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-boundendpoint-editor-role
     rules:
       - apiGroups:
@@ -102,7 +102,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-boundendpoint-viewer-role
     rules:
       - apiGroups:
@@ -130,7 +130,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-cloudendpoint-editor-role
     rules:
       - apiGroups:
@@ -162,7 +162,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-cloudendpoint-viewer-role
     rules:
       - apiGroups:
@@ -190,7 +190,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-domain-editor-role
     rules:
       - apiGroups:
@@ -222,7 +222,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-domain-viewer-role
     rules:
       - apiGroups:
@@ -250,7 +250,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-ippolicy-editor-role
     rules:
       - apiGroups:
@@ -282,7 +282,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-ippolicy-viewer-role
     rules:
       - apiGroups:
@@ -310,7 +310,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-kubernetesoperator-editor-role
     rules:
       - apiGroups:
@@ -342,7 +342,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-kubernetesoperator-viewer-role
     rules:
       - apiGroups:
@@ -370,7 +370,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-ngroktrafficpolicy-editor-role
     rules:
       - apiGroups:
@@ -402,7 +402,7 @@ should match snapshot with defaults:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/part-of: ngrok-operator
         app.kubernetes.io/version: 0.21.0-rc.1
-        helm.sh/chart: ngrok-operator-0.23.0-rc.1
+        helm.sh/chart: ngrok-operator-0.23.0-rc.2
       name: RELEASE-NAME-ngrok-operator-ngroktrafficpolicy-viewer-role
     rules:
       - apiGroups:

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ngrok-operator-agent
   namespace: ngrok-operator
   labels:
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -21,7 +21,7 @@ metadata:
   name: ngrok-operator
   namespace: ngrok-operator
   labels:
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -1576,6 +1576,14 @@ rules:
   - create
   - patch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - ""
   resources:
   - secrets
@@ -1734,6 +1742,14 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -2110,7 +2126,7 @@ metadata:
   name: ngrok-operator-agentendpoint-editor-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2143,7 +2159,7 @@ metadata:
   name: ngrok-operator-agentendpoint-viewer-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2172,7 +2188,7 @@ metadata:
   name: ngrok-operator-boundendpoint-editor-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2205,7 +2221,7 @@ metadata:
   name: ngrok-operator-boundendpoint-viewer-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2234,7 +2250,7 @@ metadata:
   name: ngrok-operator-cloudendpoint-editor-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2267,7 +2283,7 @@ metadata:
   name: ngrok-operator-cloudendpoint-viewer-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2296,7 +2312,7 @@ metadata:
   name: ngrok-operator-domain-editor-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2329,7 +2345,7 @@ metadata:
   name: ngrok-operator-domain-viewer-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2358,7 +2374,7 @@ metadata:
   name: ngrok-operator-ippolicy-editor-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2391,7 +2407,7 @@ metadata:
   name: ngrok-operator-ippolicy-viewer-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2420,7 +2436,7 @@ metadata:
   name: ngrok-operator-kubernetesoperator-editor-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2453,7 +2469,7 @@ metadata:
   name: ngrok-operator-kubernetesoperator-viewer-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2482,7 +2498,7 @@ metadata:
   name: ngrok-operator-ngroktrafficpolicy-editor-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2515,7 +2531,7 @@ metadata:
   name: ngrok-operator-ngroktrafficpolicy-viewer-role
   labels:
     app.kubernetes.io/component: rbac
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2753,7 +2769,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2763,7 +2779,7 @@ metadata:
   name: ngrok-operator-agent
   namespace: ngrok-operator
   annotations:
-    checksum/rbac: 0e1543232056c2853f293a4dcb95f2f1097e41914036be3e6641b7bcfe4d1977
+    checksum/rbac: 73ae2719b31e64e50841b665bdd7334f4c809be84fa8e759f6b2ae62eae98092
 spec:
   replicas: 1
   strategy:
@@ -2779,7 +2795,7 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: '8080'
         prometheus.io/scrape: 'true'
-        checksum/rbac: 0e1543232056c2853f293a4dcb95f2f1097e41914036be3e6641b7bcfe4d1977
+        checksum/rbac: 73ae2719b31e64e50841b665bdd7334f4c809be84fa8e759f6b2ae62eae98092
       labels:
         app.kubernetes.io/name: ngrok-operator
         app.kubernetes.io/instance: ngrok-operator
@@ -2858,7 +2874,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2868,7 +2884,7 @@ metadata:
   name: ngrok-operator-manager
   namespace: ngrok-operator
   annotations:
-    checksum/controller-role: 03c71c28e1a1bd7fe3fe3b77946b6e437280101a8ba6d4a2d19c1ee1c316afc7
+    checksum/controller-role: f40b5f0c128c0618a357d8547b09cbdb40218194f924dbab8e402e98c8d87de7
     checksum/rbac: 3c010fd2cf6a534cc29d1483b4abeb16710dfc185eded3d7ac57e5c3289e4ea2
 spec:
   replicas: 1
@@ -2883,7 +2899,7 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: '8080'
         prometheus.io/scrape: 'true'
-        checksum/controller-role: 03c71c28e1a1bd7fe3fe3b77946b6e437280101a8ba6d4a2d19c1ee1c316afc7
+        checksum/controller-role: f40b5f0c128c0618a357d8547b09cbdb40218194f924dbab8e402e98c8d87de7
         checksum/rbac: 3c010fd2cf6a534cc29d1483b4abeb16710dfc185eded3d7ac57e5c3289e4ea2
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:
@@ -2968,7 +2984,7 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -2986,7 +3002,7 @@ metadata:
   name: ngrok-operator-cleanup
   namespace: ngrok-operator
   labels:
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -3004,7 +3020,7 @@ metadata:
   name: ngrok-operator-cleanup
   namespace: ngrok-operator
   labels:
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -3032,7 +3048,7 @@ metadata:
   name: ngrok-operator-cleanup
   namespace: ngrok-operator
   labels:
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"
@@ -3058,7 +3074,7 @@ metadata:
   name: ngrok-operator-cleanup
   namespace: ngrok-operator
   labels:
-    helm.sh/chart: ngrok-operator-0.23.0-rc.1
+    helm.sh/chart: ngrok-operator-0.23.0-rc.2
     app.kubernetes.io/name: ngrok-operator
     app.kubernetes.io/instance: ngrok-operator
     app.kubernetes.io/version: "0.21.0-rc.1"


### PR DESCRIPTION
## What
The 0.23.0-rc.1 RBAC overhaul granted the operator's service accounts permission to create `events` in the core (`""`) API group, but controller-runtime v0.23's `mgr.GetEventRecorder(...)` API (used throughout the agent, api-manager, and bindings-forwarder) writes to the **`events.k8s.io`** API group instead.

  Deployed operators are logging:

```
events.events.k8s.io is forbidden: User "system:serviceaccount:ngrok-operator:ngrok-operator-agent" cannot create resource "events" in API group "events.k8s.io"
```
  
## How
- Add `events.k8s.io` `events` rules (`create`, `patch`, `update`) to the agent, api-manager, and bindings-forwarder Role/ClusterRole templates. The existing core `""` events rule stays because the new `client-go/tools/events` broadcaster keeps a legacy core broadcaster alongside the events.k8s.io one.
- Bump `helm/ngrok-operator/Chart.yaml` to `0.23.0-rc.2` (appVersion unchanged — chart-only fix).
- Add a `0.23.0-rc.2` entry to the chart `CHANGELOG.md`.
- Regenerate `manifest-bundle.yaml` and helm unittest snapshots.

## Breaking Changes
None. This is a chart-only patch on top of `0.23.0-rc.1` that grants strictly *additional* RBAC needed for event recording to function.
