### PR TITLE
fix(bindings): Skip unparseable endpoints in BoundEndpoint poller

### DIFF
--- a/internal/controller/bindings/boundendpoint_poller.go
+++ b/internal/controller/bindings/boundendpoint_poller.go
@@ -225,9 +225,13 @@ func (r *BoundEndpointPoller) reconcileBoundEndpointsFromAPI(ctx context.Context
 		return err
 	}
 
-	desiredBoundEndpoints, err := ngrokapi.AggregateBindingEndpoints(apiBindingEndpoints)
+	// Aggregate the endpoints we got from the API. Endpoints whose hostport
+	// cannot be parsed are skipped and the aggregator returns a joined error
+	// describing those failures; we log it but continue reconciling the valid
+	// endpoints so a single malformed entry can't stall the entire poll cycle.
+	desiredBoundEndpoints, err := ngrokapi.AggregateBindingEndpoints(ctx, apiBindingEndpoints)
 	if err != nil {
-		return err
+		log.Error(err, "Some binding_endpoints failed to parse; continuing with valid ones")
 	}
 
 	// Get all current BoundEndpoint resources in the cluster.

--- a/internal/ngrokapi/bindingendpoint_aggregator.go
+++ b/internal/ngrokapi/bindingendpoint_aggregator.go
@@ -1,6 +1,7 @@
 package ngrokapi
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/ngrok/ngrok-api-go/v7"
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var (
@@ -25,14 +27,24 @@ type AggregatedEndpoints map[string]bindingsv1alpha1.BoundEndpoint
 
 // AggregateBindingEndpoints aggregates the endpoints into a map of hostport to BindingEndpoint
 // by parsing the hostport 4-tuple into each piece ([<scheme>://]<service>.<namespcace>[:<port>])
-// and collecting together matching endpoints into a single BindingEndpoint
-func AggregateBindingEndpoints(endpoints []ngrok.Endpoint) (AggregatedEndpoints, error) {
+// and collecting together matching endpoints into a single BindingEndpoint.
+//
+// Endpoints whose hostport cannot be parsed (e.g. hostnames that do not match
+// the <service>.<namespace> format) are skipped and logged, and their errors
+// are joined into the returned error so callers can surface them without
+// losing the valid endpoints from the same batch.
+func AggregateBindingEndpoints(ctx context.Context, endpoints []ngrok.Endpoint) (AggregatedEndpoints, error) {
+	log := ctrl.LoggerFrom(ctx)
 	aggregated := make(AggregatedEndpoints)
+	var parseErrs []error
 
 	for _, endpoint := range endpoints {
 		parsed, err := parseHostport(endpoint.Proto, endpoint.PublicURL)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse endpoint: %s: %w", endpoint.ID, err)
+			wrapped := fmt.Errorf("failed to parse endpoint: %s: %w", endpoint.ID, err)
+			log.Error(wrapped, "Skipping unparseable binding_endpoint", "id", endpoint.ID, "publicURL", endpoint.PublicURL, "proto", endpoint.Proto)
+			parseErrs = append(parseErrs, wrapped)
+			continue
 		}
 
 		endpointURL := parsed.String()
@@ -73,7 +85,7 @@ func AggregateBindingEndpoints(endpoints []ngrok.Endpoint) (AggregatedEndpoints,
 		aggregated[endpointURL] = bindingEndpoint
 	}
 
-	return aggregated, nil
+	return aggregated, errors.Join(parseErrs...)
 }
 
 // parsedHostport is a struct to hold the parsed bits

--- a/internal/ngrokapi/bindingendpoint_aggregator_test.go
+++ b/internal/ngrokapi/bindingendpoint_aggregator_test.go
@@ -1,6 +1,7 @@
 package ngrokapi
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,6 +83,50 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			// Regression test: a single endpoint whose hostname does not match
+			// the <service>.<namespace> format (here a 3-label hostname) must
+			// not abort the aggregation — valid endpoints in the same batch
+			// must still be returned, and the parse failure must be reported
+			// in the returned error.
+			name: "skips-unparseable-and-keeps-valid",
+			endpoints: []ngrok.Endpoint{
+				{ID: "ep_bad1", PublicURL: "https://controller.example.com"},
+				{ID: "ep_good", PublicURL: "https://service1.namespace1"},
+				{ID: "ep_bad2", PublicURL: "https://just-one-label"},
+			},
+			want: AggregatedEndpoints{
+				"https://service1.namespace1:443": {
+					Spec: bindingsv1alpha1.BoundEndpointSpec{
+						EndpointURL: "https://service1.namespace1:443",
+						Scheme:      "https",
+						Target: bindingsv1alpha1.EndpointTarget{
+							Service:   "service1",
+							Namespace: "namespace1",
+							Port:      443,
+							Protocol:  "TCP",
+						},
+					},
+					Status: bindingsv1alpha1.BoundEndpointStatus{
+						Endpoints: []bindingsv1alpha1.BindingEndpoint{
+							{Ref: ngrok.Ref{ID: "ep_good"}},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			// When every endpoint is unparseable we should get an empty
+			// aggregation plus a non-nil error, not a nil map.
+			name: "all-unparseable",
+			endpoints: []ngrok.Endpoint{
+				{ID: "ep_bad1", PublicURL: "https://controller.example.com"},
+				{ID: "ep_bad2", PublicURL: "https://a.b.c.d"},
+			},
+			want:    AggregatedEndpoints{},
+			wantErr: true,
 		},
 		{
 			name: "full",
@@ -176,12 +221,14 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 			t.Parallel()
 			assert := assert.New(t)
 
-			got, err := AggregateBindingEndpoints(test.endpoints)
+			got, err := AggregateBindingEndpoints(context.Background(), test.endpoints)
 			if test.wantErr {
 				assert.Error(err)
-				return
+			} else {
+				assert.NoError(err)
 			}
-			assert.NoError(err)
+			// Even on partial failure we still expect the valid endpoints
+			// to be aggregated, so compare the map unconditionally.
 			assert.Equal(test.want, got)
 		})
 	}


### PR DESCRIPTION
## What

Previously a single endpoint whose hostname did not match the <service>.<namespace> format (e.g. controller.example.com or *.private.com) caused AggregateBindingEndpoints to return an error, which the poller treated as fatal, aborting the entire poll cycle and preventing any valid BoundEndpoints from being created or updated.

## How

The aggregator now logs each parse failure, collects them via errors.Join, and continues processing the remaining endpoints. The poller logs the joined error but no longer returns, so valid endpoints in the same batch are still reconciled.


## Breaking Changes
No