### PR TITLE
fix(release): auto-deepen shallow clones in gather-release-data.sh

### DIFF
--- a/.agents/skills/release/scripts/gather-release-data.sh
+++ b/.agents/skills/release/scripts/gather-release-data.sh
@@ -96,7 +96,12 @@ gh auth status &>/dev/null 2>&1 || die "gh not authenticated. Run: gh auth login
 REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "ngrok/ngrok-operator")
 
 log "Fetching latest from origin..."
-git fetch origin --quiet
+git fetch origin --quiet --tags
+
+if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+  log "Local clone is shallow (fetch-depth-limited checkout) — deepening to full history so PR ranges are computed correctly..."
+  git fetch origin --quiet --unshallow --tags
+fi
 
 CONTAINER_TAG="${CONTAINER_TAG_OVERRIDE:-$(find_latest_tag 'ngrok-operator-*')}"
 HELM_TAG="${HELM_TAG_OVERRIDE:-$(find_latest_tag 'helm-chart-ngrok-operator-*')}"


### PR DESCRIPTION
## Summary
- Copilot coding-agent checkouts run with `fetch-depth: 2`, leaving only 2 commits in local history. The release script's `extract_pr_numbers()` walks `git log tag..origin/main`, so it silently saw only PRs #846 and #858 instead of the full 40 PRs since the last release tag — no error, just a wrong/incomplete changelog.
- Fix is scoped to the script itself (not the checkout workflow, which would force full-history clones for every unrelated Copilot session): detect a shallow repo via `git rev-parse --is-shallow-repository` and `git fetch --unshallow --tags` before computing PR ranges.

## Test plan
- [x] Ran the script locally (non-shallow) — unchanged output, 40 PRs.
- [x] Verified via a Copilot coding-agent run against this fix that it now correctly reports 40 PRs matching the local run's classification and meta-only set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release data gathering by ensuring remote tags and complete repository history are available when calculating pull request ranges.
  * Added support for repositories using shallow clones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->