### PR TITLE
Migrate default metadatas from the old kubernetes-ingress-controller …

### DIFF
--- a/api/ingress/v1alpha1/domain_types.go
+++ b/api/ingress/v1alpha1/domain_types.go
@@ -40,10 +40,10 @@ const (
 // DomainSpec defines the desired state of Domain
 type DomainSpec struct {
 	// Description is a human-readable description of the object in the ngrok API/Dashboard
-	// +kubebuilder:default:=`Created by kubernetes-ingress-controller`
+	// +kubebuilder:default:=`Created by ngrok-operator`
 	Description string `json:"description,omitempty"`
 	// Metadata is a string of arbitrary data associated with the object in the ngrok API/Dashboard
-	// +kubebuilder:default:=`{"owned-by":"kubernetes-ingress-controller"}`
+	// +kubebuilder:default:=`{"owned-by":"ngrok-operator"}`
 	Metadata string `json:"metadata,omitempty"`
 
 	// Domain is the domain name to reserve

--- a/api/ingress/v1alpha1/ippolicy_types.go
+++ b/api/ingress/v1alpha1/ippolicy_types.go
@@ -30,10 +30,10 @@ import (
 
 type IPPolicyRule struct {
 	// Description is a human-readable description of the object in the ngrok API/Dashboard
-	// +kubebuilder:default:=`Created by kubernetes-ingress-controller`
+	// +kubebuilder:default:=`Created by ngrok-operator`
 	Description string `json:"description,omitempty"`
 	// Metadata is a string of arbitrary data associated with the object in the ngrok API/Dashboard
-	// +kubebuilder:default:=`{"owned-by":"kubernetes-ingress-controller"}`
+	// +kubebuilder:default:=`{"owned-by":"ngrok-operator"}`
 	Metadata string `json:"metadata,omitempty"`
 	// +kubebuilder:validation:Required
 	CIDR string `json:"cidr,omitempty"`
@@ -52,10 +52,10 @@ type IPPolicyRuleStatus struct {
 // IPPolicySpec defines the desired state of IPPolicy
 type IPPolicySpec struct {
 	// Description is a human-readable description of the object in the ngrok API/Dashboard
-	// +kubebuilder:default:=`Created by kubernetes-ingress-controller`
+	// +kubebuilder:default:=`Created by ngrok-operator`
 	Description string `json:"description,omitempty"`
 	// Metadata is a string of arbitrary data associated with the object in the ngrok API/Dashboard
-	// +kubebuilder:default:=`{"owned-by":"kubernetes-ingress-controller"}`
+	// +kubebuilder:default:=`{"owned-by":"ngrok-operator"}`
 	Metadata string `json:"metadata,omitempty"`
 	// Rules is a list of rules that belong to the policy
 	Rules []IPPolicyRule `json:"rules,omitempty"`

--- a/helm/ngrok-crds/templates/ingress.k8s.ngrok.com_domains.yaml
+++ b/helm/ngrok-crds/templates/ingress.k8s.ngrok.com_domains.yaml
@@ -81,7 +81,7 @@ spec:
             description: DomainSpec defines the desired state of Domain
             properties:
               description:
-                default: Created by kubernetes-ingress-controller
+                default: Created by ngrok-operator
                 description: Description is a human-readable description of the object
                   in the ngrok API/Dashboard
                 type: string
@@ -89,7 +89,7 @@ spec:
                 description: Domain is the domain name to reserve
                 type: string
               metadata:
-                default: '{"owned-by":"kubernetes-ingress-controller"}'
+                default: '{"owned-by":"ngrok-operator"}'
                 description: Metadata is a string of arbitrary data associated with
                   the object in the ngrok API/Dashboard
                 type: string

--- a/helm/ngrok-crds/templates/ingress.k8s.ngrok.com_ippolicies.yaml
+++ b/helm/ngrok-crds/templates/ingress.k8s.ngrok.com_ippolicies.yaml
@@ -63,12 +63,12 @@ spec:
             description: IPPolicySpec defines the desired state of IPPolicy
             properties:
               description:
-                default: Created by kubernetes-ingress-controller
+                default: Created by ngrok-operator
                 description: Description is a human-readable description of the object
                   in the ngrok API/Dashboard
                 type: string
               metadata:
-                default: '{"owned-by":"kubernetes-ingress-controller"}'
+                default: '{"owned-by":"ngrok-operator"}'
                 description: Metadata is a string of arbitrary data associated with
                   the object in the ngrok API/Dashboard
                 type: string
@@ -84,12 +84,12 @@ spec:
                     cidr:
                       type: string
                     description:
-                      default: Created by kubernetes-ingress-controller
+                      default: Created by ngrok-operator
                       description: Description is a human-readable description of
                         the object in the ngrok API/Dashboard
                       type: string
                     metadata:
-                      default: '{"owned-by":"kubernetes-ingress-controller"}'
+                      default: '{"owned-by":"ngrok-operator"}'
                       description: Metadata is a string of arbitrary data associated
                         with the object in the ngrok API/Dashboard
                       type: string

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/part-of: ngrok-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
+
 ---
 # Source: ngrok-operator/templates/api-manager/serviceaccount.yaml
 apiVersion: v1
@@ -28,6 +29,7 @@ metadata:
     app.kubernetes.io/part-of: ngrok-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
+
 ---
 # Source: ngrok-operator/templates/api-manager/configmap.yaml
 apiVersion: v1
@@ -46,6 +48,7 @@ data:
     leaderElection:
       leaderElect: true
       resourceName: ngrok-operator-leader
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/bindings.k8s.ngrok.com_boundendpoints.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -323,6 +326,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ingress.k8s.ngrok.com_domains.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -602,6 +606,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ingress.k8s.ngrok.com_ippolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -788,6 +793,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ngrok.k8s.ngrok.com_agentendpoints.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -1139,6 +1145,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ngrok.k8s.ngrok.com_cloudendpoints.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -1354,6 +1361,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -1559,6 +1567,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ngrok.k8s.ngrok.com_ngroktrafficpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -1622,6 +1631,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/templates/agent/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1702,6 +1712,7 @@ rules:
   - get
   - list
   - watch
+
 ---
 # Source: ngrok-operator/templates/api-manager/bindings-cluster-role.yaml
 # Bindings RBAC: cluster-wide rules required by the BoundEndpoint controller
@@ -2179,6 +2190,7 @@ rules:
   verbs:
   - patch
   - update
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/agentendpoint-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2212,6 +2224,7 @@ rules:
   - agentendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/agentendpoint-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2241,6 +2254,7 @@ rules:
   - agentendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/boundendpoint-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2274,6 +2288,7 @@ rules:
   - boundendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/boundendpoint-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2303,6 +2318,7 @@ rules:
   - boundendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/cloudendpoint-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2336,6 +2352,7 @@ rules:
   - cloudendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/cloudendpoint-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2365,6 +2382,7 @@ rules:
   - cloudendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/domain-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2398,6 +2416,7 @@ rules:
   - domains/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/domain-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2427,6 +2446,7 @@ rules:
   - domains/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/ippolicy-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2460,6 +2480,7 @@ rules:
   - ippolicies/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/ippolicy-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2489,6 +2510,7 @@ rules:
   - ippolicies/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/kubernetesoperator-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2522,6 +2544,7 @@ rules:
   - kubernetesoperators/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/kubernetesoperator-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2551,6 +2574,7 @@ rules:
   - kubernetesoperators/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/ngroktrafficpolicy-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2584,6 +2608,7 @@ rules:
   - ngroktrafficpolicies/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/ngroktrafficpolicy-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2613,6 +2638,7 @@ rules:
   - ngroktrafficpolicies/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/agent/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2627,6 +2653,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator-agent
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/api-manager/bindings-cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2641,6 +2668,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/api-manager/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2655,6 +2683,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/agent/release-namespace-role.yaml
 # Operator-state RBAC for the agent: the agent reads the singleton
@@ -2794,6 +2823,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator-agent
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/api-manager/leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2809,6 +2839,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/api-manager/release-namespace-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2824,6 +2855,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/agent/deployment.yaml
 apiVersion: apps/v1
@@ -2929,6 +2961,7 @@ spec:
         resources:
           limits: {}
           requests: {}
+
 ---
 # Source: ngrok-operator/templates/api-manager/deployment.yaml
 apiVersion: apps/v1
@@ -3039,6 +3072,7 @@ spec:
         resources:
           limits: {}
           requests: {}
+
 ---
 # Source: ngrok-operator/templates/ingress-class.yaml
 apiVersion: networking.k8s.io/v1
@@ -3127,6 +3161,7 @@ subjects:
   - kind: ServiceAccount
     name: ngrok-operator-cleanup
     namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/cleanup-hook/job.yaml
 apiVersion: batch/v1
@@ -3175,3 +3210,4 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
+

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -407,7 +407,7 @@ spec:
             description: DomainSpec defines the desired state of Domain
             properties:
               description:
-                default: Created by kubernetes-ingress-controller
+                default: Created by ngrok-operator
                 description: Description is a human-readable description of the object
                   in the ngrok API/Dashboard
                 type: string
@@ -415,7 +415,7 @@ spec:
                 description: Domain is the domain name to reserve
                 type: string
               metadata:
-                default: '{"owned-by":"kubernetes-ingress-controller"}'
+                default: '{"owned-by":"ngrok-operator"}'
                 description: Metadata is a string of arbitrary data associated with
                   the object in the ngrok API/Dashboard
                 type: string
@@ -668,12 +668,12 @@ spec:
             description: IPPolicySpec defines the desired state of IPPolicy
             properties:
               description:
-                default: Created by kubernetes-ingress-controller
+                default: Created by ngrok-operator
                 description: Description is a human-readable description of the object
                   in the ngrok API/Dashboard
                 type: string
               metadata:
-                default: '{"owned-by":"kubernetes-ingress-controller"}'
+                default: '{"owned-by":"ngrok-operator"}'
                 description: Metadata is a string of arbitrary data associated with
                   the object in the ngrok API/Dashboard
                 type: string
@@ -689,12 +689,12 @@ spec:
                     cidr:
                       type: string
                     description:
-                      default: Created by kubernetes-ingress-controller
+                      default: Created by ngrok-operator
                       description: Description is a human-readable description of
                         the object in the ngrok API/Dashboard
                       type: string
                     metadata:
-                      default: '{"owned-by":"kubernetes-ingress-controller"}'
+                      default: '{"owned-by":"ngrok-operator"}'
                       description: Metadata is a string of arbitrary data associated
                         with the object in the ngrok API/Dashboard
                       type: string

--- a/pkg/managerdriver/driver.go
+++ b/pkg/managerdriver/driver.go
@@ -168,7 +168,7 @@ func NewDriver(logger logr.Logger, scheme *runtime.Scheme, controllerName string
 
 // WithNgrokMetadata allows you to pass in custom ngrokmetadata to be added to all resources created by the controller
 func (d *Driver) WithNgrokMetadata(customNgrokMetadata map[string]string) *Driver {
-	ingressNgrokMetadata, err := d.setNgrokMetadataOwner("kubernetes-ingress-controller", customNgrokMetadata)
+	ingressNgrokMetadata, err := d.setNgrokMetadataOwner("ngrok-operator", customNgrokMetadata)
 	if err != nil {
 		d.log.Error(err, "error marshalling custom ngrokmetadata", "customNgrokMetadata", d.ingressNgrokMetadata)
 		return d


### PR DESCRIPTION
…to ngrok-operator

<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes K8SOP-275

## What

The operator used to be called the `kubernetes-ingress-controller`. we also put metadata values on all the resources we create in the ngrok api. By default we apply an "owned by" metadata field and note the operator. This changes the default values in the CRDs

## How

Change the default value the CRDs add for domains and ip policies created by the user. 
Also changes the default value the operator puts on the resources it makes via the driver. 

This will result in:
- any domains/ipPolicies users made themselves won't update automatically as its just the crd default changing
- any domains and other crds created by the operator will get their metadata updated and their controllers should reconcile them
- 

## Breaking Changes

Not in the operator, but technically someone could have recently started querying api resources using cel to filter on metadata and the value is going to change. But its easy to override the owned-by key


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated default ownership/description metadata for `Domain` and `IPPolicy` to use `ngrok-operator` instead of `kubernetes-ingress-controller`.
  * Ensured these updated defaults are applied consistently across CRD schemas, Helm charts, bundled manifests, and rule-level metadata/description values within `IPPolicy`.
  * Updated operator-provided metadata to reflect `ngrok-operator` ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->