### PR TITLE
Fix some small issues we noticed with the specs

### DIFF
--- a/specs/controllers/agentendpoint.md
+++ b/specs/controllers/agentendpoint.md
@@ -10,7 +10,7 @@ The AgentEndpoint controller reconciles `AgentEndpoint` resources by creating an
 |-----------------------|------------|----------------------------------------------|
 | `AgentEndpoint`       | Primary    | AnnotationChanged or GenerationChanged       |
 | `TrafficPolicy`  | Secondary  | Indexed by `spec.trafficPolicyName`; DELETE events filtered |
-| `Secret`              | Secondary  | Indexed by client certificate refs; DELETE events filtered |
+| `Secret`              | Secondary  | Secrets referenced by client certs or TLS termination        |
 | `Domain`              | Owned      | All events                                   |
 
 ## Reconciliation Flow
@@ -44,10 +44,10 @@ AgentEndpoints support agent-side TLS termination via `spec.tlsTermination`. Whe
 
 | Field      | Type           | Description |
 |------------|----------------|-------------|
-| `caBundleRef` | `K8sObjectRef` | Reference to a Secret whose `ca.crt` key holds a PEM-encoded CA bundle trusted to sign client certificates. |
+| `clientCAsRef` | `K8sObjectRef` | Reference to a Secret whose `ca.crt` key holds a PEM-encoded CA bundle trusted to sign client certificates. Must be in the same namespace as the AgentEndpoint. |
 | `mode`     | string         | `"require"` (client cert required) or `"request"` (client cert requested but optional). |
 
-The controller watches referenced Secrets (via secondary watch indexed by `spec.clientCertificateRefs`) and re-reconciles when they change so that certificate rotations are picked up automatically.
+The controller watches the referenced Secrets and re-reconciles when they change, so certificate rotations are picked up automatically.
 
 ## Status
 

--- a/specs/crds/agentendpoint.md
+++ b/specs/crds/agentendpoint.md
@@ -21,7 +21,8 @@
 | `description`           | string                            | No       | `"Created by the ngrok-operator"`      |                                       |
 | `metadata`              | map[string]string                 | No       | `{"owned-by": "ngrok-operator"}`      |                                       |
 | `bindings`              | []string                          | No       |                                        | MaxItems: 1, Pattern: `^(public\|internal\|kubernetes)$` |
-| `clientCertificateRefs` | []K8sObjectRefOptionalNamespace   | No       |                                        |                                       |
+| `clientCertificateRefs` | []K8sObjectRef                    | No       |                                        | Client certificates presented to the upstream during the TLS handshake |
+| `tlsTermination`        | EndpointTLSTermination            | No       |                                        | XValidation: `spec.url` must be a `tls://` URL when set |
 
 ### EndpointUpstream
 
@@ -30,6 +31,24 @@
 | `url`                  | string                   | Yes      |                         |
 | `protocol`             | ApplicationProtocol      | No       | Enum: `http1`, `http2`  |
 | `proxyProtocolVersion` | ProxyProtocolVersion     | No       | Enum: `"1"`, `"2"`     |
+
+### EndpointTLSTermination
+
+Configures agent-side ("zero-knowledge") TLS termination. When set, the ngrok edge routes the encrypted stream to the in-cluster agent based on SNI; the TLS handshake completes between the client and the agent, so ngrok never sees the plaintext. The agent then forwards to the upstream defined by `spec.upstream`.
+
+Requires `spec.url` to use the `tls://` scheme (enforced by XValidation). Cannot be combined with the edge-side `terminate-tls` traffic-policy action, which terminates before traffic reaches the agent.
+
+| Field                  | Type              | Required | Description |
+|------------------------|-------------------|----------|-------------|
+| `serverCertificateRef` | K8sObjectRef      | Yes      | Reference to a `kubernetes.io/tls` Secret containing the server certificate (`tls.crt`) and key (`tls.key`) the agent presents to clients. Must be in the same namespace as the AgentEndpoint. |
+| `mutualTLS`            | EndpointMutualTLS | No       | When set, enables mTLS — the agent requires or requests client certificates during the handshake and validates them against the supplied CA bundle. |
+
+### EndpointMutualTLS
+
+| Field          | Type         | Required | Default   | Validation                | Description |
+|----------------|--------------|----------|-----------|---------------------------|-------------|
+| `clientCAsRef` | K8sObjectRef | Yes      |           |                           | Reference to a Secret whose `ca.crt` key holds a PEM-encoded CA bundle trusted to sign client certificates. Must be in the same namespace as the AgentEndpoint. |
+| `mode`         | string       | No       | `require` | Enum: `require`, `request` | `require` rejects the handshake if no valid client cert is presented; `request` requests a client cert but does not require one. |
 
 ## Status
 

--- a/specs/crds/common.md
+++ b/specs/crds/common.md
@@ -93,7 +93,7 @@ Configures a traffic policy via either an inline definition or a reference to a 
 | Field       | Type            | Required | Description                              |
 |-------------|-----------------|----------|------------------------------------------|
 | `inline`    | json.RawMessage | No       | Inline traffic policy JSON (schemaless)  |
-| `targetRef` | K8sObjectRefOptionalNamespace | No | Reference to a TrafficPolicy |
+| `targetRef` | K8sObjectRef | No | Reference to a TrafficPolicy in the same namespace |
 
 ### ApplicationProtocol
 


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Resolves K8SOP-277

## What

When diffing the specs with the code and cutting tickets we found a couple of small issues with the specs. 

## How

Implemented the changes we called out in the ticket and compared them with the code. mostly it adds in things for the agent endpoint tls configs. additionally it sets the traffic policy ref to not support cross namespaces which is a decision we landed on afterwards.

Note: the ticket does call out consolidating the migration guide files. since i have active prs open adding to this, I figured it would be easier to consolidate those later before the release

## Breaking Changes

No, just docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `AgentEndpoint` and related CRD docs to reflect improved TLS and mutual TLS configuration.
  * Clarified certificate reference requirements, including same-namespace constraints for some references.
  * Added guidance on TLS termination settings, required server certificates, and client CA handling.
  * Documented that the controller watches referenced secrets and re-reconciles when certificates change, supporting certificate rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->