### PR TITLE
fix(nix): drop stale helm-unittest plugin.yaml override

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,16 +91,7 @@
               kubernetes-controller-tools
               (pkgs.wrapHelm pkgs.kubernetes-helm {
                 plugins = [
-                  # helm-unittest 1.1.0 changed plugin.yaml from a single `command` field
-                  # to `platformCommand` entries with platform-suffixed binary names, but
-                  # nixpkgs builds one binary from source and installs it as plain `untt`.
-                  # Patch plugin.yaml to match, mirroring the fix planned for upstream nixpkgs.
-                  (pkgs.kubernetes-helmPlugins.helm-unittest.overrideAttrs (old: {
-                    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.yq-go ];
-                    postPatch = ''
-                      yq -i 'del(.platformCommand) | del(.platformHooks) | .command = "''${HELM_PLUGIN_DIR}/untt"' plugin.yaml
-                    '';
-                  }))
+                  pkgs.kubernetes-helmPlugins.helm-unittest
                 ];
               })
               kyverno-chainsaw


### PR DESCRIPTION
## Problem

`make helm-test` fails on `main` (and any rebased branch) with:

```
Error: fork/exec /nix/store/.../helm-plugins/helm-unittest/untt: no such file or directory
```

## Cause

nixpkgs bump #836 (`e52c192` → `f205b55`) upgraded `helm-unittest` to **1.1.1**. Upstream nixpkgs now:
- installs the binary as `helm-unittest` (no longer plain `untt`)
- ships a correct `platformCommand` pointing at `$HELM_PLUGIN_DIR/helm-unittest`

Our `overrideAttrs` in `flake.nix` still deleted that `platformCommand` and rewrote `command = ${HELM_PLUGIN_DIR}/untt`. So helm exec'd a binary that no longer exists.

The override was a workaround for the *old* broken packaging. Upstream fixed the root cause, so the workaround now breaks the build.

## Fix

Use the bare `pkgs.kubernetes-helmPlugins.helm-unittest` plugin.

## Verification

```
nix develop --command helm unittest -f 'tests/**/*_test.yaml' helm/ngrok-operator
Test Suites: 15 passed, 15 total
Tests:       131 passed, 131 total
Snapshot:    52 passed, 52 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment to include the Helm unittest plugin in the default shell.
  * Aligned the plugin setup with the current upstream package behavior for a smoother local workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->