### PR TITLE
Alex/migrate ingress class r1

### DIFF
--- a/cmd/api-manager.go
+++ b/cmd/api-manager.go
@@ -155,8 +155,7 @@ func apiCmd() *cobra.Command {
 	c.Flags().StringVar(&opts.region, "region", "", "The region to use for ngrok tunnels")
 	c.Flags().StringVar(&opts.serverAddr, "server-addr", "", "The address of the ngrok server to use for tunnels")
 	c.Flags().StringVar(&opts.apiURL, "api-url", "", "The base URL to use for the ngrok api")
-	// TODO(operator-rename): This probably needs to be on a per controller basis. Each of the controllers will have their own value or we migrate this to k8s.ngrok.com/ngrok-operator.
-	c.Flags().StringVar(&opts.ingressControllerName, "ingress-controller-name", "k8s.ngrok.com/ingress-controller", "The name of the controller to use for matching ingresses classes")
+	c.Flags().StringVar(&opts.ingressControllerName, "ingress-controller-name", "ngrok.com/ingress-controller", "The name of the controller to use for matching ingresses classes")
 	c.Flags().StringVar(&opts.ingressWatchNamespace, "ingress-watch-namespace", "", "Namespace to watch for Kubernetes Ingress resources. Defaults to all namespaces.")
 	// TODO(operator-rename): Same as above, but for the manager name.
 	c.Flags().StringVar(&opts.managerName, "manager-name", "ngrok-ingress-controller-manager", "Manager name to identify unique ngrok ingress controller instances")

--- a/docs/developer-guide/passivity-shims.md
+++ b/docs/developer-guide/passivity-shims.md
@@ -66,7 +66,13 @@ rather than archaeology.
 - **Pattern:** Helm-rendered manifest deferred to cleanup release.
 - **R1 (0.24):**
   - Operator binary: `internal/store/store.go::ListNgrokIngressClassesV1`
-    dual-matches when `controllerName` equals the new default.
+    dual-matches whenever `controllerName` equals either stock default
+    (legacy `k8s.ngrok.com/ingress-controller` or new
+    `ngrok.com/ingress-controller`). Custom controller names retain
+    exact-match for multi-instance isolation. The Go code cannot
+    distinguish "default" from "explicitly set to the default value",
+    so both stock defaults are treated symmetrically; nobody sets the
+    legacy default explicitly to mean "exact-match legacy only".
   - CLI flag default in `cmd/api-manager.go` flips to the new prefix.
   - Helm chart **stays on legacy**: `helm/ngrok-operator/values.yaml`
     `ingress.controllerName` remains `k8s.ngrok.com/ingress-controller`;

--- a/docs/developer-guide/passivity-shims.md
+++ b/docs/developer-guide/passivity-shims.md
@@ -1,0 +1,79 @@
+# Passivity shims and migration strategy
+
+This document is for ngrok-operator maintainers. It describes how we stage
+backwards-incompatible changes across multiple releases using **passivity
+shims** — small pieces of read-side and/or write-side compatibility code
+that let an older operator coexist with a newer one during rolling
+upgrades and (where possible) survive a `helm rollback`. The user-facing
+counterpart that lists what each release means for users is
+[`docs/v1-migration-guide.md`](../v1-migration-guide.md).
+
+## Why we need shims
+
+A `helm upgrade` (and a rolling `kubectl apply`) does not atomically swap
+the operator. For a window of seconds to minutes:
+
+1. The new manifest (with a new IngressClass `spec.controller`, new label
+   selectors expected on AEPs/CEPs, etc.) has been applied.
+2. The **old** operator pod is still running, watching, and reconciling.
+3. The new operator pod is starting up.
+
+During that window the old operator can interpret newly-written objects in
+ways that destroy resources or stall finalizers, unless we constrain *what
+the new operator writes* during the migration release.
+
+Rollbacks are worse: a `helm rollback` returns the cluster to the prior
+operator image but leaves objects in whatever state the newer operator
+stamped them. Anything the newer operator wrote that the older release
+doesn't understand becomes a hazard.
+
+## Deferral for rollout races
+
+Some changes are safe to ship in the operator binary but unsafe to ship in
+the rendered helm chart at the same time, because the rendered manifest
+takes effect mid-upgrade while the old operator pod is still running.
+The IngressClass `spec.controller` flip is the only example so far. The
+operator binary gains dual-match in R1; the rendered manifest stays on the
+legacy value until R2.
+
+## The `LEGACY-PREFIX-MIGRATION` sentinel
+
+Every code site that exists *only* to support the legacy prefix during a
+migration window carries the marker `LEGACY-PREFIX-MIGRATION`. Two forms:
+
+```go
+// LEGACY-PREFIX-MIGRATION: BEGIN
+// ... block to delete ...
+// LEGACY-PREFIX-MIGRATION: END
+
+someLegacyCall(...) // LEGACY-PREFIX-MIGRATION: drop in 1.0
+```
+
+In the cleanup release for each migration, run:
+
+```sh
+git grep 'LEGACY-PREFIX-MIGRATION'
+```
+
+For each hit, delete the block between `BEGIN` / `END` or delete the
+marked line. The sentinel exists so cleanup is a single, auditable sweep
+rather than archaeology.
+
+## Per-shim catalog: `k8s.ngrok.com/` → `ngrok.com/` migration
+
+### IngressClass `spec.controller` (rollout-race deferral)
+
+- **Pattern:** Helm-rendered manifest deferred to cleanup release.
+- **R1 (0.24):**
+  - Operator binary: `internal/store/store.go::ListNgrokIngressClassesV1`
+    dual-matches when `controllerName` equals the new default.
+  - CLI flag default in `cmd/api-manager.go` flips to the new prefix.
+  - Helm chart **stays on legacy**: `helm/ngrok-operator/values.yaml`
+    `ingress.controllerName` remains `k8s.ngrok.com/ingress-controller`;
+    `values.schema.json` default matches; `README.md` table matches;
+    `tests/__snapshot__/ingress-class_test.yaml.snap` shows the legacy
+    controller. The helm `CHANGELOG.md` notes that the *default will
+    change in 0.25*, not that it does now.
+- **R2 (0.25):** flip the helm-rendered IngressClass to the new prefix.
+  At this point no pre-migration operator pod can observe the change.
+- **R3 cleanup:** drop the dual-match branch in `store.go`.

--- a/docs/v1-migration-guide.md
+++ b/docs/v1-migration-guide.md
@@ -1,0 +1,67 @@
+# ngrok-operator v1 migration guide
+
+This guide tracks the backwards-incompatible changes the ngrok-operator is
+making on the path to 1.0. Each migration is staged across multiple releases
+so existing manifests and running deployments keep working during the
+transition window. Migrate during the release noted under "Action required";
+read-side compatibility code is removed in the listed cleanup release.
+
+If you are an operator maintainer auditing the read-side / write-side shims
+that implement these transitions, see
+[`docs/developer-guide/passivity-shims.md`](./developer-guide/passivity-shims.md).
+
+## Migrations
+
+### IngressClass `spec.controller`: `k8s.ngrok.com/ingress-controller` → `ngrok.com/ingress-controller`
+
+Status: in progress across 0.24 → 0.25.
+
+The operator binary's default `--ingress-controller-name` flips to
+`ngrok.com/ingress-controller` in 0.24. To keep existing IngressClasses
+matching during the transition, the operator dual-matches both
+`k8s.ngrok.com/ingress-controller` and `ngrok.com/ingress-controller`
+whenever its configured `controllerName` is the new default. Custom
+controller names retain exact-match behavior so multi-instance isolation is
+preserved.
+
+The helm chart deliberately **does not** flip the rendered IngressClass
+`spec.controller` in 0.24. A `helm upgrade` applies the new manifest while
+the previous operator pod is still running — flipping the rendered value
+at the same time as the operator image would briefly leave the
+pre-migration operator unable to match its own IngressClass. The helm
+chart's rendered controller value stays on `k8s.ngrok.com/ingress-controller`
+through 0.24 and flips to `ngrok.com/ingress-controller` in 0.25, by which
+point no pre-migration operator pod can be running.
+
+#### What changes for you
+
+| Legacy                                  | New                                |
+| --------------------------------------- | ---------------------------------- |
+| `k8s.ngrok.com/ingress-controller`      | `ngrok.com/ingress-controller`     |
+
+If you author your own IngressClass manifests, you can adopt the new value
+any time in 0.24 — both work. If you rely on the helm-rendered
+IngressClass, no action is required; the chart manages the transition for
+you.
+
+#### Action required, by release
+
+| Release | Operator binary default | Helm-rendered IngressClass | What you do |
+| ------- | ----------------------- | -------------------------- | ----------- |
+| 0.24 (this) | `ngrok.com/ingress-controller`, dual-matches legacy | `k8s.ngrok.com/ingress-controller` (unchanged) | Nothing required. |
+| 0.25 | `ngrok.com/ingress-controller`, dual-matches legacy | `ngrok.com/ingress-controller` | Nothing required if you use the helm chart. |
+| 0.26 | `ngrok.com/ingress-controller`, exact-match | `ngrok.com/ingress-controller` | Confirm no `k8s.ngrok.com/ingress-controller` IngressClasses remain in self-authored manifests. |
+
+#### Supported upgrade path
+
+`previous-stable → 0.24 → 0.25 → 0.26`. Skipping 0.24 is unsupported
+because the rendered IngressClass and the operator's controller name flip
+together without an intermediate dual-match release.
+
+## What did *not* change in this set of migrations
+
+The CRD API groups (`ingress.k8s.ngrok.com/v1alpha1`,
+`ngrok.k8s.ngrok.com/v1alpha1`, `bindings.k8s.ngrok.com/v1alpha1`) are
+**unchanged**. A separate 1.0 workstream will consolidate these into
+`ngrok.com/v1` with a conversion webhook; that migration will appear here
+when it begins.

--- a/docs/v1-migration-guide.md
+++ b/docs/v1-migration-guide.md
@@ -20,8 +20,10 @@ The operator binary's default `--ingress-controller-name` flips to
 `ngrok.com/ingress-controller` in 0.24. To keep existing IngressClasses
 matching during the transition, the operator dual-matches both
 `k8s.ngrok.com/ingress-controller` and `ngrok.com/ingress-controller`
-whenever its configured `controllerName` is the new default. Custom
-controller names retain exact-match behavior so multi-instance isolation is
+whenever its configured `controllerName` equals either of those two stock
+defaults — which is the case for both the new binary default and the
+legacy value still rendered by the helm chart in 0.24. Custom controller
+names retain exact-match behavior so multi-instance isolation is
 preserved.
 
 The helm chart deliberately **does not** flip the rendered IngressClass

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -224,13 +224,33 @@ func (s Store) ListIngressClassesV1() []*netv1.IngressClass {
 	return genericListSorted[netv1.IngressClass](s.log, s.stores.IngressClassV1)
 }
 
-// ListNgrokIngressClassesV1 returns the list of Ingresses in the Ingress v1 store filtered
-// by ones that match the controllerName
+const defaultIngressControllerName = "ngrok.com/ingress-controller"
+
+// LEGACY-PREFIX-MIGRATION: BEGIN
+// legacyDefaultIngressControllerName is matched as a one-release migration
+// affordance when the operator runs on the new helm default — IngressClasses
+// stamped with the legacy controller string by previous releases still get
+// picked up. Delete this const and the `if s.controllerName == ...` branch
+// in ListNgrokIngressClassesV1 in the release immediately before 1.0.
+const legacyDefaultIngressControllerName = "k8s.ngrok.com/ingress-controller"
+
+// LEGACY-PREFIX-MIGRATION: END
+
+// ListNgrokIngressClassesV1 returns IngressClasses whose spec.controller
+// matches the configured controller name. Custom controller names get
+// exact-match behavior — they do not silently pull in default-named
+// IngressClasses, which would break multi-instance isolation.
 func (s Store) ListNgrokIngressClassesV1() []*netv1.IngressClass {
+	accepted := map[string]bool{s.controllerName: true}
+	// LEGACY-PREFIX-MIGRATION: drop this branch in 1.0
+	if s.controllerName == defaultIngressControllerName {
+		accepted[legacyDefaultIngressControllerName] = true
+	}
+
 	filteredClasses := []*netv1.IngressClass{}
 	classes := s.ListIngressClassesV1()
 	for _, class := range classes {
-		if class.Spec.Controller == s.controllerName {
+		if accepted[class.Spec.Controller] {
 			filteredClasses = append(filteredClasses, class)
 		}
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -228,10 +228,12 @@ const defaultIngressControllerName = "ngrok.com/ingress-controller"
 
 // LEGACY-PREFIX-MIGRATION: BEGIN
 // legacyDefaultIngressControllerName is matched as a one-release migration
-// affordance when the operator runs on the new helm default — IngressClasses
-// stamped with the legacy controller string by previous releases still get
-// picked up. Delete this const and the `if s.controllerName == ...` branch
-// in ListNgrokIngressClassesV1 in the release immediately before 1.0.
+// affordance whenever the operator is running on either well-known stock
+// default — we cannot distinguish "default" from "explicitly set to the
+// default value", and nobody sets the legacy default explicitly to mean
+// "exact-match legacy only", so treating both stock defaults symmetrically
+// is the least surprising behavior. Delete this const and the dual-match
+// branch in ListNgrokIngressClassesV1 in the release immediately before 1.0.
 const legacyDefaultIngressControllerName = "k8s.ngrok.com/ingress-controller"
 
 // LEGACY-PREFIX-MIGRATION: END
@@ -243,7 +245,8 @@ const legacyDefaultIngressControllerName = "k8s.ngrok.com/ingress-controller"
 func (s Store) ListNgrokIngressClassesV1() []*netv1.IngressClass {
 	accepted := map[string]bool{s.controllerName: true}
 	// LEGACY-PREFIX-MIGRATION: drop this branch in 1.0
-	if s.controllerName == defaultIngressControllerName {
+	if s.controllerName == defaultIngressControllerName || s.controllerName == legacyDefaultIngressControllerName {
+		accepted[defaultIngressControllerName] = true
 		accepted[legacyDefaultIngressControllerName] = true
 	}
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -249,6 +249,26 @@ var _ = Describe("Store", func() {
 				Expect(ics[0].Name).To(Equal("ngrok-legacy"))
 			})
 		})
+		Context("when the operator runs under the legacy default controller name", func() {
+			var legacyStore Storer
+			BeforeEach(func() {
+				logger := logr.New(logr.Discard().GetSink())
+				cs := NewCacheStores(logger)
+				legacyStore = New(cs, testutils.LegacyControllerName, logger)
+
+				icLegacy := testutils.NewTestIngressClass("legacy-class", true, false)
+				icLegacy.Spec.Controller = testutils.LegacyControllerName
+				Expect(legacyStore.Add(icLegacy)).To(BeNil())
+
+				icDefault := testutils.NewTestIngressClass("default-class", true, false)
+				icDefault.Spec.Controller = testutils.DefaultControllerName
+				Expect(legacyStore.Add(icDefault)).To(BeNil())
+			})
+			It("dual-matches both stock defaults (R1 helm path)", func() {
+				ics := legacyStore.ListNgrokIngressClassesV1()
+				Expect(len(ics)).To(Equal(2))
+			})
+		})
 		Context("when the operator runs under a custom controller name", func() {
 			var customStore Storer
 			BeforeEach(func() {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -237,6 +237,43 @@ var _ = Describe("Store", func() {
 				Expect(len(ics)).To(Equal(0))
 			})
 		})
+		Context("when an IngressClass uses the legacy controller name", func() {
+			BeforeEach(func() {
+				ic := testutils.NewTestIngressClass("ngrok-legacy", true, false)
+				ic.Spec.Controller = testutils.LegacyControllerName
+				Expect(store.Add(ic)).To(BeNil())
+			})
+			It("is still selected during the migration window", func() {
+				ics := store.ListNgrokIngressClassesV1()
+				Expect(len(ics)).To(Equal(1))
+				Expect(ics[0].Name).To(Equal("ngrok-legacy"))
+			})
+		})
+		Context("when the operator runs under a custom controller name", func() {
+			var customStore Storer
+			BeforeEach(func() {
+				logger := logr.New(logr.Discard().GetSink())
+				cs := NewCacheStores(logger)
+				customStore = New(cs, "custom.example.com/my-controller", logger)
+
+				icCustom := testutils.NewTestIngressClass("custom-class", true, false)
+				icCustom.Spec.Controller = "custom.example.com/my-controller"
+				Expect(customStore.Add(icCustom)).To(BeNil())
+
+				icDefault := testutils.NewTestIngressClass("default-class", true, false)
+				icDefault.Spec.Controller = testutils.DefaultControllerName
+				Expect(customStore.Add(icDefault)).To(BeNil())
+
+				icLegacy := testutils.NewTestIngressClass("legacy-class", true, false)
+				icLegacy.Spec.Controller = testutils.LegacyControllerName
+				Expect(customStore.Add(icLegacy)).To(BeNil())
+			})
+			It("does NOT match the default-named IngressClasses (multi-instance isolation)", func() {
+				ics := customStore.ListNgrokIngressClassesV1()
+				Expect(len(ics)).To(Equal(1))
+				Expect(ics[0].Name).To(Equal("custom-class"))
+			})
+		})
 	})
 
 	var _ = Describe("ListNgrokGateways", func() {

--- a/internal/testutils/controller.go
+++ b/internal/testutils/controller.go
@@ -1,3 +1,10 @@
 package testutils
 
-const DefaultControllerName = "k8s.ngrok.com/ingress-controller"
+const DefaultControllerName = "ngrok.com/ingress-controller"
+
+// LEGACY-PREFIX-MIGRATION: BEGIN
+// LegacyControllerName is referenced by store dual-read tests. Delete this
+// constant along with those tests in the release immediately before 1.0.
+const LegacyControllerName = "k8s.ngrok.com/ingress-controller"
+
+// LEGACY-PREFIX-MIGRATION: END

--- a/internal/testutils/k8s-resources.go
+++ b/internal/testutils/k8s-resources.go
@@ -29,7 +29,7 @@ func NewTestIngressClass(name string, isDefault bool, isNgrok bool) *netv1.Ingre
 	}
 
 	if isNgrok {
-		i.Spec.Controller = "k8s.ngrok.com/ingress-controller"
+		i.Spec.Controller = DefaultControllerName
 	} else {
 		i.Spec.Controller = "kubernetes.io/ingress-other"
 	}


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
For our 1.0 release, 1 thing we identified is that we want to use ngrok.com everywhere instead of k8s.ngrok.com. One area for this is our ingress class controller name. 

## How
This needs to be done passively so it will be done in multiple passes spanning releases. To make this easier we are including both a developer guide and a user guide on how to deal with these non-passive changes. 

For this one in particular, we are not changing the default value in this initial release. Instead it just makes it so that if the configured value matches the old or new value it will read from both. This sets us up so we can change the default value in the next release. Then after that we can just remove the passivitity code. 

## Breaking Changes
None in this technically


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced staged migration approach for ingress controller naming with backward compatibility support across operator releases leading up to v1.0.

* **Documentation**
  * Added v1.0 migration guide detailing the ingress controller name change and compatibility behavior per operator release.
  * Added developer documentation on managing backward-incompatible changes using staged migration techniques.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ngrok/ngrok-operator/pull/819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->