### PR TITLE
refactor(conditions): Consolidate status conditions

### DIFF
--- a/internal/controller/agent/agent_endpoint_conditions.go
+++ b/internal/controller/agent/agent_endpoint_conditions.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
+	"github.com/ngrok/ngrok-operator/internal/controller/conditions"
 	domainpkg "github.com/ngrok/ngrok-operator/internal/domain"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,56 +27,17 @@ const (
 
 // setReadyCondition sets the Ready condition based on the overall endpoint state
 func setReadyCondition(endpoint *ngrokv1alpha1.AgentEndpoint, ready bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !ready {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionReady,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: endpoint.Generation,
-	}
-
-	meta.SetStatusCondition(&endpoint.Status.Conditions, condition)
+	conditions.Set(&endpoint.Status.Conditions, endpoint.Generation, ConditionReady, ready, reason, message)
 }
 
 // setEndpointCreatedCondition sets the EndpointCreated condition
 func setEndpointCreatedCondition(endpoint *ngrokv1alpha1.AgentEndpoint, created bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !created {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionEndpointCreated,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: endpoint.Generation,
-	}
-
-	meta.SetStatusCondition(&endpoint.Status.Conditions, condition)
+	conditions.Set(&endpoint.Status.Conditions, endpoint.Generation, ConditionEndpointCreated, created, reason, message)
 }
 
 // setTrafficPolicyCondition sets the TrafficPolicyApplied condition
 func setTrafficPolicyCondition(endpoint *ngrokv1alpha1.AgentEndpoint, applied bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !applied {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionTrafficPolicy,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: endpoint.Generation,
-	}
-
-	meta.SetStatusCondition(&endpoint.Status.Conditions, condition)
+	conditions.Set(&endpoint.Status.Conditions, endpoint.Generation, ConditionTrafficPolicy, applied, reason, message)
 }
 
 // calculateAgentEndpointReadyCondition calculates the overall Ready condition based on other conditions and domain status

--- a/internal/controller/bindings/boundendpoint_conditions.go
+++ b/internal/controller/bindings/boundendpoint_conditions.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
+	"github.com/ngrok/ngrok-operator/internal/controller/conditions"
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
 )
 
@@ -32,43 +33,20 @@ const (
 
 // setServicesCreatedCondition sets the ServicesCreated condition
 func setServicesCreatedCondition(be *bindingsv1alpha1.BoundEndpoint, created bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !created {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionTypeServicesCreated,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: be.Generation,
-	}
-
-	meta.SetStatusCondition(&be.Status.Conditions, condition)
+	conditions.Set(&be.Status.Conditions, be.Generation, ConditionTypeServicesCreated, created, reason, message)
 }
 
 // setConnectivityVerifiedCondition sets the ConnectivityVerified condition
 func setConnectivityVerifiedCondition(be *bindingsv1alpha1.BoundEndpoint, verified bool, err error) {
-	status := metav1.ConditionTrue
 	reason := ReasonConnectivityVerified
 	message := "Successfully connected to upstream service"
 
 	if !verified {
-		status = metav1.ConditionFalse
 		reason = ReasonConnectivityFailed
 		message = ngrokapi.SanitizeErrorMessage(err.Error())
 	}
 
-	condition := metav1.Condition{
-		Type:               ConditionTypeConnectivityVerified,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: be.Generation,
-	}
-
-	meta.SetStatusCondition(&be.Status.Conditions, condition)
+	conditions.Set(&be.Status.Conditions, be.Generation, ConditionTypeConnectivityVerified, verified, reason, message)
 }
 
 // calculateReadyCondition calculates the overall Ready condition based on other conditions
@@ -116,18 +94,5 @@ func calculateReadyCondition(be *bindingsv1alpha1.BoundEndpoint) {
 
 // setReadyCondition sets the Ready condition
 func setReadyCondition(be *bindingsv1alpha1.BoundEndpoint, ready bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !ready {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionTypeReady,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: be.Generation,
-	}
-
-	meta.SetStatusCondition(&be.Status.Conditions, condition)
+	conditions.Set(&be.Status.Conditions, be.Generation, ConditionTypeReady, ready, reason, message)
 }

--- a/internal/controller/conditions/conditions.go
+++ b/internal/controller/conditions/conditions.go
@@ -1,0 +1,24 @@
+package conditions
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Set sets a condition on the provided conditions slice.
+func Set(conditions *[]metav1.Condition, generation int64, condType string, ok bool, reason, message string) {
+	status := metav1.ConditionTrue
+	if !ok {
+		status = metav1.ConditionFalse
+	}
+
+	condition := metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: generation,
+	}
+
+	meta.SetStatusCondition(conditions, condition)
+}

--- a/internal/controller/conditions/conditions_test.go
+++ b/internal/controller/conditions/conditions_test.go
@@ -1,0 +1,95 @@
+package conditions
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSet(t *testing.T) {
+	tests := []struct {
+		name       string
+		conds      []metav1.Condition
+		generation int64
+		condType   string
+		ok         bool
+		reason     string
+		message    string
+		verify     func(t *testing.T, conds []metav1.Condition)
+	}{
+		{
+			name:       "set new condition with ok = true",
+			conds:      []metav1.Condition{},
+			generation: 1,
+			condType:   "Ready",
+			ok:         true,
+			reason:     "Initialized",
+			message:    "Resource is ready",
+			verify: func(t *testing.T, conds []metav1.Condition) {
+				assert.Len(t, conds, 1)
+				cond := conds[0]
+				assert.Equal(t, "Ready", cond.Type)
+				assert.Equal(t, metav1.ConditionTrue, cond.Status)
+				assert.Equal(t, int64(1), cond.ObservedGeneration)
+				assert.Equal(t, "Initialized", cond.Reason)
+				assert.Equal(t, "Resource is ready", cond.Message)
+				assert.NotZero(t, cond.LastTransitionTime)
+			},
+		},
+		{
+			name:       "set new condition with ok = false",
+			conds:      []metav1.Condition{},
+			generation: 2,
+			condType:   "Ready",
+			ok:         false,
+			reason:     "Failed",
+			message:    "Resource failed to initialize",
+			verify: func(t *testing.T, conds []metav1.Condition) {
+				assert.Len(t, conds, 1)
+				cond := conds[0]
+				assert.Equal(t, "Ready", cond.Type)
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t, int64(2), cond.ObservedGeneration)
+				assert.Equal(t, "Failed", cond.Reason)
+				assert.Equal(t, "Resource failed to initialize", cond.Message)
+				assert.NotZero(t, cond.LastTransitionTime)
+			},
+		},
+		{
+			name: "update existing condition status and details",
+			conds: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionFalse,
+					Reason:             "Failed",
+					Message:            "Old error",
+					ObservedGeneration: 1,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+				},
+			},
+			generation: 2,
+			condType:   "Ready",
+			ok:         true,
+			reason:     "Succeeded",
+			message:    "Now OK",
+			verify: func(t *testing.T, conds []metav1.Condition) {
+				assert.Len(t, conds, 1)
+				cond := conds[0]
+				assert.Equal(t, "Ready", cond.Type)
+				assert.Equal(t, metav1.ConditionTrue, cond.Status)
+				assert.Equal(t, int64(2), cond.ObservedGeneration)
+				assert.Equal(t, "Succeeded", cond.Reason)
+				assert.Equal(t, "Now OK", cond.Message)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Set(&tt.conds, tt.generation, tt.condType, tt.ok, tt.reason, tt.message)
+			tt.verify(t, tt.conds)
+		})
+	}
+}

