### PR TITLE
fix(agent): restrict clientCertificateRefs to same-namespace secrets

### DIFF
--- a/api/ngrok/v1alpha1/agentendpoint_types.go
+++ b/api/ngrok/v1alpha1/agentendpoint_types.go
@@ -142,7 +142,7 @@ type AgentEndpointSpec struct {
 	Bindings []string `json:"bindings,omitempty"`
 
 	// List of client certificates to present to the upstream when performing a TLS handshake
-	ClientCertificateRefs []K8sObjectRefOptionalNamespace `json:"clientCertificateRefs,omitempty"`
+	ClientCertificateRefs []K8sObjectRef `json:"clientCertificateRefs,omitempty"`
 
 	// TLSTermination configures the agent to terminate TLS in-cluster for incoming
 	// traffic ("zero-knowledge TLS"). When set, ngrok's edge routes the encrypted

--- a/api/ngrok/v1alpha1/zz_generated.deepcopy.go
+++ b/api/ngrok/v1alpha1/zz_generated.deepcopy.go
@@ -110,10 +110,8 @@ func (in *AgentEndpointSpec) DeepCopyInto(out *AgentEndpointSpec) {
 	}
 	if in.ClientCertificateRefs != nil {
 		in, out := &in.ClientCertificateRefs, &out.ClientCertificateRefs
-		*out = make([]K8sObjectRefOptionalNamespace, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = make([]K8sObjectRef, len(*in))
+		copy(*out, *in)
 	}
 	if in.TLSTermination != nil {
 		in, out := &in.TLSTermination, &out.TLSTermination

--- a/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_agentendpoints.yaml
+++ b/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_agentendpoints.yaml
@@ -78,13 +78,10 @@ spec:
                 description: List of client certificates to present to the upstream
                   when performing a TLS handshake
                 items:
+                  description: K8sObjectRef defines a reference to a Kubernetes Object
                   properties:
                     name:
                       description: The name of the Kubernetes resource being referenced
-                      type: string
-                    namespace:
-                      description: The namespace of the Kubernetes resource being
-                        referenced
                       type: string
                   required:
                   - name

--- a/internal/controller/agent/agent_endpoint_controller.go
+++ b/internal/controller/agent/agent_endpoint_controller.go
@@ -86,14 +86,9 @@ func indexTLSTerminationSecrets(o client.Object) []string {
 	return keys
 }
 
-// secretIndexKey returns the "namespace/name" key used by Secret-watch indexes,
-// resolving the ref's namespace (defaulting to the owning AgentEndpoint's namespace).
-func secretIndexKey(defaultNamespace string, ref ngrokv1alpha1.K8sObjectRefOptionalNamespace) string {
-	ns := defaultNamespace
-	if ref.Namespace != nil && *ref.Namespace != "" {
-		ns = *ref.Namespace
-	}
-	return ns + "/" + ref.Name
+// secretIndexKey returns the "namespace/name" key used by Secret-watch indexes.
+func secretIndexKey(namespace string, ref ngrokv1alpha1.K8sObjectRef) string {
+	return namespace + "/" + ref.Name
 }
 
 var (
@@ -452,9 +447,6 @@ func (r *AgentEndpointReconciler) getClientCerts(ctx context.Context, aep *ngrok
 	ret := []tls.Certificate{}
 	for _, clientCertRef := range aep.Spec.ClientCertificateRefs {
 		key := client.ObjectKey{Name: clientCertRef.Name, Namespace: aep.Namespace}
-		if clientCertRef.Namespace != nil {
-			key.Namespace = *clientCertRef.Namespace
-		}
 
 		// Attempt to get the Secret from the API server
 		certSecret := &v1.Secret{}

--- a/internal/controller/agent/agent_endpoint_controller_test.go
+++ b/internal/controller/agent/agent_endpoint_controller_test.go
@@ -838,7 +838,7 @@ var _ = Describe("AgentEndpoint Controller", func() {
 					Upstream: ngrokv1alpha1.EndpointUpstream{
 						URL: "http://test-service:80",
 					},
-					ClientCertificateRefs: []ngrokv1alpha1.K8sObjectRefOptionalNamespace{
+					ClientCertificateRefs: []ngrokv1alpha1.K8sObjectRef{
 						{Name: "missing-secret"},
 					},
 				},
@@ -883,7 +883,7 @@ var _ = Describe("AgentEndpoint Controller", func() {
 					Upstream: ngrokv1alpha1.EndpointUpstream{
 						URL: "http://test-service:80",
 					},
-					ClientCertificateRefs: []ngrokv1alpha1.K8sObjectRefOptionalNamespace{
+					ClientCertificateRefs: []ngrokv1alpha1.K8sObjectRef{
 						{Name: "invalid-cert"},
 					},
 				},
@@ -927,7 +927,7 @@ var _ = Describe("AgentEndpoint Controller", func() {
 					Upstream: ngrokv1alpha1.EndpointUpstream{
 						URL: "http://test-service:80",
 					},
-					ClientCertificateRefs: []ngrokv1alpha1.K8sObjectRefOptionalNamespace{
+					ClientCertificateRefs: []ngrokv1alpha1.K8sObjectRef{
 						{Name: "no-crt-secret"},
 					},
 				},
@@ -1413,7 +1413,7 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 					Upstream: ngrokv1alpha1.EndpointUpstream{
 						URL: "http://test-service:80",
 					},
-					ClientCertificateRefs: []ngrokv1alpha1.K8sObjectRefOptionalNamespace{
+					ClientCertificateRefs: []ngrokv1alpha1.K8sObjectRef{
 						{Name: "watch-test-cert"},
 					},
 				},

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -869,13 +869,10 @@ spec:
                 description: List of client certificates to present to the upstream
                   when performing a TLS handshake
                 items:
+                  description: K8sObjectRef defines a reference to a Kubernetes Object
                   properties:
                     name:
                       description: The name of the Kubernetes resource being referenced
-                      type: string
-                    namespace:
-                      description: The namespace of the Kubernetes resource being
-                        referenced
                       type: string
                   required:
                   - name

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -871,9 +871,8 @@ func buildAgentEndpoint(
 	}
 
 	for _, certRef := range irService.ClientCertRefs {
-		ret.Spec.ClientCertificateRefs = append(ret.Spec.ClientCertificateRefs, ngrokv1alpha1.K8sObjectRefOptionalNamespace{
-			Name:      certRef.Name,
-			Namespace: &certRef.Namespace,
+		ret.Spec.ClientCertificateRefs = append(ret.Spec.ClientCertificateRefs, ngrokv1alpha1.K8sObjectRef{
+			Name: certRef.Name,
 		})
 	}
 


### PR DESCRIPTION
## What

  `AgentEndpoint.spec.clientCertificateRefs` accepted an optional `namespace` field, allowing any user who can create or update an `AgentEndpoint` to
  direct the operator to read a Secret from an arbitrary namespace. Since the agent-manager runs with a ClusterRole granting `secrets:[get,list,watch]`
  cluster-wide (in the default install), this was a confused deputy vulnerability — a user could read secrets they shouldn't have direct access to.

  ## How

  Changed `clientCertificateRefs` from `[]K8sObjectRefOptionalNamespace` to `[]K8sObjectRef`, which has no `namespace` field. The controller now always
  resolves certificate secrets against the AgentEndpoint's own namespace. The CRD schema is updated accordingly so Kubernetes prunes any `namespace`
  field at admission time.

  ## Breaking Changes

  Yes. The `namespace` field on `clientCertificateRefs` items is removed. Any existing `AgentEndpoint` with a cross-namespace cert ref will silently fall
  back to same-namespace resolution after the CRD is updated. Cross-namespace client certificate references were never a documented use case and the
  operator is pre-1.0.