### PR TITLE
Add top-level status.observedGeneration to all CRDs

### DIFF
--- a/api/bindings/v1alpha1/boundendpoint_types.go
+++ b/api/bindings/v1alpha1/boundendpoint_types.go
@@ -75,6 +75,12 @@ func (s *BoundEndpointSpec) GetEndpointURL() string {
 
 // BoundEndpointStatus defines the observed state of BoundEndpoint
 type BoundEndpointStatus struct {
+	// ObservedGeneration is the most recent metadata.generation observed by the
+	// controller. When it matches metadata.generation, the status reflects the
+	// latest spec.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Endpoints is the list of ngrok API endpoint references bound to this BoundEndpoint
 	// All endpoints share the same underlying Kubernetes services
 	Endpoints []BindingEndpoint `json:"endpoints,omitempty"`
@@ -165,6 +171,11 @@ type BoundEndpoint struct {
 
 	Spec   BoundEndpointSpec   `json:"spec,omitempty"`
 	Status BoundEndpointStatus `json:"status,omitempty"`
+}
+
+// SetObservedGeneration records the generation the controller reconciled.
+func (b *BoundEndpoint) SetObservedGeneration(generation int64) {
+	b.Status.ObservedGeneration = generation
 }
 
 // +kubebuilder:object:root=true

--- a/api/ingress/v1alpha1/domain_types.go
+++ b/api/ingress/v1alpha1/domain_types.go
@@ -85,6 +85,12 @@ func (s *DomainSpec) GetResolvesTo() *[]DomainResolvesToEntry {
 // DomainStatus defines the observed state of Domain
 type DomainStatus struct {
 
+	// ObservedGeneration is the most recent metadata.generation observed by the
+	// controller. When it matches metadata.generation, the status reflects the
+	// latest spec.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// ID is the unique identifier of the domain
 	ID string `json:"id,omitempty"`
 
@@ -178,6 +184,11 @@ type Domain struct {
 
 	Spec   DomainSpec   `json:"spec,omitempty"`
 	Status DomainStatus `json:"status,omitempty"`
+}
+
+// SetObservedGeneration records the generation the controller reconciled.
+func (d *Domain) SetObservedGeneration(generation int64) {
+	d.Status.ObservedGeneration = generation
 }
 
 // +kubebuilder:object:root=true

--- a/api/ingress/v1alpha1/ippolicy_types.go
+++ b/api/ingress/v1alpha1/ippolicy_types.go
@@ -63,6 +63,12 @@ type IPPolicySpec struct {
 
 // IPPolicyStatus defines the observed state of IPPolicy
 type IPPolicyStatus struct {
+	// ObservedGeneration is the most recent metadata.generation observed by the
+	// controller. When it matches metadata.generation, the status reflects the
+	// latest spec.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	ID string `json:"id,omitempty"`
 
 	// Conditions represent the latest available observations of the IP policy's state
@@ -89,6 +95,11 @@ type IPPolicy struct {
 
 	Spec   IPPolicySpec   `json:"spec,omitempty"`
 	Status IPPolicyStatus `json:"status,omitempty"`
+}
+
+// SetObservedGeneration records the generation the controller reconciled.
+func (p *IPPolicy) SetObservedGeneration(generation int64) {
+	p.Status.ObservedGeneration = generation
 }
 
 // +kubebuilder:object:root=true

--- a/api/ngrok/v1alpha1/agentendpoint_types.go
+++ b/api/ngrok/v1alpha1/agentendpoint_types.go
@@ -234,6 +234,12 @@ func (t *TrafficPolicyCfg) Type() TrafficPolicyCfgType {
 
 // AgentEndpointStatus defines the observed state of an AgentEndpoint
 type AgentEndpointStatus struct {
+	// ObservedGeneration is the most recent metadata.generation observed by the
+	// controller. When it matches metadata.generation, the status reflects the
+	// latest spec.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// The assigned URL. This will either be the user-supplied url, or the generated assigned url
 	// depending on the configuration of spec.url
 	AssignedURL string `json:"assignedURL,omitempty"`
@@ -275,6 +281,11 @@ func (a *AgentEndpoint) GetConditions() *[]metav1.Condition {
 // GetGeneration returns the generation for AgentEndpoint
 func (a *AgentEndpoint) GetGeneration() int64 {
 	return a.Generation
+}
+
+// SetObservedGeneration records the generation the controller reconciled.
+func (a *AgentEndpoint) SetObservedGeneration(generation int64) {
+	a.Status.ObservedGeneration = generation
 }
 
 // GetDomainRef returns the domain reference for AgentEndpoint

--- a/api/ngrok/v1alpha1/cloudendpoint_types.go
+++ b/api/ngrok/v1alpha1/cloudendpoint_types.go
@@ -80,6 +80,12 @@ type CloudEndpointSpec struct {
 
 // CloudEndpointStatus defines the observed state of CloudEndpoint
 type CloudEndpointStatus struct {
+	// ObservedGeneration is the most recent metadata.generation observed by the
+	// controller. When it matches metadata.generation, the status reflects the
+	// latest spec.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// ID is the unique identifier for this endpoint
 	ID string `json:"id,omitempty"`
 
@@ -139,6 +145,11 @@ func (c *CloudEndpoint) GetConditions() *[]metav1.Condition {
 // GetGeneration returns the generation for CloudEndpoint
 func (c *CloudEndpoint) GetGeneration() int64 {
 	return c.Generation
+}
+
+// SetObservedGeneration records the generation the controller reconciled.
+func (c *CloudEndpoint) SetObservedGeneration(generation int64) {
+	c.Status.ObservedGeneration = generation
 }
 
 // GetDomainRef returns the domain reference for CloudEndpoint

--- a/api/ngrok/v1alpha1/kubernetesoperator_types.go
+++ b/api/ngrok/v1alpha1/kubernetesoperator_types.go
@@ -56,6 +56,12 @@ type KubernetesOperatorBinding struct {
 
 // KubernetesOperatorStatus defines the observed state of KubernetesOperator
 type KubernetesOperatorStatus struct {
+	// ObservedGeneration is the most recent metadata.generation observed by the
+	// controller. When it matches metadata.generation, the status reflects the
+	// latest spec.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// ID is the unique identifier for this Kubernetes Operator
 	ID string `json:"id,omitempty"`
 
@@ -185,6 +191,11 @@ type KubernetesOperator struct {
 
 	Spec   KubernetesOperatorSpec   `json:"spec,omitempty"`
 	Status KubernetesOperatorStatus `json:"status,omitempty"`
+}
+
+// SetObservedGeneration records the generation the controller reconciled.
+func (ko *KubernetesOperator) SetObservedGeneration(generation int64) {
+	ko.Status.ObservedGeneration = generation
 }
 
 // +kubebuilder:object:root=true

--- a/api/ngrok/v1alpha1/kubernetesoperator_types.go
+++ b/api/ngrok/v1alpha1/kubernetesoperator_types.go
@@ -193,11 +193,6 @@ type KubernetesOperator struct {
 	Status KubernetesOperatorStatus `json:"status,omitempty"`
 }
 
-// SetObservedGeneration records the generation the controller reconciled.
-func (ko *KubernetesOperator) SetObservedGeneration(generation int64) {
-	ko.Status.ObservedGeneration = generation
-}
-
 // +kubebuilder:object:root=true
 
 // KubernetesOperatorList contains a list of KubernetesOperator

--- a/api/ngrok/v1alpha1/ngroktrafficpolicy_types.go
+++ b/api/ngrok/v1alpha1/ngroktrafficpolicy_types.go
@@ -42,6 +42,12 @@ type NgrokTrafficPolicySpec struct {
 // NgrokTrafficPolicyStatus defines the observed state of NgrokTrafficPolicy
 type NgrokTrafficPolicyStatus struct {
 
+	// ObservedGeneration is the most recent metadata.generation observed by the
+	// controller. When it matches metadata.generation, the status reflects the
+	// latest spec.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// The raw json encoded policy that was applied to the ngrok API
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
@@ -59,6 +65,11 @@ type NgrokTrafficPolicy struct {
 
 	Spec   NgrokTrafficPolicySpec   `json:"spec,omitempty"`
 	Status NgrokTrafficPolicyStatus `json:"status,omitempty"`
+}
+
+// SetObservedGeneration records the generation the controller reconciled.
+func (tp *NgrokTrafficPolicy) SetObservedGeneration(generation int64) {
+	tp.Status.ObservedGeneration = generation
 }
 
 // +kubebuilder:object:root=true

--- a/helm/ngrok-crds/templates/bindings.k8s.ngrok.com_boundendpoints.yaml
+++ b/helm/ngrok-crds/templates/bindings.k8s.ngrok.com_boundendpoints.yaml
@@ -245,6 +245,13 @@ spec:
                 description: HashName is the hashed output of the TargetService and
                   TargetNamespace for unique identification
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               targetServiceRef:
                 description: TargetServiceRef references the created ExternalName
                   Service in the target namespace

--- a/helm/ngrok-crds/templates/ingress.k8s.ngrok.com_domains.yaml
+++ b/helm/ngrok-crds/templates/ingress.k8s.ngrok.com_domains.yaml
@@ -268,6 +268,13 @@ spec:
               id:
                 description: ID is the unique identifier of the domain
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               region:
                 description: Region is the region in which the domain was created
                 type: string

--- a/helm/ngrok-crds/templates/ingress.k8s.ngrok.com_ippolicies.yaml
+++ b/helm/ngrok-crds/templates/ingress.k8s.ngrok.com_ippolicies.yaml
@@ -166,6 +166,13 @@ spec:
                 x-kubernetes-list-type: map
               id:
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               rules:
                 items:
                   properties:

--- a/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_agentendpoints.yaml
+++ b/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_agentendpoints.yaml
@@ -338,6 +338,13 @@ spec:
                 required:
                 - name
                 type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               trafficPolicy:
                 description: Identifies any traffic policies attached to the AgentEndpoint
                   ("inline", "none", or reference name).

--- a/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_cloudendpoints.yaml
+++ b/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_cloudendpoints.yaml
@@ -206,6 +206,13 @@ spec:
               id:
                 description: ID is the unique identifier for this endpoint
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
+++ b/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
@@ -180,6 +180,13 @@ spec:
               id:
                 description: ID is the unique identifier for this Kubernetes Operator
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               registrationErrorCode:
                 description: RegistrationErrorCode is the returned ngrok error code
                 pattern: ^ERR_NGROK_\d+$

--- a/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_ngroktrafficpolicies.yaml
+++ b/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_ngroktrafficpolicies.yaml
@@ -49,6 +49,13 @@ spec:
           status:
             description: NgrokTrafficPolicyStatus defines the observed state of NgrokTrafficPolicy
             properties:
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               policy:
                 description: The raw json encoded policy that was applied to the ngrok
                   API

--- a/internal/controller/base_controller.go
+++ b/internal/controller/base_controller.go
@@ -153,6 +153,14 @@ func (self *BaseController[T]) handleErr(op BaseControllerOp, obj T, err error) 
 	return CtrlResultForErr(err)
 }
 
+// ObservedGenerationSetter is implemented by CRDs whose status records the most
+// recently reconciled metadata.generation. ReconcileStatus stamps it
+// automatically so external tooling (kubectl wait, Argo CD, etc.) can detect
+// whether the status reflects the latest spec.
+type ObservedGenerationSetter interface {
+	SetObservedGeneration(generation int64)
+}
+
 // ReconcileStatus reconciles the status of an object, retrying on conflict.
 //
 // Status update conflicts are common because the object's resourceVersion can
@@ -166,6 +174,10 @@ func (self *BaseController[T]) handleErr(op BaseControllerOp, obj T, err error) 
 // callers manage their own retry/conflict logic and should not use this method.
 func (self *BaseController[T]) ReconcileStatus(ctx context.Context, obj T, origErr error) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("originalError", origErr)
+
+	if setter, ok := client.Object(obj).(ObservedGenerationSetter); ok {
+		setter.SetObservedGeneration(obj.GetGeneration())
+	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		err := self.Kube.Status().Update(ctx, obj)

--- a/internal/controller/base_controller_test.go
+++ b/internal/controller/base_controller_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/ngrok/ngrok-api-go/v7"
+	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/drain"
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
 	"github.com/ngrok/ngrok-operator/internal/util"
@@ -296,6 +297,60 @@ func TestBaseController_Reconcile_Delete_NotFound(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
+}
+
+func TestBaseController_ReconcileStatus_SetsObservedGeneration(t *testing.T) {
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	require.NoError(t, ingressv1alpha1.AddToScheme(s))
+
+	domain := &ingressv1alpha1.Domain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-domain",
+			Namespace:  "default",
+			Generation: 3,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(domain).WithStatusSubresource(domain).Build()
+
+	bc := &BaseController[*ingressv1alpha1.Domain]{
+		Kube:     c,
+		Log:      logr.Discard(),
+		Recorder: events.NewFakeRecorder(10),
+	}
+
+	require.NoError(t, bc.ReconcileStatus(ctx, domain, nil))
+
+	updated := &ingressv1alpha1.Domain{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "test-domain", Namespace: "default"}, updated))
+	assert.Equal(t, int64(3), updated.Status.ObservedGeneration)
+}
+
+func TestBaseController_ReconcileStatus_NoObservedGenerationSetter(t *testing.T) {
+	// netv1.Ingress does not implement ObservedGenerationSetter; ReconcileStatus
+	// must still update the status without stamping anything.
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	require.NoError(t, scheme.AddToScheme(s))
+
+	ingress := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-ingress",
+			Namespace:  "default",
+			Generation: 2,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).WithStatusSubresource(ingress).Build()
+
+	bc := &BaseController[*netv1.Ingress]{
+		Kube:     c,
+		Log:      logr.Discard(),
+		Recorder: events.NewFakeRecorder(10),
+	}
+
+	assert.NoError(t, bc.ReconcileStatus(ctx, ingress, nil))
 }
 
 func TestCtrlResultForErr(t *testing.T) {

--- a/internal/controller/bindings/boundendpoint_controller.go
+++ b/internal/controller/bindings/boundendpoint_controller.go
@@ -614,8 +614,9 @@ func (r *BoundEndpointReconciler) testBoundEndpointConnectivity(ctx context.Cont
 // updateStatus writes the controller-owned BoundEndpoint status fields.
 //
 // BoundEndpoint status has two concurrent writers: this controller (Conditions,
-// TargetServiceRef, UpstreamServiceRef) and the poller (Endpoints,
-// EndpointsSummary, HashedName; see boundendpoint_poller.go). To avoid
+// TargetServiceRef, UpstreamServiceRef, ObservedGeneration — stamped by
+// ReconcileStatus) and the poller (Endpoints, EndpointsSummary, HashedName; see
+// boundendpoint_poller.go). To avoid
 // clobbering, each writer re-fetches the object and copies only its own fields
 // onto that fresh copy before writing. Keep that pattern when changing status
 // fields; the write mechanism itself (BaseController.ReconcileStatus here, bare

--- a/internal/controller/bindings/boundendpoint_poller.go
+++ b/internal/controller/bindings/boundendpoint_poller.go
@@ -559,7 +559,8 @@ func (r *BoundEndpointPoller) deleteBinding(ctx context.Context, boundEndpoint b
 //
 // BoundEndpoint status has two concurrent writers: this poller (Endpoints,
 // EndpointsSummary, HashedName) and the controller (Conditions,
-// TargetServiceRef, UpstreamServiceRef; see boundendpoint_controller.go). To
+// TargetServiceRef, UpstreamServiceRef, ObservedGeneration; see
+// boundendpoint_controller.go). To
 // avoid clobbering, each writer re-fetches the object and copies only its own
 // fields onto that fresh copy before writing. Keep that pattern when changing
 // status fields; the write mechanism itself (bare Status().Update here,

--- a/internal/controller/ngrok/ngroktrafficpolicy_controller.go
+++ b/internal/controller/ngrok/ngroktrafficpolicy_controller.go
@@ -85,7 +85,21 @@ func (r *NgrokTrafficPolicyReconciler) Reconcile(ctx context.Context, req ctrl.R
 		r.Recorder.Eventf(policy, nil, v1.EventTypeWarning, EventPolicyDeprecation, "Validate", "Traffic Policy has 'enabled' set. This is a legacy option that will stop being supported soon.")
 	}
 
-	return managerdriver.HandleSyncResult(r.Driver.SyncEndpoints(ctx, r.Client))
+	res, err := managerdriver.HandleSyncResult(r.Driver.SyncEndpoints(ctx, r.Client))
+	if err != nil {
+		return res, err
+	}
+
+	// Stamp observedGeneration only on success: the CRD has no conditions yet to
+	// signal failure, so stamping on error would read as a healthy reconcile.
+	if policy.Status.ObservedGeneration != policy.Generation {
+		policy.Status.ObservedGeneration = policy.Generation
+		if err := r.Status().Update(ctx, policy); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return res, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -297,6 +297,13 @@ spec:
                 description: HashName is the hashed output of the TargetService and
                   TargetNamespace for unique identification
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               targetServiceRef:
                 description: TargetServiceRef references the created ExternalName
                   Service in the target namespace
@@ -598,6 +605,13 @@ spec:
               id:
                 description: ID is the unique identifier of the domain
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               region:
                 description: Region is the region in which the domain was created
                 type: string
@@ -791,6 +805,13 @@ spec:
                 x-kubernetes-list-type: map
               id:
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               rules:
                 items:
                   properties:
@@ -1150,6 +1171,13 @@ spec:
                 required:
                 - name
                 type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               trafficPolicy:
                 description: Identifies any traffic policies attached to the AgentEndpoint
                   ("inline", "none", or reference name).
@@ -1370,6 +1398,13 @@ spec:
               id:
                 description: ID is the unique identifier for this endpoint
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true
@@ -1560,6 +1595,13 @@ spec:
               id:
                 description: ID is the unique identifier for this Kubernetes Operator
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               registrationErrorCode:
                 description: RegistrationErrorCode is the returned ngrok error code
                 pattern: ^ERR_NGROK_\d+$
@@ -1635,6 +1677,13 @@ spec:
           status:
             description: NgrokTrafficPolicyStatus defines the observed state of NgrokTrafficPolicy
             properties:
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent metadata.generation observed by the
+                  controller. When it matches metadata.generation, the status reflects the
+                  latest spec.
+                format: int64
+                type: integer
               policy:
                 description: The raw json encoded policy that was applied to the ngrok
                   API

--- a/specs/crds/agentendpoint.md
+++ b/specs/crds/agentendpoint.md
@@ -54,6 +54,7 @@ Requires `spec.url` to use the `tls://` scheme (enforced by XValidation). Cannot
 
 | Field                    | Type                            | Description                              |
 |--------------------------|---------------------------------|------------------------------------------|
+| `observedGeneration`     | int64                           | Generation last reconciled by the controller |
 | `assignedURL`            | string                          | The URL assigned by ngrok                |
 | `attachedTrafficPolicy`  | string                          | `"none"`, `"inline"`, or policy ref name |
 | `domainRef`              | *K8sObjectRefOptionalNamespace  | Reference to the associated Domain CR    |

--- a/specs/crds/boundendpoint.md
+++ b/specs/crds/boundendpoint.md
@@ -47,6 +47,7 @@
 
 | Field                | Type                            | Owner      | Description                                  |
 |----------------------|---------------------------------|------------|----------------------------------------------|
+| `observedGeneration` | int64                           | controller | Generation last reconciled by the controller |
 | `endpoints`          | []BindingEndpoint               | poller     | ngrok endpoint references (id, uri)          |
 | `hashedName`         | string                          | poller     | Hashed name for the bound endpoint           |
 | `endpointsSummary`   | string                          | poller     | Human-readable summary of endpoints          |

--- a/specs/crds/cloudendpoint.md
+++ b/specs/crds/cloudendpoint.md
@@ -26,6 +26,7 @@
 
 | Field                    | Type                            | Description                              |
 |--------------------------|---------------------------------|------------------------------------------|
+| `observedGeneration`     | int64                           | Generation last reconciled by the controller |
 | `id`                     | string                          | The ngrok API resource ID                |
 | `assignedURL`            | string                          | The URL assigned by ngrok                |
 | `attachedTrafficPolicy`  | string                          | `"none"`, `"inline"`, or policy ref name |

--- a/specs/crds/common.md
+++ b/specs/crds/common.md
@@ -43,6 +43,32 @@ Condition type constants must be defined in the API package, not in internal con
 
 The API package must only contain API types and constants. Internal implementation details (controller interfaces, reconciliation helpers, etc.) must not be defined in the API package.
 
+## Status `observedGeneration`
+
+Every CRD status carries a top-level `observedGeneration` field recording the
+`metadata.generation` the controller most recently reconciled.
+
+**Why:** a status field like `Ready=True` is ambiguous on its own — right after a
+user applies a spec change it may still describe the previous generation. External
+tooling (`kubectl wait`, Argo CD health checks, Flux, other controllers composing on
+our CRDs) compares `status.observedGeneration == metadata.generation` to decide
+whether the status reflects the latest spec. It is the standard Kubernetes
+convention for this (Deployments, Gateway API, cert-manager all follow it), and the
+top-level field is where generic tooling looks — per-condition `observedGeneration`
+alone is not enough.
+
+**Rules:**
+
+- Controllers stamp it on every status write for the generation they reconciled.
+  In the implementation this happens centrally (`BaseController.ReconcileStatus` via
+  the `ObservedGenerationSetter` interface), not per-controller.
+- It is an **external contract only**. Controllers must not use it to skip
+  reconciliation or ngrok API calls: `metadata.generation` only changes on spec
+  writes, while ngrok-side state can drift without any generation change (dashboard
+  edits, deletes, cert expiry). Reconciliation stays level-based.
+- Conditions additionally carry their own per-condition `observedGeneration`, set
+  automatically by the shared condition helper.
+
 ## Finalizers
 
 The operator adds the finalizer `ngrok.com/finalizer` to resources it manages. This ensures that:

--- a/specs/crds/domain.md
+++ b/specs/crds/domain.md
@@ -38,6 +38,7 @@ The default can be overridden globally via the Helm value `defaultDomainReclaimP
 
 | Field                           | Type                                    | Description                                |
 |---------------------------------|-----------------------------------------|--------------------------------------------|
+| `observedGeneration`            | int64                                   | Generation last reconciled by the controller |
 | `id`                            | string                                  | ngrok domain ID                            |
 | `domain`                        | string                                  | The domain name                            |
 | `resolvesTo`                    | []DomainResolvesToEntry                | Resolved targets                           |

--- a/specs/crds/ippolicy.md
+++ b/specs/crds/ippolicy.md
@@ -28,9 +28,10 @@
 
 ## Status
 
-| Field        | Type                 | Description                |
-|--------------|----------------------|----------------------------|
-| `id`         | string               | ngrok IP policy ID         |
+| Field                | Type                 | Description                                  |
+|----------------------|----------------------|----------------------------------------------|
+| `observedGeneration` | int64                | Generation last reconciled by the controller |
+| `id`                 | string               | ngrok IP policy ID         |
 | `conditions` | []Condition          | MaxItems: 8                |
 | `rules`      | []IPPolicyRuleStatus | Status of each rule        |
 

--- a/specs/crds/kubernetesoperator.md
+++ b/specs/crds/kubernetesoperator.md
@@ -47,6 +47,7 @@
 
 | Field                      | Type        | Description                                         |
 |----------------------------|-------------|-----------------------------------------------------|
+| `observedGeneration`       | int64       | Generation last reconciled by the controller        |
 | `id`                       | string      | ngrok API resource ID                               |
 | `uri`                      | string      | ngrok API resource URI                              |
 | `registrationStatus`       | string      | Enum: `registered`, `error`, `pending` (default: `pending`) |


### PR DESCRIPTION
related: [K8SOP-286](https://linear.app/ngrok/issue/K8SOP-286/add-top-level-statusobservedgeneration-to-all-crds)

## What

Adds a top-level `status.observedGeneration` field to all 7 CRDs (Domain, IPPolicy, AgentEndpoint, CloudEndpoint, KubernetesOperator, NgrokTrafficPolicy, BoundEndpoint), recording the `metadata.generation` the controller most recently reconciled.

This is part of the pre-1.0 CR status audit (K8SOP-137). A status field like `Ready=True` is ambiguous on its own — right after a user applies a spec change, it may still describe the previous generation. External tooling (`kubectl wait`, Argo CD health checks, Flux, controllers composing on our CRDs) compares `status.observedGeneration == metadata.generation` to detect whether status reflects the latest spec. The top-level field is the standard Kubernetes convention and the location generic tooling reads — the per-condition `observedGeneration` we already stamp is not enough by itself.

**Explicit non-goal:** this is an external contract only. Reconcilers do not (and must not) use it to skip ngrok API calls — `metadata.generation` only bumps on spec writes, while ngrok-side state can drift without one (dashboard edits/deletes, cert expiry). Reconciliation stays level-based. This rationale is documented in `specs/crds/common.md`.

## How

- `ObservedGeneration int64` + `SetObservedGeneration` method on all 7 CRD types
- New `ObservedGenerationSetter` interface in `internal/controller`; `BaseController.ReconcileStatus` stamps it automatically for any object implementing it — covers Domain, IPPolicy, AgentEndpoint, CloudEndpoint, KubernetesOperator, and the BoundEndpoint controller with zero per-controller boilerplate
- NgrokTrafficPolicy's controller wrote no status at all; it now stamps after a successful sync only (the CRD has no conditions yet to signal failure, so stamping on error would read as healthy — K8SOP-288 adds conditions)
- BoundEndpoint poller needs no code change: its re-fetch + copy-only-owned-fields pattern preserves the field; ownership comments updated in both writers (`observedGeneration` is controller-owned)
- Regenerated CRD manifests; documented the field in `specs/crds/*.md` plus a new "Status `observedGeneration`" section in `specs/crds/common.md` explaining the goal and rules
- Tests: `ReconcileStatus` stamps the field for implementing types and remains a no-op-safe for types that don't implement the interface (e.g. `netv1.Ingress`); full `make test` green
- Ignores the KubernetesOperator for now as there are other status updates i'm working on

## Breaking Changes

None. Purely additive to CRD schemas — existing manifests and clients are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `status.observedGeneration` to multiple custom resources (endpoints, policies, domains, and traffic policy) so Kubernetes tooling can confirm status freshness against `metadata.generation`.
* **Bug Fixes**
  * Improved status reconciliation so `observedGeneration` is stamped only when out of date, and status updates are avoided on reconcile errors to prevent misleading “healthy” signals.
* **Documentation**
  * Updated CRD schemas and CRD docs (including shared contract guidance) to define and describe `status.observedGeneration`.
* **Tests**
  * Added unit test coverage for `observedGeneration` stamping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->