### PR TITLE
Make the secret name used for mtls with the operator and bindings con…

### DIFF
--- a/api/ngrok/v1alpha1/kubernetesoperator_types.go
+++ b/api/ngrok/v1alpha1/kubernetesoperator_types.go
@@ -50,7 +50,7 @@ type KubernetesOperatorBinding struct {
 
 	// TlsSecretName is the name of the k8s secret that contains the TLS private/public keys to use for the ngrok forwarding endpoint
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default="default-tls"
+	// +kubebuilder:validation:MinLength=1
 	TlsSecretName string `json:"tlsSecretName"`
 }
 

--- a/cmd/api-manager.go
+++ b/cmd/api-manager.go
@@ -125,6 +125,7 @@ type apiManagerOpts struct {
 		serviceAnnotations string
 		serviceLabels      string
 		ingressEndpoint    string
+		tlsSecretName      string
 	}
 
 	// env vars
@@ -171,6 +172,7 @@ func apiCmd() *cobra.Command {
 	c.Flags().StringVar(&opts.bindings.serviceAnnotations, "bindings-service-annotations", "", "Service Annotations to propagate to the target service")
 	c.Flags().StringVar(&opts.bindings.serviceLabels, "bindings-service-labels", "", "Service Labels to propagate to the target service")
 	c.Flags().StringVar(&opts.bindings.ingressEndpoint, "bindings-ingress-endpoint", "", "The endpoint the bindings forwarder connects to")
+	c.Flags().StringVar(&opts.bindings.tlsSecretName, "bindings-tls-secret-name", "", "Name of the k8s Secret holding the bindings mTLS certificate")
 	c.Flags().StringVar(&opts.defaultDomainReclaimPolicy, "default-domain-reclaim-policy", string(ingressv1alpha1.DomainReclaimPolicyDelete), "The default domain reclaim policy to apply to created domains")
 	c.Flags().StringVar((*string)(&opts.drainPolicy), "drain-policy", string(ngrokv1alpha1.DrainPolicyRetain), "Policy for draining resources during uninstall: Delete or Retain")
 
@@ -822,9 +824,12 @@ func createKubernetesOperator(ctx context.Context, client client.Client, opts ap
 		}
 
 		if opts.enableFeatureBindings {
+			if opts.bindings.tlsSecretName == "" {
+				return errors.New("--bindings-tls-secret-name is required when bindings are enabled")
+			}
 			features = append(features, ngrokv1alpha1.KubernetesOperatorFeatureBindings)
 			k8sOperator.Spec.Binding = &ngrokv1alpha1.KubernetesOperatorBinding{
-				TlsSecretName:     "ngrok-operator-default-tls",
+				TlsSecretName:     opts.bindings.tlsSecretName,
 				EndpointSelectors: opts.bindings.endpointSelectors,
 			}
 			if opts.bindings.ingressEndpoint != "" {

--- a/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
+++ b/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
@@ -76,10 +76,10 @@ spec:
                     description: The public ingress endpoint for this Kubernetes Operator
                     type: string
                   tlsSecretName:
-                    default: default-tls
                     description: TlsSecretName is the name of the k8s secret that
                       contains the TLS private/public keys to use for the ngrok forwarding
                       endpoint
+                    minLength: 1
                     type: string
                 required:
                 - endpointSelectors

--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -191,6 +191,7 @@ To run multiple ngrok-operator instances in the same cluster (e.g., in different
 | `bindings.serviceAnnotations`                      | Annotations to add to projected services bound to an endpoint                                                 | `{}`                                      |
 | `bindings.serviceLabels`                           | Labels to add to projected services bound to an endpoint                                                      | `{}`                                      |
 | `bindings.ingressEndpoint`                         | The hostname of the ingress endpoint for the bindings                                                         | `kubernetes-binding-ingress.ngrok.io:443` |
+| `bindings.tlsSecretName`                           | Name of the Secret holding the bindings mTLS certificate. When empty, defaults to "<fullname>-default-tls".   | `""`                                      |
 | `bindings.forwarder.replicaCount`                  | The number of bindings forwarders to run.                                                                     | `1`                                       |
 | `bindings.forwarder.resources.limits`              | The resources limits for the container                                                                        | `{}`                                      |
 | `bindings.forwarder.resources.requests`            | The requested resources for the container                                                                     | `{}`                                      |

--- a/helm/ngrok-operator/templates/api-manager/deployment.yaml
+++ b/helm/ngrok-operator/templates/api-manager/deployment.yaml
@@ -98,6 +98,7 @@ spec:
           {{- $serviceLabels | join "," }}
         {{- end }}
         - --bindings-ingress-endpoint={{ .Values.bindings.ingressEndpoint }}
+        - --bindings-tls-secret-name={{ .Values.bindings.tlsSecretName | default (printf "%s-default-tls" (include "ngrok-operator.fullname" .)) }}
         {{- end }}
         {{- if .Values.description }}
         - {{ printf "--description=%s" .Values.description | quote }}

--- a/helm/ngrok-operator/tests/api-manager/deployment_test.yaml
+++ b/helm/ngrok-operator/tests/api-manager/deployment_test.yaml
@@ -236,6 +236,29 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: --bindings-endpoint-selectors=true,false
+- it: Defaults the bindings TLS secret name to <fullname>-default-tls
+  set:
+    bindings:
+      enabled: true
+  release:
+    name: ngrok-operator
+  template: api-manager/deployment.yaml
+  documentIndex: 0
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --bindings-tls-secret-name=ngrok-operator-default-tls
+- it: Allows overriding the bindings TLS secret name
+  set:
+    bindings:
+      enabled: true
+      tlsSecretName: my-custom-tls
+  template: api-manager/deployment.yaml
+  documentIndex: 0
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --bindings-tls-secret-name=my-custom-tls
 - it: Should pass one-click-demo mode if set
   set:
     oneClickDemoMode: true

--- a/helm/ngrok-operator/values.schema.json
+++ b/helm/ngrok-operator/values.schema.json
@@ -488,6 +488,11 @@
                     "description": "The hostname of the ingress endpoint for the bindings",
                     "default": "kubernetes-binding-ingress.ngrok.io:443"
                 },
+                "tlsSecretName": {
+                    "type": "string",
+                    "description": "Name of the Secret holding the bindings mTLS certificate. When empty, defaults to \"<fullname>-default-tls\".",
+                    "default": ""
+                },
                 "forwarder": {
                     "type": "object",
                     "properties": {

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -352,6 +352,7 @@ gateway:
 ## @param bindings.serviceAnnotations Annotations to add to projected services bound to an endpoint
 ## @param bindings.serviceLabels Labels to add to projected services bound to an endpoint
 ## @param bindings.ingressEndpoint The hostname of the ingress endpoint for the bindings
+## @param bindings.tlsSecretName Name of the Secret holding the bindings mTLS certificate. When empty, defaults to "<fullname>-default-tls".
 ##
 bindings:
   enabled: false # in-development
@@ -360,6 +361,7 @@ bindings:
   serviceAnnotations: {}
   serviceLabels: {}
   ingressEndpoint: "kubernetes-binding-ingress.ngrok.io:443"
+  tlsSecretName: ""
 
   forwarder:
     ## @param bindings.forwarder.replicaCount The number of bindings forwarders to run.

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -1441,10 +1441,10 @@ spec:
                     description: The public ingress endpoint for this Kubernetes Operator
                     type: string
                   tlsSecretName:
-                    default: default-tls
                     description: TlsSecretName is the name of the k8s secret that
                       contains the TLS private/public keys to use for the ngrok forwarding
                       endpoint
+                    minLength: 1
                     type: string
                 required:
                 - endpointSelectors

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -68,7 +68,7 @@ The operator pods mount the Secret as environment variables:
 
 ## mTLS for Bindings
 
-When the bindings feature is enabled, the operator generates a self-signed TLS certificate and creates a Certificate Signing Request (CSR) with the ngrok API. This certificate is stored in a Secret (default name: `default-tls`) in the operator's namespace and is used for mTLS communication between the bindings forwarder and ngrok's ingress endpoint.
+When the bindings feature is enabled, the operator generates a self-signed TLS certificate and creates a Certificate Signing Request (CSR) with the ngrok API. This certificate is stored in a Secret in the operator's namespace and is used for mTLS communication between the bindings forwarder and ngrok's ingress endpoint. The Secret name is configurable via the `bindings.tlsSecretName` Helm value; when empty it defaults to `<release-fullname>-default-tls` (e.g. `ngrok-operator-default-tls`).
 
 ## One-Click Demo Mode
 

--- a/specs/controllers/kubernetesoperator.md
+++ b/specs/controllers/kubernetesoperator.md
@@ -61,7 +61,7 @@ This prevents different clusters with identical release names from clobbering ea
 
 The controller calls `findOrCreateTLSSecret` to manage the operator's mTLS certificate:
 
-1. Reads the Secret named `default-tls` (or the configured name) from the release namespace.
+1. Reads the Secret named by `binding.tlsSecretName` (default `<release-fullname>-default-tls`) from the release namespace.
 2. If it doesn't exist, generates a self-signed certificate and creates the Secret.
 3. Submits a CSR to the ngrok API so the certificate is trusted for bindings mTLS.
 4. On subsequent reconciles, reads the existing Secret and refreshes the CSR if the certificate is near expiry.

--- a/specs/crds/kubernetesoperator.md
+++ b/specs/crds/kubernetesoperator.md
@@ -35,7 +35,7 @@
 |---------------------|----------|----------|----------------|---------------------------------------|
 | `endpointSelectors` | []string | Yes      |                | CEL expressions filtering endpoints   |
 | `ingressEndpoint`   | *string  | No       |                | Bindings ingress endpoint hostname    |
-| `tlsSecretName`     | string   | Yes      | `"default-tls"`| Secret name for mTLS certificate      |
+| `tlsSecretName`     | string   | Yes      | _(none)_       | Secret name for mTLS certificate. Required, no schema default; the operator always sets it from `--bindings-tls-secret-name` (Helm `bindings.tlsSecretName`, default `<release-fullname>-default-tls`). |
 
 ### DrainConfig
 

--- a/specs/features/bindings.md
+++ b/specs/features/bindings.md
@@ -39,7 +39,7 @@ Bindings is opt-in (`features.bindings.enabled: false` by default).
 The bindings forwarder uses mutual TLS for secure communication with ngrok's ingress endpoint:
 
 - The operator generates a self-signed TLS certificate and submits a CSR to the ngrok API.
-- The certificate is stored in a Kubernetes Secret (default name: `default-tls`).
+- The certificate is stored in a Kubernetes Secret in the operator's namespace. The name is set via the `bindings.tlsSecretName` Helm value, which plumbs through to the `--bindings-tls-secret-name` flag and onto the `KubernetesOperator` CR's `binding.tlsSecretName` field. When the Helm value is empty it defaults to `<release-fullname>-default-tls` (e.g. `ngrok-operator-default-tls`), prefixed per-release to avoid collisions between operators sharing a namespace.
 - The forwarder uses this certificate to authenticate with the ingress endpoint.
 
 ## Related Specs


### PR DESCRIPTION
…figurable via helm

<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Resolves K8SOP-278

## What

On startup the operator is responsible for creating its KubernetesOperator CRD. On that CRD is a `TlsSecretName`. the KubernetesOperator controller makes a cert in this secret and the bindings forwarder uses the operator field to find the secret name to lookup and use when connecting to the bindings endpoint. 

Previously this was just hardcoded to `ngrok-operator-default-tls`

## How

Add a helm value to make it configurable. use the full name override as a prefix to avoid secret collisions. 

## Breaking Changes

If you are overriding the release name to be something different than `ngrok-operator` then your "default" value for this secret name will change but should reconcile and be eventually consistent. Users can set the secret name to the old secret value for passivity if they want. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the TLS secret used by the Bindings feature via Helm/flags.
  * When not set, the operator now uses a release-scoped default secret name instead of a fixed value.

* **Bug Fixes**
  * Removed the implicit default for the bindings TLS secret field.
  * Enforced validation to reject empty secret names.

* **Documentation**
  * Updated Bindings and authentication docs, plus CRD/reference text, to reflect the new release-based TLS secret naming and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->