### PR TITLE
chore(dependencies): Add nix updates to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,11 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(github-actions)"
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "area/devenv"
+      - "dependencies"


### PR DESCRIPTION
## What

This pull request updates the `.github/dependabot.yml` configuration to enable automated dependency updates for Nix packages. Dependabot will now check for Nix dependency updates weekly on Mondays and apply appropriate labels to related pull requests.

## How

* Added a new configuration for the `nix` package ecosystem, scheduling weekly updates on Mondays and labeling these pull requests with `area/devenv` and `dependencies`.

## Breaking Changes
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated update tracking for Nix-related dependencies.
  * Update pull requests will now be created weekly on Mondays from the repository root and labeled for easier triage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->