### PR TITLE
Update GitHub actions versions

### DIFF
--- a/.github/actions/build-and-test/action.yaml
+++ b/.github/actions/build-and-test/action.yaml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: engineerd/setup-kind@v0.6.2
+    - uses: engineerd/setup-kind@71e45b960fc8dd50b4aeabf6eb6ef2ca0920b4c1 # v0.6.2
       with:
         version: ${{ inputs.kind-version }}
         name: ngrok-operator

--- a/.github/actions/build-and-test/action.yaml
+++ b/.github/actions/build-and-test/action.yaml
@@ -14,18 +14,15 @@ inputs:
     description: "NGROK_AUTHTOKEN for e2e tests, if enabled"
     required: false
     default: "fake-authtoken"
-  kind-version:
-    description: "KIND version to use"
-    required: false
-    default: "v0.30.0"
 
 runs:
   using: "composite"
   steps:
-    - uses: engineerd/setup-kind@71e45b960fc8dd50b4aeabf6eb6ef2ca0920b4c1 # v0.6.2
-      with:
-        version: ${{ inputs.kind-version }}
-        name: ngrok-operator
+    # kind is provided by the nix devShell (see .github/actions/nix-setup),
+    # so we create the cluster directly instead of installing kind separately.
+    - name: Create Kind Cluster
+      shell: bash
+      run: make kind-create
 
     - shell: bash
       run: |

--- a/.github/actions/changes/action.yaml
+++ b/.github/actions/changes/action.yaml
@@ -29,7 +29,7 @@ runs:
   steps:
     - name: filter
       id: filter
-      uses: dorny/paths-filter@v2.11.1
+      uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
       with:
         filters: |
           actions:

--- a/.github/actions/changes/action.yaml
+++ b/.github/actions/changes/action.yaml
@@ -29,7 +29,7 @@ runs:
   steps:
     - name: filter
       id: filter
-      uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:
         filters: |
           actions:

--- a/.github/actions/nix-setup/action.yaml
+++ b/.github/actions/nix-setup/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
   - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
-  - uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
+  - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
   - name: Install direnv
     shell: bash
     run: |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      # Workflows in .github/workflows/
+      - "/"
+      # Local composite actions that also pin third-party actions
+      - "/.github/actions/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Don't pick up a new release until it has been out for a week. This
+    # gives the community time to catch compromised or broken releases
+    # before we pull them in.
+    cooldown:
+      default-days: 7
+    # Group all action updates into a single PR to avoid PR noise.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(github-actions)"

