### PR TITLE
fix: KubernetesOperator status.enabledFeatures rollback crash

### DIFF
--- a/api/ngrok/v1alpha1/kubernetesoperator_status_compat.go
+++ b/api/ngrok/v1alpha1/kubernetesoperator_status_compat.go
@@ -31,14 +31,23 @@ import (
 	"strings"
 )
 
-// LEGACY-STATUS-MIGRATION: BEGIN
+// LEGACY-enabledfeatures-format: BEGIN
 //
-// KubernetesOperatorEnabledFeatures is named only so its decoder can passively
-// read the comma-separated status value written by older operator versions.
-// This compatibility is read-only: current versions always write an array.
+// KubernetesOperatorEnabledFeatures decodes either the array this field will
+// write once the migration window closes, or the comma-separated string
+// written by pre-migration operator versions (and by this version, for now —
+// see MarshalJSON below).
 //
-// Remove this type and use []string directly once upgrades from versions that
-// wrote the string representation are outside the supported upgrade window.
+// Two-release, same-key type change (see docs/developer-guide/passivity-shims.md):
+// this release still WRITES the legacy comma-separated string, so a rollback
+// to a pre-migration operator can decode status it never expected to change
+// shape. Once this release is the accepted rollback floor, delete
+// MarshalJSON below (write-side cleanup) so the field marshals as a plain
+// array again, drop the `+kubebuilder:validation:Type=string` override on
+// the field in kubernetesoperator_types.go, and regenerate the CRD. Keep
+// UnmarshalJSON a while longer — existing objects still carry the legacy
+// string until their next reconcile — then delete it too (read-side
+// cleanup) along with this type, switching the field to plain []string.
 type KubernetesOperatorEnabledFeatures []string
 
 func (features *KubernetesOperatorEnabledFeatures) UnmarshalJSON(data []byte) error {
@@ -66,4 +75,14 @@ func (features *KubernetesOperatorEnabledFeatures) UnmarshalJSON(data []byte) er
 	return nil
 }
 
-// LEGACY-STATUS-MIGRATION: END
+// MarshalJSON writes the legacy comma-separated string form so a rollback to
+// a pre-migration operator can still decode this field.
+//
+// LEGACY-enabledfeatures-format (write-side cleanup): delete this method once
+// this release is the accepted rollback floor; encoding/json will then
+// marshal the field as a plain array.
+func (features KubernetesOperatorEnabledFeatures) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strings.Join(features, ","))
+}
+
+// LEGACY-enabledfeatures-format: END

--- a/api/ngrok/v1alpha1/kubernetesoperator_status_compat_test.go
+++ b/api/ngrok/v1alpha1/kubernetesoperator_status_compat_test.go
@@ -8,23 +8,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// LEGACY-STATUS-MIGRATION: BEGIN
+// LEGACY-enabledfeatures-format: BEGIN
 
-func TestKubernetesOperatorEnabledFeatures_LegacyStatusCompatibility(t *testing.T) {
+func TestKubernetesOperatorEnabledFeatures_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want KubernetesOperatorEnabledFeatures
+	}{
+		{
+			name: "legacy comma-separated string",
+			json: `{"enabledFeatures":"ingress,bindings"}`,
+			want: KubernetesOperatorEnabledFeatures{"ingress", "bindings"},
+		},
+		{
+			name: "array",
+			json: `{"enabledFeatures":["ingress","bindings"]}`,
+			want: KubernetesOperatorEnabledFeatures{"ingress", "bindings"},
+		},
+		{
+			name: "empty legacy string",
+			json: `{"enabledFeatures":""}`,
+			want: nil,
+		},
+		{
+			name: "absent",
+			json: `{}`,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var status KubernetesOperatorStatus
+			require.NoError(t, json.Unmarshal([]byte(tt.json), &status))
+			assert.Equal(t, tt.want, status.EnabledFeatures)
+		})
+	}
+}
+
+// This release still writes the legacy string form so a rollback to a
+// pre-migration operator can decode it; see MarshalJSON in
+// kubernetesoperator_status_compat.go.
+func TestKubernetesOperatorEnabledFeatures_MarshalJSON(t *testing.T) {
 	var ko KubernetesOperator
 	require.NoError(t, json.Unmarshal([]byte(`{
 		"apiVersion":"ngrok.k8s.ngrok.com/v1alpha1",
 		"kind":"KubernetesOperator",
-		"status":{"enabledFeatures":"ingress,bindings"}
+		"status":{"enabledFeatures":["ingress","bindings"]}
 	}`), &ko))
-	assert.Equal(t,
-		KubernetesOperatorEnabledFeatures{"ingress", "bindings"},
-		ko.Status.EnabledFeatures,
-	)
 
 	encoded, err := json.Marshal(&ko)
 	require.NoError(t, err)
-	assert.Contains(t, string(encoded), `"enabledFeatures":["ingress","bindings"]`)
+	assert.Contains(t, string(encoded), `"enabledFeatures":"ingress,bindings"`)
 }
 