--- a/internal/controller/ingress/domain_conditions.go
+++ b/internal/controller/ingress/domain_conditions.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ngrok/ngrok-api-go/v7"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
+	"github.com/ngrok/ngrok-operator/internal/controller/conditions"
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
 )
 
@@ -38,91 +39,27 @@ const (
 
 // setReadyCondition sets the Ready condition based on the overall domain state
 func setDomainReadyCondition(domain *ingressv1alpha1.Domain, ready bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !ready {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionDomainReady,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: domain.Generation,
-	}
-
-	meta.SetStatusCondition(&domain.Status.Conditions, condition)
+	conditions.Set(&domain.Status.Conditions, domain.Generation, ConditionDomainReady, ready, reason, message)
 }
 
 // setProgressingCondition sets the Progressing condition
 func setProgressingCondition(domain *ingressv1alpha1.Domain, progressing bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !progressing {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionProgressing,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: domain.Generation,
-	}
-	meta.SetStatusCondition(&domain.Status.Conditions, condition)
+	conditions.Set(&domain.Status.Conditions, domain.Generation, ConditionProgressing, progressing, reason, message)
 }
 
 // setDomainCreatedCondition sets the DomainCreated condition
 func setDomainCreatedCondition(domain *ingressv1alpha1.Domain, created bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !created {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionDomainCreated,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: domain.Generation,
-	}
-
-	meta.SetStatusCondition(&domain.Status.Conditions, condition)
+	conditions.Set(&domain.Status.Conditions, domain.Generation, ConditionDomainCreated, created, reason, message)
 }
 
 // setCertificateReadyCondition sets the CertificateReady condition
 func setCertificateReadyCondition(domain *ingressv1alpha1.Domain, ready bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !ready {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionCertificateReady,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: domain.Generation,
-	}
-
-	meta.SetStatusCondition(&domain.Status.Conditions, condition)
+	conditions.Set(&domain.Status.Conditions, domain.Generation, ConditionCertificateReady, ready, reason, message)
 }
 
 // setDNSConfiguredCondition sets the DNSConfigured condition
 func setDNSConfiguredCondition(domain *ingressv1alpha1.Domain, configured bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !configured {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionDNSConfigured,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: domain.Generation,
-	}
-
-	meta.SetStatusCondition(&domain.Status.Conditions, condition)
+	conditions.Set(&domain.Status.Conditions, domain.Generation, ConditionDNSConfigured, configured, reason, message)
 }
 
 // updateDomainConditions updates all domain conditions based on the ngrok domain state and any creation errors

--- a/internal/controller/ingress/ippolicy_conditions.go
+++ b/internal/controller/ingress/ippolicy_conditions.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
+	"github.com/ngrok/ngrok-operator/internal/controller/conditions"
 )
 
 const (
@@ -24,56 +25,17 @@ const (
 
 // setIPPolicyReadyCondition sets the Ready condition based on the overall IP policy state
 func setIPPolicyReadyCondition(ipPolicy *ingressv1alpha1.IPPolicy, ready bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !ready {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionIPPolicyReady,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: ipPolicy.Generation,
-	}
-
-	meta.SetStatusCondition(&ipPolicy.Status.Conditions, condition)
+	conditions.Set(&ipPolicy.Status.Conditions, ipPolicy.Generation, ConditionIPPolicyReady, ready, reason, message)
 }
 
 // setIPPolicyCreatedCondition sets the IPPolicyCreated condition
 func setIPPolicyCreatedCondition(ipPolicy *ingressv1alpha1.IPPolicy, created bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !created {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionIPPolicyCreated,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: ipPolicy.Generation,
-	}
-
-	meta.SetStatusCondition(&ipPolicy.Status.Conditions, condition)
+	conditions.Set(&ipPolicy.Status.Conditions, ipPolicy.Generation, ConditionIPPolicyCreated, created, reason, message)
 }
 
 // setIPPolicyRulesConfiguredCondition sets the RulesConfigured condition
 func setIPPolicyRulesConfiguredCondition(ipPolicy *ingressv1alpha1.IPPolicy, configured bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !configured {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionIPPolicyRulesConfigured,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: ipPolicy.Generation,
-	}
-
-	meta.SetStatusCondition(&ipPolicy.Status.Conditions, condition)
+	conditions.Set(&ipPolicy.Status.Conditions, ipPolicy.Generation, ConditionIPPolicyRulesConfigured, configured, reason, message)
 }
 
 // sets the Ready condition based on the other conditions

--- a/internal/controller/ngrok/cloudendpoint_conditions.go
+++ b/internal/controller/ngrok/cloudendpoint_conditions.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
+	"github.com/ngrok/ngrok-operator/internal/controller/conditions"
 	domainpkg "github.com/ngrok/ngrok-operator/internal/domain"
 )
 
@@ -21,38 +22,12 @@ const (
 
 // setCloudEndpointReadyCondition sets the Ready condition
 func setCloudEndpointReadyCondition(clep *ngrokv1alpha1.CloudEndpoint, ready bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !ready {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionCloudEndpointReady,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: clep.Generation,
-	}
-
-	meta.SetStatusCondition(&clep.Status.Conditions, condition)
+	conditions.Set(&clep.Status.Conditions, clep.Generation, ConditionCloudEndpointReady, ready, reason, message)
 }
 
 // setCloudEndpointCreatedCondition sets the CloudEndpointCreated condition
 func setCloudEndpointCreatedCondition(clep *ngrokv1alpha1.CloudEndpoint, created bool, reason, message string) {
-	status := metav1.ConditionTrue
-	if !created {
-		status = metav1.ConditionFalse
-	}
-
-	condition := metav1.Condition{
-		Type:               ConditionCloudEndpointCreated,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: clep.Generation,
-	}
-
-	meta.SetStatusCondition(&clep.Status.Conditions, condition)
+	conditions.Set(&clep.Status.Conditions, clep.Generation, ConditionCloudEndpointCreated, created, reason, message)
 }
 
 // calculateCloudEndpointReadyCondition calculates the overall Ready condition based on other conditions and domain status


### PR DESCRIPTION
## What

Refactor and centralize status condition management across multiple resource reconcilers, eliminating redundant boilerplate logic for setting
Kubernetes conditions.

## How

1. Created a shared helper: Introduced a centralized function conditions.Set in a new package conditions.go. This helper handles the mapping of a boolean status ( ok ) to  `metav1.ConditionTrue`  or  `metav1.ConditionFalse` , builds the `metav1.Condition`  struct, and calls `meta.SetStatusCondition`.
2. Refactored controllers: Updated multiple resource condition helper files to use the new conditions.Set helper:
    * AgentEndpoint : `agent_endpoint_conditions.go`
    *  BoundEndpoint : `boundendpoint_conditions.go`
    *  Domain : `domain_conditions.go`
    *  IPPolicy : `ippolicy_conditions.go`
    *  CloudEndpoint : `cloudendpoint_conditions.go`
3. Added tests: Created unit tests in `conditions_test.go` to verify the behavior of the new helper function (including new conditions, condition updates, generation checking, and transition times).

## Breaking Changes

No breaking changes. This is a refactoring of internal controller helper logic and does not change any public API or CRD behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated status condition handling logic across multiple modules, eliminating code duplication and improving maintainability throughout the codebase.

* **Tests**
  * Added comprehensive unit tests to validate condition management operations and status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->