--- a/.github/workflows/basic-tests.yaml
+++ b/.github/workflows/basic-tests.yaml
@@ -25,6 +25,8 @@ jobs:
     if: ${{ inputs.go-changed || inputs.make-changed }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/nix-setup
     - name: Generate manifests
       run: make manifests
@@ -40,6 +42,8 @@ jobs:
     if: ${{ inputs.go-changed || inputs.make-changed }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/nix-setup
     - name: Lint
       run: make lint
@@ -50,6 +54,8 @@ jobs:
     if: ${{ inputs.go-changed }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/nix-setup
     - run: go mod tidy
     - run: git diff --exit-code go.mod
@@ -63,6 +69,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/nix-setup
     - name: Run go fix
       run: make go-fix
@@ -75,6 +83,8 @@ jobs:
     if: ${{ inputs.go-changed || inputs.make-changed || github.event_name == 'schedule' }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/nix-setup
     - name: Run unit tests
       run: make test

--- a/.github/workflows/basic-tests.yaml
+++ b/.github/workflows/basic-tests.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.go-changed || inputs.make-changed }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - uses: ./.github/actions/nix-setup
     - name: Generate manifests
       run: make manifests
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 10
     if: ${{ inputs.go-changed || inputs.make-changed }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - uses: ./.github/actions/nix-setup
     - name: Lint
       run: make lint
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.go-changed }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - uses: ./.github/actions/nix-setup
     - run: go mod tidy
     - run: git diff --exit-code go.mod
@@ -62,7 +62,7 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - uses: ./.github/actions/nix-setup
     - name: Run go fix
       run: make go-fix
@@ -74,12 +74,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.go-changed || inputs.make-changed || github.event_name == 'schedule' }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - uses: ./.github/actions/nix-setup
     - name: Run unit tests
       run: make test
     - if: github.repository == 'ngrok/ngrok-operator'
       name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/basic-tests.yaml
+++ b/.github/workflows/basic-tests.yaml
@@ -80,6 +80,6 @@ jobs:
       run: make test
     - if: github.repository == 'ngrok/ngrok-operator'
       name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,14 +66,14 @@ jobs:
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
     - id: buildx-setup
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       with:
         platforms: ${{ env.DOCKER_BUILDX_PLATFORMS }}
     - name: Build
-      uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: .
         platforms: ${{ steps.buildx-setup.outputs.platforms }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,8 @@ jobs:
       make: ${{ steps.changes.outputs.make }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - uses: "./.github/actions/changes"
       id: changes
 
@@ -49,6 +51,8 @@ jobs:
       (needs.changes.outputs.make == 'true')
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/nix-setup
     - name: Generate manifest bundle
       run: make manifest-bundle
@@ -65,6 +69,8 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Set up QEMU
       uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
     - id: buildx-setup
@@ -104,6 +110,8 @@ jobs:
       pull-requests: read
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Setup Nix
       uses: ./.github/actions/nix-setup
     - uses: "./.github/actions/build-and-test"
@@ -120,6 +128,8 @@ jobs:
     if: needs.changes.outputs.charts == 'true'
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Setup Nix
       uses: ./.github/actions/nix-setup
     - name: Lint Helm Chart
@@ -156,6 +166,8 @@ jobs:
       )
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Setup Nix
       uses: ./.github/actions/nix-setup
     - uses: "./.github/actions/build-and-test"
@@ -190,6 +202,8 @@ jobs:
       )
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Setup Nix
       uses: ./.github/actions/nix-setup
     - name: Create Kind Cluster
@@ -237,6 +251,8 @@ jobs:
       )
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Setup Nix
       uses: ./.github/actions/nix-setup
     - name: Create Kind Cluster

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       tests: ${{ steps.changes.outputs.tests }}
       make: ${{ steps.changes.outputs.make }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - uses: "./.github/actions/changes"
       id: changes
 
@@ -48,7 +48,7 @@ jobs:
       (needs.changes.outputs.charts == 'true') ||
       (needs.changes.outputs.make == 'true')
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - uses: ./.github/actions/nix-setup
     - name: Generate manifest bundle
       run: make manifest-bundle
@@ -64,16 +64,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
     - id: buildx-setup
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
       with:
         platforms: ${{ env.DOCKER_BUILDX_PLATFORMS }}
     - name: Build
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
       with:
         context: .
         platforms: ${{ steps.buildx-setup.outputs.platforms }}
@@ -103,7 +103,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Setup Nix
       uses: ./.github/actions/nix-setup
     - uses: "./.github/actions/build-and-test"
@@ -119,7 +119,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.charts == 'true'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Setup Nix
       uses: ./.github/actions/nix-setup
     - name: Lint Helm Chart
@@ -155,7 +155,7 @@ jobs:
         (needs.changes.outputs.make == 'true')
       )
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Setup Nix
       uses: ./.github/actions/nix-setup
     - uses: "./.github/actions/build-and-test"
@@ -189,7 +189,7 @@ jobs:
         (needs.changes.outputs.make == 'true')
       )
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Setup Nix
       uses: ./.github/actions/nix-setup
     - name: Create Kind Cluster
@@ -236,7 +236,7 @@ jobs:
         (needs.changes.outputs.make == 'true')
       )
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Setup Nix
       uses: ./.github/actions/nix-setup
     - name: Create Kind Cluster

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Nix
         uses: ./.github/actions/nix-setup

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Nix
         uses: ./.github/actions/nix-setup

--- a/.github/workflows/docker-branch.yaml
+++ b/.github/workflows/docker-branch.yaml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set VERSION to provided tag
         run: printf '%s' "${{ inputs.tag }}" > VERSION

