### PR TITLE
Remove default resource request helm values for cleanup hook to follo…

### DIFF
--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -211,15 +211,13 @@ To run multiple ngrok-operator instances in the same cluster (e.g., in different
 
 ### Cleanup Hook configuration
 
-| Name                                    | Description                                                                                                                                      | Value             |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
-| `drainPolicy`                           | Policy for what to do with ngrok API resources while draining during an Uninstall. "Delete" removes ngrok API resources, "Retain" preserves them | `Retain`          |
-| `cleanupHook.enabled`                   | Enable the pre-delete cleanup hook that drains resources before uninstall                                                                        | `true`            |
-| `cleanupHook.timeout`                   | Timeout in seconds for the cleanup process                                                                                                       | `300`             |
-| `cleanupHook.image.repository`          | The repository for the kubectl image used by the cleanup hook                                                                                    | `bitnami/kubectl` |
-| `cleanupHook.image.tag`                 | The tag for the kubectl image                                                                                                                    | `latest`          |
-| `cleanupHook.image.pullPolicy`          | The pull policy for the cleanup hook image                                                                                                       | `IfNotPresent`    |
-| `cleanupHook.resources.limits.cpu`      | CPU limit for the cleanup hook container                                                                                                         | `100m`            |
-| `cleanupHook.resources.limits.memory`   | Memory limit for the cleanup hook container                                                                                                      | `128Mi`           |
-| `cleanupHook.resources.requests.cpu`    | CPU request for the cleanup hook container                                                                                                       | `50m`             |
-| `cleanupHook.resources.requests.memory` | Memory request for the cleanup hook container                                                                                                    | `64Mi`            |
+| Name                             | Description                                                                                                                                      | Value             |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
+| `drainPolicy`                    | Policy for what to do with ngrok API resources while draining during an Uninstall. "Delete" removes ngrok API resources, "Retain" preserves them | `Retain`          |
+| `cleanupHook.enabled`            | Enable the pre-delete cleanup hook that drains resources before uninstall                                                                        | `true`            |
+| `cleanupHook.timeout`            | Timeout in seconds for the cleanup process                                                                                                       | `300`             |
+| `cleanupHook.image.repository`   | The repository for the kubectl image used by the cleanup hook                                                                                    | `bitnami/kubectl` |
+| `cleanupHook.image.tag`          | The tag for the kubectl image                                                                                                                    | `latest`          |
+| `cleanupHook.image.pullPolicy`   | The pull policy for the cleanup hook image                                                                                                       | `IfNotPresent`    |
+| `cleanupHook.resources.limits`   | The resources limits for the cleanup hook container                                                                                              | `{}`              |
+| `cleanupHook.resources.requests` | The requested resources for the cleanup hook container                                                                                           | `{}`              |

--- a/helm/ngrok-operator/values.schema.json
+++ b/helm/ngrok-operator/values.schema.json
@@ -615,33 +615,13 @@
                     "properties": {
                         "limits": {
                             "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string",
-                                    "description": "CPU limit for the cleanup hook container",
-                                    "default": "100m"
-                                },
-                                "memory": {
-                                    "type": "string",
-                                    "description": "Memory limit for the cleanup hook container",
-                                    "default": "128Mi"
-                                }
-                            }
+                            "description": "The resources limits for the cleanup hook container",
+                            "default": {}
                         },
                         "requests": {
                             "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string",
-                                    "description": "CPU request for the cleanup hook container",
-                                    "default": "50m"
-                                },
-                                "memory": {
-                                    "type": "string",
-                                    "description": "Memory request for the cleanup hook container",
-                                    "default": "64Mi"
-                                }
-                            }
+                            "description": "The requested resources for the cleanup hook container",
+                            "default": {}
                         }
                     }
                 }

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -439,10 +439,13 @@ installCRDs: true
 ## @param cleanupHook.image.repository The repository for the kubectl image used by the cleanup hook
 ## @param cleanupHook.image.tag The tag for the kubectl image
 ## @param cleanupHook.image.pullPolicy The pull policy for the cleanup hook image
-## @param cleanupHook.resources.limits.cpu CPU limit for the cleanup hook container
-## @param cleanupHook.resources.limits.memory Memory limit for the cleanup hook container
-## @param cleanupHook.resources.requests.cpu CPU request for the cleanup hook container
-## @param cleanupHook.resources.requests.memory Memory request for the cleanup hook container
+## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param cleanupHook.resources.limits The resources limits for the cleanup hook container
+## @param cleanupHook.resources.requests The requested resources for the cleanup hook container
 ##
 drainPolicy: "Retain"  # "Delete" or "Retain"
 
@@ -454,9 +457,15 @@ cleanupHook:
     tag: latest
     pullPolicy: IfNotPresent
   resources:
-    limits:
-      cpu: 100m
-      memory: 128Mi
-    requests:
-      cpu: 50m
-      memory: 64Mi
+    ## Example:
+    ## limits:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    ##
+    limits: {}
+    ## Examples:
+    ## requests:
+    ##    cpu: 50m
+    ##    memory: 64Mi
+    ##
+    requests: {}

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/part-of: ngrok-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
+
 ---
 # Source: ngrok-operator/templates/api-manager/serviceaccount.yaml
 apiVersion: v1