-// LEGACY-STATUS-MIGRATION: END
+// LEGACY-enabledfeatures-format: END

--- a/api/ngrok/v1alpha1/kubernetesoperator_types.go
+++ b/api/ngrok/v1alpha1/kubernetesoperator_types.go
@@ -79,8 +79,16 @@ type KubernetesOperatorStatus struct {
 	// +kubebuilder:validation:MaxItems=8
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
+	// LEGACY-enabledfeatures-format: forces the CRD schema to accept the
+	// comma-separated string wire format this field writes during the
+	// migration window (MarshalJSON in kubernetesoperator_status_compat.go).
+	// Delete this marker in the cleanup release; controller-gen will
+	// regenerate the natural array schema once MarshalJSON is also removed.
+
 	// EnabledFeatures are the features enabled for this Kubernetes Operator, as
 	// reported by the ngrok API
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	EnabledFeatures KubernetesOperatorEnabledFeatures `json:"enabledFeatures,omitempty"`
 
 	// BindingsIngressEndpoint is the URL that the operator will use to talk

--- a/docs/developer-guide/passivity-shims.md
+++ b/docs/developer-guide/passivity-shims.md
@@ -198,6 +198,7 @@ Current sentinel tags:
 - `LEGACY-trafficpolicy-name` — `CloudEndpoint.spec.trafficPolicyName` → `spec.trafficPolicy.targetRef.name`.
 - `LEGACY-trafficpolicy-policy` — `CloudEndpoint.spec.trafficPolicy.policy` → `spec.trafficPolicy.inline`.
 - `LEGACY-metadata-format` — CRD `spec.metadata` raw JSON **string** → `map[string]string` (a field *type* change, not a rename; same `json:` tag).
+- `LEGACY-enabledfeatures-format` — `KubernetesOperator.status.enabledFeatures` comma-separated **string** → `[]string` (a field *type* change on an operator-only, operator-written status field; same `json:` tag).
 
 ## Per-shim catalog: `k8s.ngrok.com/` → `ngrok.com/` migration
 
@@ -629,3 +630,73 @@ server no longer enforces string values on the map. The operator normalizes the
 supported forms (legacy string, flat string map) and passes any other JSON
 through to ngrok unchanged rather than rejecting it — plus the rollback caveat
 for object-form adopters documented in the user-facing guide.
+
+## Per-shim catalog: `KubernetesOperator.status.enabledFeatures` type change
+
+Same family as the `spec.metadata` type change above (a live key can't
+passively change the shape it accepts), but simpler: `status.enabledFeatures`
+is entirely operator-written — no user ever sets it — so there's no
+user-authored-legacy-object case to dual-read, and the operator fully
+recomputes the field from the ngrok API on every reconcile rather than
+merging into existing state, so it self-heals to the current wire format on
+the object's next reconcile with no backfill needed.
+
+Landed via #846 with only a read-side shim (`UnmarshalJSON` accepting either
+shape), which covers upgrades but not rollback: the *old* operator binary
+predates the shim entirely, so it can never be taught to read the array this
+release would otherwise write. Caught testing the 0.24 RC: rolling the
+operator back to the prior release while the array-shaped status was already
+live crashed api-manager (`unable to create KubernetesOperator: json: cannot
+unmarshal array into Go struct field ... of type string`) and spammed
+agent-manager's reflector with the same decode failure on every `List`. Both
+call sites — `controllerutil.CreateOrUpdate`'s `Get` in
+`cmd/api-manager.go::createKubernetesOperator`, and the informer's `List` —
+decode the *entire* stored object with the old binary's plain-`string`
+`EnabledFeatures` field, so the crash is unconditional and has no
+workaround short of `kubectl edit --subresource=status` on every existing
+object before starting the old binary.
+
+- **Pattern:** Two-release (deprecated form, same key), operator-written
+  variant — no coexistence window is needed because there is exactly one
+  writer. Tag: `LEGACY-enabledfeatures-format`.
+- **Type:** `api/ngrok/v1alpha1/kubernetesoperator_types.go`'s
+  `KubernetesOperatorStatus.EnabledFeatures` keeps its final-state type
+  (`KubernetesOperatorEnabledFeatures`, an eventual `[]string`) and doc
+  comment — only a `+kubebuilder:validation:Schemaless` /
+  `+kubebuilder:pruning:PreserveUnknownFields` marker pair is added so the
+  CRD accepts whichever shape is actually written this release
+  (`+kubebuilder:validation:Type=string` was tried first and rejected by
+  controller-gen: `conflicting types in allOf branches in schema: array vs
+  string`, because the field's underlying Go type is a slice).
+- **R1 (0.24):**
+  - `api/ngrok/v1alpha1/kubernetesoperator_status_compat.go`:
+    `UnmarshalJSON` (already landed in #846) keeps reading either shape.
+    A new `MarshalJSON` writes the legacy comma-separated string — the
+    write-side half #846 was missing — so a rollback to the prior release
+    can decode status this release wrote.
+  - CRD: `status.enabledFeatures` becomes schemaless (no `type:`,
+    `x-kubernetes-preserve-unknown-fields: true`) instead of the strict
+    `type: array` #846 generated, matching what's actually on the wire.
+  - No controller change: `kubernetesoperator_controller.go:308`
+    (`ko.Status.EnabledFeatures = ngrokKo.EnabledFeatures`) is unaware of
+    the wire format; the shim type's `MarshalJSON`/`UnmarshalJSON` handle
+    it transparently.
+- **R-cleanup:** delete `MarshalJSON` (write-side cleanup) so the field
+  marshals as a plain array again; drop the `Schemaless` /
+  `PreserveUnknownFields` markers and regenerate the CRD back to strict
+  `type: array`. Keep `UnmarshalJSON` one release longer — an object last
+  reconciled under R1 still carries the legacy string until its next
+  reconcile — then delete it too (read-side cleanup) along with the
+  `KubernetesOperatorEnabledFeatures` type, switching the field to plain
+  `[]string`. Sweep with `git grep 'LEGACY-enabledfeatures-format'`.
+
+### Why not a rename or a conversion webhook
+
+Same reasoning as `spec.metadata`: a new field name (e.g.
+`enabledFeatureList`) would need its own eventual deprecation once
+`enabledFeatures` was free to take the array shape, trading one migration
+for two; a conversion webhook is a pattern this operator has deliberately
+not adopted anywhere. Unlike `spec.metadata`, there's no user-authored form
+to ever reconcile away — once every operator's next reconcile has run
+against a release with `MarshalJSON` removed, no object anywhere is left
+carrying the string form.

--- a/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
+++ b/helm/ngrok-crds/templates/ngrok.k8s.ngrok.com_kubernetesoperators.yaml
@@ -255,9 +255,7 @@ spec:
                 description: |-
                   EnabledFeatures are the features enabled for this Kubernetes Operator, as
                   reported by the ngrok API
-                items:
-                  type: string
-                type: array
+                x-kubernetes-preserve-unknown-fields: true
               id:
                 description: ID is the unique identifier for this Kubernetes Operator
                 type: string

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -1715,9 +1715,7 @@ spec:
                 description: |-
                   EnabledFeatures are the features enabled for this Kubernetes Operator, as
                   reported by the ngrok API
-                items:
-                  type: string
-                type: array
+                x-kubernetes-preserve-unknown-fields: true
               id:
                 description: ID is the unique identifier for this Kubernetes Operator
                 type: string


### PR DESCRIPTION
## Summary
- `68fc9246` changed `status.enabledFeatures` from a comma-separated string to `[]string` (same `json:"enabledFeatures"` key) and added a read-side shim, but kept writing the array unconditionally — rolling the operator back to the prior release after that data was written crashes the old binary's decode: `json: cannot unmarshal array into Go struct field KubernetesOperatorStatus.status.enabledFeatures of type string`.
- Adds the missing write-side half (`MarshalJSON` emitting the legacy string) plus a schemaless CRD for this field during the migration window, so a rollback to the prior release decodes cleanly.
- Documents the shim (`LEGACY-enabledfeatures-format`) in `docs/developer-guide/passivity-shims.md`, following the existing `LEGACY-metadata-format` precedent for same-key type changes.
- Audited the rest of the 0.24 passivity-migration series (two independent sweeps: Go-level `UnmarshalJSON`/commit diff, and structural CRD-schema diff across all CRDs) — this was the only same-key type change lacking a symmetric shim. `spec.metadata`'s string→map change has the same theoretical exposure but is already documented/accepted as unfixable the same way, since it's user-writable data, not operator-owned.

## Test plan
- [x] `go build ./...`, `go test ./...` pass
- [x] Reproduced the exact bug and verified the fix against a real kind cluster: built actual `ngrok-operator-0.21.0` and HEAD images, patched a live `KubernetesOperator` object's status subresource to the array shape, confirmed the old binary hits the reported error verbatim; patched to the legacy string shape (what this fix writes) and confirmed the old binary decodes it successfully.
- [x] `make manifests` / `make generate` / `make manifest-bundle` regenerated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Implemented two-release migration window for data format changes, supporting both old and new formats with rollback compatibility.

* **Documentation**
  * Added comprehensive migration documentation for format transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->