--- a/.github/workflows/docker-branch.yaml
+++ b/.github/workflows/docker-branch.yaml
@@ -63,22 +63,22 @@ jobs:
         run: printf '%s' "${{ inputs.tag }}" > VERSION
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - id: buildx-setup
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           platforms: ${{ env.DOCKER_BUILDX_PLATFORMS }}
 
       - name: Build and push docker image
-        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           platforms: ${{ steps.buildx-setup.outputs.platforms }}

--- a/.github/workflows/docker-branch.yaml
+++ b/.github/workflows/docker-branch.yaml
@@ -57,28 +57,28 @@ jobs:
           fi
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set VERSION to provided tag
         run: printf '%s' "${{ inputs.tag }}" > VERSION
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
 
       - id: buildx-setup
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
         with:
           platforms: ${{ env.DOCKER_BUILDX_PLATFORMS }}
 
       - name: Build and push docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
         with:
           context: .
           platforms: ${{ steps.buildx-setup.outputs.platforms }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,10 +21,10 @@ jobs:
     if: github.repository == 'ngrok/ngrok-operator'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Check for changes
         id: filter
-        uses: dorny/paths-filter@v2.11.1
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         with:
           filters: |
             tag:
@@ -44,32 +44,32 @@ jobs:
       github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Extract Version tag
         id: extract_tag
         run: |
           echo "tag=$(cat VERSION)" >> $GITHUB_OUTPUT
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
       - id: buildx-setup
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
         with:
           platforms: ${{ env.DOCKER_BUILDX_PLATFORMS }}
       - name: Build and push latest docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
         with:
           context: .
           platforms: ${{ steps.buildx-setup.outputs.platforms }}
           push: true
           tags: ngrok/ngrok-operator:latest
       - name: Build and push tag'd docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
         if: ${{ needs.changes.outputs.tag == 'true' }}
         with:
           context: .
@@ -77,7 +77,7 @@ jobs:
           push: true
           tags: ngrok/ngrok-operator:${{ steps.extract_tag.outputs.tag }}
       - name: Create GitHub Release
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         if: ${{ needs.changes.outputs.tag == 'true' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Check for changes
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -45,6 +47,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Extract Version tag
         id: extract_tag
         run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Check for changes
         id: filter
-        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             tag:
@@ -50,26 +50,26 @@ jobs:
         run: |
           echo "tag=$(cat VERSION)" >> $GITHUB_OUTPUT
       - name: Log in to Docker Hub
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - id: buildx-setup
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           platforms: ${{ env.DOCKER_BUILDX_PLATFORMS }}
       - name: Build and push latest docker image
-        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           platforms: ${{ steps.buildx-setup.outputs.platforms }}
           push: true
           tags: ngrok/ngrok-operator:latest
       - name: Build and push tag'd docker image
-        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         if: ${{ needs.changes.outputs.tag == 'true' }}
         with:
           context: .
@@ -77,7 +77,7 @@ jobs:
           push: true
           tags: ngrok/ngrok-operator:${{ steps.extract_tag.outputs.tag }}
       - name: Create GitHub Release
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: ${{ needs.changes.outputs.tag == 'true' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-chart-readme.yaml
+++ b/.github/workflows/generate-chart-readme.yaml
@@ -26,6 +26,6 @@ jobs:
         working-directory: helm/ngrok-operator
         run: readme-generator --values "values.yaml" --readme "README.md" --schema "values.schema.json"
       - name: Push changes
-        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: Update README.md and values.schema.json with readme-generator-for-helm

--- a/.github/workflows/generate-chart-readme.yaml
+++ b/.github/workflows/generate-chart-readme.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install readme-generator-for-helm
         run: npm install -g @bitnami/readme-generator-for-helm@2.6.1
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
@@ -26,6 +26,6 @@ jobs:
         working-directory: helm/ngrok-operator
         run: readme-generator --values "values.yaml" --readme "README.md" --schema "values.schema.json"
       - name: Push changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4
         with:
           commit_message: Update README.md and values.schema.json with readme-generator-for-helm

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Check for changes
         id: filter
-        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             ngrok-operator:
@@ -70,7 +70,7 @@ jobs:
         run: make _helm_setup
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Name }}-{{ .Version }}" # Publishes a new release. Ex: helm-chart-ngrok-operator-0.1.0

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -22,10 +22,10 @@ jobs:
     if: github.repository == 'ngrok/ngrok-operator'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Check for changes
         id: filter
-        uses: dorny/paths-filter@v2.11.1
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         with:
           filters: |
             ngrok-operator:
@@ -48,7 +48,7 @@ jobs:
       )
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Fetch entire history. Required for chart-releaser to work.
           fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
         run: make _helm_setup
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Name }}-{{ .Version }}" # Publishes a new release. Ex: helm-chart-ngrok-operator-0.1.0

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Check for changes
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/install-relased-helm.yaml
+++ b/.github/workflows/install-relased-helm.yaml
@@ -20,13 +20,13 @@ jobs:
     env:
       NAMESPACE: ngrok-operator
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Install Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
       with:
         version: ${{ matrix.helm_version }}
     - name: Install kind
