### PR TITLE
refactor: Use maps.Equal when the type is known at compile time

### DIFF
--- a/internal/controller/bindings/boundendpoint_poller.go
+++ b/internal/controller/bindings/boundendpoint_poller.go
@@ -3,7 +3,7 @@ package bindings
 import (
 	"context"
 	"fmt"
-	"reflect"
+	"maps"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -582,41 +582,7 @@ func (r *BoundEndpointPoller) updateBindingStatus(ctx context.Context, desired *
 
 // targetMetadataIsEqual returns true if the metadata fields in a and b are equal
 func targetMetadataIsEqual(a bindingsv1alpha1.TargetMetadata, b bindingsv1alpha1.TargetMetadata) bool {
-	if len(a.Annotations) != len(b.Annotations) {
-		return false
-	}
-
-	if len(a.Labels) != len(b.Labels) {
-		return false
-	}
-
-	// massage the maps to conform to reflect.DeepEqual()
-
-	if a.Annotations == nil && b.Annotations != nil {
-		a.Annotations = map[string]string{}
-	}
-
-	if a.Labels == nil && b.Labels != nil {
-		a.Labels = map[string]string{}
-	}
-
-	if b.Annotations == nil && a.Annotations != nil {
-		b.Annotations = map[string]string{}
-	}
-
-	if b.Labels == nil && a.Labels != nil {
-		b.Labels = map[string]string{}
-	}
-
-	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
-		return false
-	}
-
-	if !reflect.DeepEqual(a.Labels, b.Labels) {
-		return false
-	}
-
-	return true
+	return maps.Equal(a.Annotations, b.Annotations) && maps.Equal(a.Labels, b.Labels)
 }
 
 // computeEndpointsSummary returns "N endpoint" or "N endpoints" string

--- a/internal/controller/service/controller.go
+++ b/internal/controller/service/controller.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -809,7 +810,7 @@ func newServiceCloudEndpointReconciler() serviceSubresourceReconciler {
 		},
 		matches: func(desired, existing ngrokv1alpha1.CloudEndpoint) bool {
 			return reflect.DeepEqual(existing.Spec, desired.Spec) &&
-				reflect.DeepEqual(existing.Labels, desired.Labels)
+				maps.Equal(existing.Labels, desired.Labels)
 		},
 		mergeExisting: func(desired ngrokv1alpha1.CloudEndpoint, existing *ngrokv1alpha1.CloudEndpoint) {
 			existing.Spec = desired.Spec
@@ -832,7 +833,7 @@ func newServiceAgentEndpointReconciler() serviceSubresourceReconciler {
 		},
 		matches: func(desired, existing ngrokv1alpha1.AgentEndpoint) bool {
 			return reflect.DeepEqual(existing.Spec, desired.Spec) &&
-				reflect.DeepEqual(existing.Labels, desired.Labels)
+				maps.Equal(existing.Labels, desired.Labels)
 		},
 		mergeExisting: func(desired ngrokv1alpha1.AgentEndpoint, existing *ngrokv1alpha1.AgentEndpoint) {
 			existing.Spec = desired.Spec


### PR DESCRIPTION
## What

Replaces usages of `reflect.DeepEqual` with `maps.Equal` in places where the type is known at compile time. This is more efficient as we don't need to rely on runtime reflection. Also makes the code easier to read.

## How

Use `maps.Equal` instead of `reflect.DeepEqual`

## Breaking Changes
No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code efficiency and maintainability through implementation optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->