@@ -28,6 +29,7 @@ metadata:
     app.kubernetes.io/part-of: ngrok-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
+
 ---
 # Source: ngrok-operator/templates/api-manager/configmap.yaml
 apiVersion: v1
@@ -46,6 +48,7 @@ data:
     leaderElection:
       leaderElect: true
       resourceName: ngrok-operator-leader
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/bindings.k8s.ngrok.com_boundendpoints.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -323,6 +326,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ingress.k8s.ngrok.com_domains.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -602,6 +606,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ingress.k8s.ngrok.com_ippolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -788,6 +793,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ngrok.k8s.ngrok.com_agentendpoints.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -1139,6 +1145,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ngrok.k8s.ngrok.com_cloudendpoints.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -1354,6 +1361,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -1559,6 +1567,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/charts/ngrok-crds/templates/ngrok.k8s.ngrok.com_ngroktrafficpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -1622,6 +1631,7 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 # Source: ngrok-operator/templates/agent/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1702,6 +1712,7 @@ rules:
   - get
   - list
   - watch
+
 ---
 # Source: ngrok-operator/templates/api-manager/bindings-cluster-role.yaml
 # Bindings RBAC: cluster-wide rules required by the BoundEndpoint controller
@@ -2179,6 +2190,7 @@ rules:
   verbs:
   - patch
   - update
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/agentendpoint-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2212,6 +2224,7 @@ rules:
   - agentendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/agentendpoint-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2241,6 +2254,7 @@ rules:
   - agentendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/boundendpoint-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2274,6 +2288,7 @@ rules:
   - boundendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/boundendpoint-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2303,6 +2318,7 @@ rules:
   - boundendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/cloudendpoint-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2336,6 +2352,7 @@ rules:
   - cloudendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/cloudendpoint-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2365,6 +2382,7 @@ rules:
   - cloudendpoints/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/domain-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2398,6 +2416,7 @@ rules:
   - domains/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/domain-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2427,6 +2446,7 @@ rules:
   - domains/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/ippolicy-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2460,6 +2480,7 @@ rules:
   - ippolicies/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/ippolicy-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2489,6 +2510,7 @@ rules:
   - ippolicies/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/kubernetesoperator-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2522,6 +2544,7 @@ rules:
   - kubernetesoperators/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/kubernetesoperator-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2551,6 +2574,7 @@ rules:
   - kubernetesoperators/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/ngroktrafficpolicy-editor.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2584,6 +2608,7 @@ rules:
   - ngroktrafficpolicies/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/rbac/crd-access/ngroktrafficpolicy-viewer.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2613,6 +2638,7 @@ rules:
   - ngroktrafficpolicies/status
   verbs:
   - get
+
 ---
 # Source: ngrok-operator/templates/agent/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2627,6 +2653,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator-agent
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/api-manager/bindings-cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2641,6 +2668,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/api-manager/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2655,6 +2683,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/agent/release-namespace-role.yaml
 # Operator-state RBAC for the agent: the agent reads the singleton
@@ -2794,6 +2823,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator-agent
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/api-manager/leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2809,6 +2839,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/api-manager/release-namespace-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2824,6 +2855,7 @@ subjects:
 - kind: ServiceAccount
   name: ngrok-operator
   namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/agent/deployment.yaml
 apiVersion: apps/v1
@@ -2929,6 +2961,7 @@ spec:
         resources:
           limits: {}
           requests: {}
+
 ---
 # Source: ngrok-operator/templates/api-manager/deployment.yaml
 apiVersion: apps/v1
@@ -3039,6 +3072,7 @@ spec:
         resources:
           limits: {}
           requests: {}
+
 ---
 # Source: ngrok-operator/templates/ingress-class.yaml
 apiVersion: networking.k8s.io/v1
@@ -3127,6 +3161,7 @@ subjects:
   - kind: ServiceAccount
     name: ngrok-operator-cleanup
     namespace: ngrok-operator
+
 ---
 # Source: ngrok-operator/templates/cleanup-hook/job.yaml
 apiVersion: batch/v1
@@ -3169,9 +3204,6 @@ spec:
               echo "Deleting KubernetesOperator 'ngrok-operator' to trigger drain..."
               kubectl delete kubernetesoperator "ngrok-operator" -n ngrok-operator --wait=true --timeout=300s || true
           resources:
-            limits:
-              cpu: 100m
-              memory: 128Mi
-            requests:
-              cpu: 50m
-              memory: 64Mi
+            limits: {}
+            requests: {}
+


### PR DESCRIPTION
…w best practices

<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Resolves K8SOP-281

## What

Removes the default resource requests and limits for the helm cleanup hook job. Typical best practices are to not set resource requests so that the chart works by default even on small clusters.

## How

Followed the conventions of other helm value resources

## Breaking Changes
Very minor yes, removing the defaults


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Helm chart docs to describe `cleanupHook.resources.limits` and `cleanupHook.resources.requests` as generic resource maps.

* **Bug Fixes**
  * Updated cleanup hook default resources to empty maps (`{}`), removing preset CPU/memory values.
  * Adjusted the chart value schema and bundled chart output to match the new cleanup hook resource configuration.
  * Ensured the cleanup hook job no longer applies fixed CPU/memory constraints by default.

* **Chores**
  * Applied whitespace-only formatting updates in the bundled manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->