-      uses: helm/kind-action@v1
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
       with:
         node_image: kindest/node:${{ matrix.k8s_version }}
         kubectl_version: ${{ matrix.k8s_version }}

--- a/.github/workflows/install-relased-helm.yaml
+++ b/.github/workflows/install-relased-helm.yaml
@@ -21,6 +21,8 @@ jobs:
       NAMESPACE: ngrok-operator
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Install Helm
       uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:

--- a/.github/workflows/install-relased-helm.yaml
+++ b/.github/workflows/install-relased-helm.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Install Helm
-      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+      uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: ${{ matrix.helm_version }}
     - name: Install kind

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4
+    - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - id: filter
-      uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:
         filters: |
           chartyaml:
@@ -57,7 +57,7 @@ jobs:
     steps:
     - if: needs.changes.outputs.chartyaml == 'true'
       name: Notify about changes to Chart.yaml
-      uses: actions/github-script@211cb3fefb35a799baa5156f9321bb774fe56294 # v5
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -69,7 +69,7 @@ jobs:
           })
     - if: needs.changes.outputs.tag == 'true'
       name: Notify about version change
-      uses: actions/github-script@211cb3fefb35a799baa5156f9321bb774fe56294 # v5
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - id: filter
       uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -21,9 +21,9 @@ jobs:
       pull-requests: read
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - id: filter
-      uses: dorny/paths-filter@v2.11.1
+      uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
       with:
         filters: |
           chartyaml:
@@ -57,7 +57,7 @@ jobs:
     steps:
     - if: needs.changes.outputs.chartyaml == 'true'
       name: Notify about changes to Chart.yaml
-      uses: actions/github-script@v5
+      uses: actions/github-script@211cb3fefb35a799baa5156f9321bb774fe56294 # v5
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -69,7 +69,7 @@ jobs:
           })
     - if: needs.changes.outputs.tag == 'true'
       name: Notify about version change
-      uses: actions/github-script@v5
+      uses: actions/github-script@211cb3fefb35a799baa5156f9321bb774fe56294 # v5
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Apply size label
       uses: ngrok/pr-size-labeler@77827af3431595c474d738acf7cfcee30c86edc1 # v1
       with:

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Apply size label
       uses: ngrok/pr-size-labeler@77827af3431595c474d738acf7cfcee30c86edc1 # v1
       with:


### PR DESCRIPTION
## What

Updates our GitHub Actions versions and pins them to SHAs. Also sets up dependabot to do this for us.

## How

Resolved them to their current refs and then pins them to the latest release. 

## Breaking Changes

No customer facing changes. Only impacts CI & release actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned third-party GitHub Actions (including checkout, Docker, Codecov, and scripting/path filtering) to specific commit SHAs for consistent, reproducible CI runs
  * Updated Codecov action from v5 to v7.0.0
  * Added a Dependabot configuration to keep GitHub Actions up to date on a weekly schedule
  * Updated CI tooling for cluster creation and Nix caching while keeping existing build/test/release flow behavior the same
<!-- end of auto-generated comment: release notes by coderabbit.ai -->