### PR TITLE
R2 write-side cleanup: k8s.ngrok.com -> ngrok.com prefix migration (K8SOP-303)

### DIFF
--- a/helm/ngrok-operator/README.md
+++ b/helm/ngrok-operator/README.md
@@ -143,19 +143,19 @@ To run multiple ngrok-operator instances in the same cluster (e.g., in different
 
 ### Kubernetes Ingress feature configuration
 
-| Name                           | Description                                                     | Value                              |
-| ------------------------------ | --------------------------------------------------------------- | ---------------------------------- |
-| `ingressClass.name`            | DEPRECATED: Use ingress.ingressClass.name instead               |                                    |
-| `ingressClass.create`          | DEPRECATED: Use ingress.ingressClass.create instead             |                                    |
-| `ingressClass.default`         | DEPRECATED: Use ingress.ingressClass.default instead            |                                    |
-| `watchNamespace`               | DEPRECATED: Use ingress.watchNamespace instead                  |                                    |
-| `controllerName`               | DEPRECATED: Use ingress.controllerName instead                  |                                    |
-| `ingress.enabled`              | When true, enable the Ingress controller features               | `true`                             |
-| `ingress.ingressClass.name`    | The name of the ingress class to use.                           | `ngrok`                            |
-| `ingress.ingressClass.create`  | Whether to create the ingress class.                            | `true`                             |
-| `ingress.ingressClass.default` | Whether to set the ingress class as default.                    | `false`                            |
-| `ingress.watchNamespace`       | The namespace to watch for ingress resources (default all)      | `""`                               |
-| `ingress.controllerName`       | The name of the controller to look for matching ingress classes | `k8s.ngrok.com/ingress-controller` |
+| Name                           | Description                                                     | Value                          |
+| ------------------------------ | --------------------------------------------------------------- | ------------------------------ |
+| `ingressClass.name`            | DEPRECATED: Use ingress.ingressClass.name instead               |                                |
+| `ingressClass.create`          | DEPRECATED: Use ingress.ingressClass.create instead             |                                |
+| `ingressClass.default`         | DEPRECATED: Use ingress.ingressClass.default instead            |                                |
+| `watchNamespace`               | DEPRECATED: Use ingress.watchNamespace instead                  |                                |
+| `controllerName`               | DEPRECATED: Use ingress.controllerName instead                  |                                |
+| `ingress.enabled`              | When true, enable the Ingress controller features               | `true`                         |
+| `ingress.ingressClass.name`    | The name of the ingress class to use.                           | `ngrok`                        |
+| `ingress.ingressClass.create`  | Whether to create the ingress class.                            | `true`                         |
+| `ingress.ingressClass.default` | Whether to set the ingress class as default.                    | `false`                        |
+| `ingress.watchNamespace`       | The namespace to watch for ingress resources (default all)      | `""`                           |
+| `ingress.controllerName`       | The name of the controller to look for matching ingress classes | `ngrok.com/ingress-controller` |
 
 ### Agent configuration
 

--- a/helm/ngrok-operator/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ngrok-operator/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -13,4 +13,4 @@ Should match snapshot:
         helm.sh/chart: ngrok-operator-0.24.0-rc.2
       name: ngrok
     spec:
-      controller: k8s.ngrok.com/ingress-controller
+      controller: ngrok.com/ingress-controller

--- a/helm/ngrok-operator/tests/api-manager/__snapshot__/deployment_test.yaml.snap
+++ b/helm/ngrok-operator/tests/api-manager/__snapshot__/deployment_test.yaml.snap
@@ -60,7 +60,7 @@ Should match all-options snapshot:
                 - --enable-feature-gateway=true
                 - --disable-reference-grants=false
                 - --description=The official ngrok Kubernetes Operator.
-                - --ingress-controller-name=k8s.ngrok.com/ingress-controller
+                - --ingress-controller-name=ngrok.com/ingress-controller
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error
                 - --zap-encoder=json
@@ -600,7 +600,7 @@ Should match default snapshot:
                 - --enable-feature-gateway=true
                 - --disable-reference-grants=false
                 - --description=The official ngrok Kubernetes Operator.
-                - --ingress-controller-name=k8s.ngrok.com/ingress-controller
+                - --ingress-controller-name=ngrok.com/ingress-controller
                 - --zap-log-level=info
                 - --zap-stacktrace-level=error
                 - --zap-encoder=json

--- a/helm/ngrok-operator/values.schema.json
+++ b/helm/ngrok-operator/values.schema.json
@@ -349,7 +349,7 @@
                 "controllerName": {
                     "type": "string",
                     "description": "The name of the controller to look for matching ingress classes",
-                    "default": "k8s.ngrok.com/ingress-controller"
+                    "default": "ngrok.com/ingress-controller"
                 }
             }
         },

--- a/helm/ngrok-operator/values.yaml
+++ b/helm/ngrok-operator/values.yaml
@@ -258,7 +258,7 @@ credentials:
 ##
 ingress:
   enabled: true # enabled by default
-  controllerName: "k8s.ngrok.com/ingress-controller"
+  controllerName: "ngrok.com/ingress-controller"
   watchNamespace: "" # default all
   ingressClass:
     name: ngrok

--- a/internal/controller/bindings/boundendpoint_controller.go
+++ b/internal/controller/bindings/boundendpoint_controller.go
@@ -403,9 +403,6 @@ func (r *BoundEndpointReconciler) convertBoundEndpointToServices(boundEndpoint *
 	thisBindingLabels := map[string]string{
 		LabelBoundEndpointName:      boundEndpoint.Name,
 		LabelBoundEndpointNamespace: boundEndpoint.Namespace,
-		// LEGACY-PREFIX-MIGRATION (write-side cleanup): drop the two legacy entries
-		LegacyLabelBoundEndpointName:      boundEndpoint.Name,
-		LegacyLabelBoundEndpointNamespace: boundEndpoint.Namespace,
 	}
 
 	// Target Labels in order of increasing precedence
@@ -449,8 +446,6 @@ func (r *BoundEndpointReconciler) convertBoundEndpointToServices(boundEndpoint *
 	upstreamLabels := util.MergeMaps(commonBoundEndpointLabels, thisBindingLabels)
 	upstreamAnnotations := map[string]string{
 		LabelEndpointURL: endpointURL,
-		// LEGACY-PREFIX-MIGRATION (write-side cleanup): drop the legacy entry
-		LegacyLabelEndpointURL: endpointURL,
 	}
 	// upstreamService represents the Pod Forwarders as a Service
 	// Target Service will point to this Service via an ExternalName

--- a/internal/controller/bindings/boundendpoint_controller_test.go
+++ b/internal/controller/bindings/boundendpoint_controller_test.go
@@ -70,17 +70,17 @@ func Test_convertBoundEndpointToServices(t *testing.T) {
 	assert.Equal(upstreamService.Name, "abc123")
 	assert.Equal(upstreamService.Spec.Ports[0].Name, "https")
 
-	// LEGACY-PREFIX-MIGRATION: both Services dual-write the new and legacy
-	// ownership labels, and the upstream Service dual-writes the endpoint-url
-	// annotation, so a rollback to a pre-migration operator still finds them.
 	for _, svc := range []*v1.Service{targetService, upstreamService} {
 		assert.Equal("abc123", svc.Labels[LabelBoundEndpointName])
 		assert.Equal("ngrok-op", svc.Labels[LabelBoundEndpointNamespace])
-		assert.Equal("abc123", svc.Labels[LegacyLabelBoundEndpointName])
-		assert.Equal("ngrok-op", svc.Labels[LegacyLabelBoundEndpointNamespace])
+		_, hasLegacyName := svc.Labels[LegacyLabelBoundEndpointName]
+		_, hasLegacyNamespace := svc.Labels[LegacyLabelBoundEndpointNamespace]
+		assert.False(hasLegacyName)
+		assert.False(hasLegacyNamespace)
 	}
 	assert.Equal("abc123.ngrok-op.svc.cluster.local", upstreamService.Annotations[LabelEndpointURL])
-	assert.Equal("abc123.ngrok-op.svc.cluster.local", upstreamService.Annotations[LegacyLabelEndpointURL])
+	_, hasLegacyURL := upstreamService.Annotations[LegacyLabelEndpointURL]
+	assert.False(hasLegacyURL)
 }
 
 func Test_boundEndpointLabelsFor(t *testing.T) {

--- a/internal/controller/gateway/tcproute_controller_test.go
+++ b/internal/controller/gateway/tcproute_controller_test.go
@@ -99,7 +99,7 @@ var _ = Describe("TCPRoute controller", Ordered, func() {
 				Eventually(func(g Gomega) {
 					obj := &gatewayv1alpha2.TCPRoute{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(route), obj)).To(Succeed())
-					g.Expect(obj.Finalizers).To(ContainElement("k8s.ngrok.com/finalizer"))
+					g.Expect(obj.Finalizers).To(ContainElement("ngrok.com/finalizer"))
 
 					routes := driver.GetStore().ListTCPRoutes()
 					g.Expect(routes).To(HaveLen(1))

--- a/internal/controller/gateway/tlsroute_controller_test.go
+++ b/internal/controller/gateway/tlsroute_controller_test.go
@@ -99,7 +99,7 @@ var _ = Describe("TLSRoute controller", Ordered, func() {
 				Eventually(func(g Gomega) {
 					obj := &gatewayv1alpha2.TLSRoute{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(route), obj)).To(Succeed())
-					g.Expect(obj.Finalizers).To(ContainElement("k8s.ngrok.com/finalizer"))
+					g.Expect(obj.Finalizers).To(ContainElement("ngrok.com/finalizer"))
 
 					routes := driver.GetStore().ListTLSRoutes()
 					g.Expect(routes).To(HaveLen(1))

--- a/internal/controller/labels/controller.go
+++ b/internal/controller/labels/controller.go
@@ -31,17 +31,11 @@ const (
 // LEGACY-PREFIX-MIGRATION: END
 
 // ControllerLabels returns the standard labels identifying which operator
-// instance manages a resource. During the migration window this dual-writes
-// both the new (ngrok.com/...) and legacy (k8s.ngrok.com/...) key pairs so a
-// rollback to a pre-migration operator can still match its own labels. The
-// write-side cleanup drops the legacy entries from this map.
+// instance manages a resource.
 func ControllerLabels(controllerNamespace, controllerName string) map[string]string {
 	return map[string]string{
 		ControllerNamespace: controllerNamespace,
 		ControllerName:      controllerName,
-		// LEGACY-PREFIX-MIGRATION (write-side cleanup): drop both legacy entries
-		LegacyControllerNamespace: controllerNamespace,
-		LegacyControllerName:      controllerName,
 	}
 }
 
@@ -63,12 +57,9 @@ func HasControllerLabels(obj client.Object, controllerNamespace, controllerName 
 	return false
 }
 
-// EnsureControllerLabels writes both the new-prefix and legacy-prefix
-// controller labels on obj, setting them to the desired values. During the
-// migration window we keep the legacy pair set so a rollback to a pre-migration
-// operator still finds its own resources. The write-side cleanup removes the
-// legacy keys instead of ensure-setting them.
-// Returns true if any label changed.
+// EnsureControllerLabels writes the controller labels on obj, setting them to
+// the desired values, and removes the legacy-prefix pair left behind by a
+// pre-migration operator. Returns true if any label changed.
 func EnsureControllerLabels(obj client.Object, controllerNamespace, controllerName string) bool {
 	labels := obj.GetLabels()
 	if labels == nil {
@@ -84,18 +75,16 @@ func EnsureControllerLabels(obj client.Object, controllerNamespace, controllerNa
 		labels[ControllerName] = controllerName
 		modified = true
 	}
-	// LEGACY-PREFIX-MIGRATION: BEGIN — the write-side cleanup replaces this
-	// ensure-set with delete(labels, LegacyControllerNamespace) /
-	// delete(labels, LegacyControllerName).
-	if labels[LegacyControllerNamespace] != controllerNamespace {
-		labels[LegacyControllerNamespace] = controllerNamespace
+	// LEGACY-PREFIX-MIGRATION (read-side cleanup): drop these deletes once no
+	// pre-migration-stamped objects remain.
+	if _, ok := labels[LegacyControllerNamespace]; ok {
+		delete(labels, LegacyControllerNamespace)
 		modified = true
 	}
-	if labels[LegacyControllerName] != controllerName {
-		labels[LegacyControllerName] = controllerName
+	if _, ok := labels[LegacyControllerName]; ok {
+		delete(labels, LegacyControllerName)
 		modified = true
 	}
-	// LEGACY-PREFIX-MIGRATION: END
 
 	if modified {
 		obj.SetLabels(labels)

--- a/internal/controller/labels/controller_test.go
+++ b/internal/controller/labels/controller_test.go
@@ -17,25 +17,21 @@ func TestControllerLabels(t *testing.T) {
 		want                map[string]string
 	}{
 		{
-			name:                "returns labels with namespace and name (dual-write)",
+			name:                "returns labels with namespace and name",
 			controllerNamespace: "ngrok-operator",
 			controllerName:      "my-controller",
 			want: map[string]string{
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 		{
-			name:                "handles empty values (dual-write)",
+			name:                "handles empty values",
 			controllerNamespace: "",
 			controllerName:      "",
 			want: map[string]string{
-				ControllerNamespace:       "",
-				ControllerName:            "",
-				LegacyControllerNamespace: "",
-				LegacyControllerName:      "",
+				ControllerNamespace: "",
+				ControllerName:      "",
 			},
 		},
 	}
@@ -170,7 +166,7 @@ func TestEnsureControllerLabels(t *testing.T) {
 		wantLabels          map[string]string
 	}{
 		{
-			name: "adds labels to object with nil labels (dual-write)",
+			name: "adds labels to object with nil labels",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: nil,
@@ -180,14 +176,12 @@ func TestEnsureControllerLabels(t *testing.T) {
 			controllerName:      "my-controller",
 			wantModified:        true,
 			wantLabels: map[string]string{
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 		{
-			name: "adds labels to object with empty labels (dual-write)",
+			name: "adds labels to object with empty labels",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{},
@@ -197,14 +191,12 @@ func TestEnsureControllerLabels(t *testing.T) {
 			controllerName:      "my-controller",
 			wantModified:        true,
 			wantLabels: map[string]string{
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 		{
-			name: "preserves existing labels and adds controller labels (dual-write)",
+			name: "preserves existing labels and adds controller labels",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -216,15 +208,13 @@ func TestEnsureControllerLabels(t *testing.T) {
 			controllerName:      "my-controller",
 			wantModified:        true,
 			wantLabels: map[string]string{
-				"app":                     "my-app",
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				"app":               "my-app",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 		{
-			name: "returns false when both new and legacy labels already match",
+			name: "removes stray legacy pair when new pair already matches",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -237,16 +227,14 @@ func TestEnsureControllerLabels(t *testing.T) {
 			},
 			controllerNamespace: "ngrok-operator",
 			controllerName:      "my-controller",
-			wantModified:        false,
+			wantModified:        true,
 			wantLabels: map[string]string{
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 		{
-			name: "ensure-sets legacy pair when only new pair is present",
+			name: "returns false when only new pair is present and already correct",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -257,16 +245,14 @@ func TestEnsureControllerLabels(t *testing.T) {
 			},
 			controllerNamespace: "ngrok-operator",
 			controllerName:      "my-controller",
-			wantModified:        true,
+			wantModified:        false,
 			wantLabels: map[string]string{
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 		{
-			name: "ensure-sets new pair when only legacy pair is present (R1 keeps legacy)",
+			name: "adds new pair and removes legacy pair when only legacy pair is present",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -280,15 +266,13 @@ func TestEnsureControllerLabels(t *testing.T) {
 			controllerName:      "my-controller",
 			wantModified:        true,
 			wantLabels: map[string]string{
-				"app":                     "my-app",
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				"app":               "my-app",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 		{
-			name: "updates namespace label when different",
+			name: "updates namespace label when different and removes legacy pair",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -303,14 +287,12 @@ func TestEnsureControllerLabels(t *testing.T) {
 			controllerName:      "my-controller",
 			wantModified:        true,
 			wantLabels: map[string]string{
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 		{
-			name: "updates name label when different",
+			name: "updates name label when different and removes legacy pair",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -325,14 +307,12 @@ func TestEnsureControllerLabels(t *testing.T) {
 			controllerName:      "my-controller",
 			wantModified:        true,
 			wantLabels: map[string]string{
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 		{
-			name: "adds missing namespace label",
+			name: "adds missing namespace label and removes legacy pair",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -345,14 +325,12 @@ func TestEnsureControllerLabels(t *testing.T) {
 			controllerName:      "my-controller",
 			wantModified:        true,
 			wantLabels: map[string]string{
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 		{
-			name: "adds missing name label",
+			name: "adds missing name label and removes legacy pair",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -365,10 +343,8 @@ func TestEnsureControllerLabels(t *testing.T) {
 			controllerName:      "my-controller",
 			wantModified:        true,
 			wantLabels: map[string]string{
-				ControllerNamespace:       "ngrok-operator",
-				ControllerName:            "my-controller",
-				LegacyControllerNamespace: "ngrok-operator",
-				LegacyControllerName:      "my-controller",
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		},
 	}
@@ -428,10 +404,8 @@ func TestControllerLabelValues(t *testing.T) {
 		clv := ControllerLabelValues{Namespace: "ngrok-operator", Name: "my-controller"}
 		got := clv.Labels()
 		want := map[string]string{
-			ControllerNamespace:       "ngrok-operator",
-			ControllerName:            "my-controller",
-			LegacyControllerNamespace: "ngrok-operator",
-			LegacyControllerName:      "my-controller",
+			ControllerNamespace: "ngrok-operator",
+			ControllerName:      "my-controller",
 		}
 		assert.Equal(t, want, got)
 	})
@@ -468,10 +442,8 @@ func TestControllerLabelValues(t *testing.T) {
 		modified := clv.EnsureLabels(obj)
 		assert.True(t, modified)
 		assert.Equal(t, map[string]string{
-			ControllerNamespace:       "ngrok-operator",
-			ControllerName:            "my-controller",
-			LegacyControllerNamespace: "ngrok-operator",
-			LegacyControllerName:      "my-controller",
+			ControllerNamespace: "ngrok-operator",
+			ControllerName:      "my-controller",
 		}, obj.GetLabels())
 
 		modified = clv.EnsureLabels(obj)
@@ -516,9 +488,10 @@ func TestHasControllerLabels_DualPrefix(t *testing.T) {
 	})
 }
 
-func TestEnsureControllerLabels_R1KeepsLegacy(t *testing.T) {
-	// R1 dual-writes: an object that arrives with only the legacy pair must
-	// be promoted to having both pairs, not have the legacy pair removed.
+func TestEnsureControllerLabels_R2RemovesLegacy(t *testing.T) {
+	// R2 write-side cleanup: an object that arrives with only the legacy pair
+	// (stamped by a pre-migration operator) must be promoted to the new pair
+	// and have the legacy pair removed.
 	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 		LegacyControllerNamespace: "ngrok-operator",
 		LegacyControllerName:      "my-controller",
@@ -531,10 +504,10 @@ func TestEnsureControllerLabels_R1KeepsLegacy(t *testing.T) {
 	got := obj.GetLabels()
 	assert.Equal(t, "ngrok-operator", got[ControllerNamespace])
 	assert.Equal(t, "my-controller", got[ControllerName])
-	assert.Equal(t, "ngrok-operator", got[LegacyControllerNamespace],
-		"R1 must preserve the legacy pair (in R2 this becomes a delete)")
-	assert.Equal(t, "my-controller", got[LegacyControllerName],
-		"R1 must preserve the legacy pair (in R2 this becomes a delete)")
+	_, hasLegacyNamespace := got[LegacyControllerNamespace]
+	_, hasLegacyName := got[LegacyControllerName]
+	assert.False(t, hasLegacyNamespace, "R2 must remove the legacy pair")
+	assert.False(t, hasLegacyName, "R2 must remove the legacy pair")
 	assert.Equal(t, "my-app", got["app"], "unrelated labels are preserved")
 }
 

--- a/internal/controller/ngrok/kubernetesoperator_controller_test.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller_test.go
@@ -87,8 +87,7 @@ var _ = Describe("KubernetesOperator Controller", Ordered, func() {
 		Expect(k8sClient.Create(ctx, ko)).To(Succeed())
 
 		By("Expecting the finalizer to be added")
-		// R1: AddFinalizer writes the legacy key. Flip to util.FinalizerName in R2.
-		kginkgo.ExpectFinalizerToBeAdded(ctx, ko, util.LegacyFinalizerName, testutils.WithTimeout(timeout))
+		kginkgo.ExpectFinalizerToBeAdded(ctx, ko, util.FinalizerName, testutils.WithTimeout(timeout))
 
 		By("Expecting registration to succeed")
 		kginkgo.EventuallyWithObject(ctx, ko.DeepCopy(), func(g Gomega, fetched client.Object) {
@@ -157,7 +156,7 @@ var _ = Describe("KubernetesOperator Controller", Ordered, func() {
 		Expect(k8sClient.Create(ctx, ko)).To(Succeed())
 
 		By("Expecting the finalizer to be added")
-		kginkgo.ExpectFinalizerToBeAdded(ctx, ko, util.LegacyFinalizerName, testutils.WithTimeout(timeout))
+		kginkgo.ExpectFinalizerToBeAdded(ctx, ko, util.FinalizerName, testutils.WithTimeout(timeout))
 
 		By("Expecting the public failure condition contract")
 		kginkgo.EventuallyWithObject(ctx, ko.DeepCopy(), func(g Gomega, fetched client.Object) {

--- a/internal/controller/service/controller.go
+++ b/internal/controller/service/controller.go
@@ -381,18 +381,14 @@ func (r *ServiceReconciler) setComputedURLAnnotation(ctx context.Context, svc *c
 	if a == nil {
 		a = make(map[string]string)
 	}
-	// LEGACY-PREFIX-MIGRATION: BEGIN
-	// Dual-write both the new and legacy computed-url keys so a rollback to a
-	// pre-migration operator still sees the value it knows how to read. The
-	// write-side cleanup drops the legacy comparison and the legacy write; the
-	// body collapses back to the simple "skip if equal, otherwise write" form.
-	if a[annotations.ComputedURLAnnotation] == computedURL &&
-		a[annotations.LegacyComputedURLAnnotation] == computedURL {
+	// LEGACY-PREFIX-MIGRATION (read-side cleanup): drop this delete once no
+	// pre-migration-stamped Services remain.
+	_, hadLegacy := a[annotations.LegacyComputedURLAnnotation]
+	if a[annotations.ComputedURLAnnotation] == computedURL && !hadLegacy {
 		return nil
 	}
 	a[annotations.ComputedURLAnnotation] = computedURL
-	a[annotations.LegacyComputedURLAnnotation] = computedURL
-	// LEGACY-PREFIX-MIGRATION: END
+	delete(a, annotations.LegacyComputedURLAnnotation)
 	svc.SetAnnotations(a)
 	return r.Client.Update(ctx, svc)
 }

--- a/internal/controller/service/controller_test.go
+++ b/internal/controller/service/controller_test.go
@@ -48,9 +48,7 @@ const (
 	LoadBalancer = corev1.ServiceTypeLoadBalancer
 	ClusterIP    = corev1.ServiceTypeClusterIP
 
-	// R1: AddFinalizer writes the legacy key, so tests assert against it.
-	// Flip to util.FinalizerName in R2.
-	FinalizerName = util.LegacyFinalizerName
+	FinalizerName = util.FinalizerName
 
 	Annotation_URL             = annotations.URLAnnotation
 	Annotation_MappingStrategy = annotations.MappingStrategyAnnotation
@@ -237,7 +235,8 @@ var _ = Describe("ServiceController", func() {
 				// LEGACY-PREFIX-MIGRATION: a TCP Service stamped by a
 				// pre-migration operator carries only the legacy computed-url
 				// key. The reserved-address happy path must re-stamp the new
-				// key so the value survives once the legacy read is removed.
+				// key (and shed the legacy key) so the value survives once the
+				// legacy read is removed.
 				It("Should migrate a legacy-only computed-url to the new key", func() {
 					var reservedURL string
 
@@ -262,13 +261,14 @@ var _ = Describe("ServiceController", func() {
 						return k8sClient.Update(ctx, fetched)
 					}, timeout, interval).Should(Succeed())
 
-					By("expecting the operator to re-stamp the new key while keeping the legacy key (no new reservation)")
+					By("expecting the operator to re-stamp the new key and drop the legacy key (no new reservation)")
 					Eventually(func(g Gomega) {
 						fetched := &corev1.Service{}
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(svc), fetched)).To(Succeed())
 						a := fetched.GetAnnotations()
 						g.Expect(a[annotations.ComputedURLAnnotation]).To(Equal(reservedURL))
-						g.Expect(a[annotations.LegacyComputedURLAnnotation]).To(Equal(reservedURL))
+						_, hasLegacy := a[annotations.LegacyComputedURLAnnotation]
+						g.Expect(hasLegacy).To(BeFalse())
 					}, timeout, interval).Should(Succeed())
 				})
 			})

--- a/internal/domain/manager_test.go
+++ b/internal/domain/manager_test.go
@@ -153,10 +153,7 @@ func assertDomainLabels(t *testing.T, c client.Client, name, namespace string, e
 	t.Helper()
 	var domain ingressv1alpha1.Domain
 	require.NoError(t, c.Get(t.Context(), types.NamespacedName{Name: name, Namespace: namespace}, &domain))
-	domainLabels := domain.GetLabels()
-	for k, v := range expectedLabels {
-		assert.Equal(t, v, domainLabels[k])
-	}
+	assert.Equal(t, expectedLabels, domain.GetLabels())
 }
 
 // Tests
@@ -316,9 +313,6 @@ func TestManager_EnsureDomainExists_CreateNewDomain(t *testing.T) {
 	assertDomainLabels(t, c, "example-com", "default", map[string]string{
 		labels.ControllerNamespace: "test-namespace",
 		labels.ControllerName:      "test-controller",
-		// LEGACY-PREFIX-MIGRATION: new domains are dual-stamped with the legacy pair.
-		labels.LegacyControllerNamespace: "test-namespace",
-		labels.LegacyControllerName:      "test-controller",
 	})
 }
 
@@ -629,34 +623,33 @@ func TestManager_EnsureDomainExists_ControllerLabels(t *testing.T) {
 			name:           "adds labels to domain without labels",
 			existingLabels: nil,
 			wantLabels: map[string]string{
-				labels.ControllerNamespace:       "test-namespace",
-				labels.ControllerName:            "test-controller",
-				labels.LegacyControllerNamespace: "test-namespace",
-				labels.LegacyControllerName:      "test-controller",
+				labels.ControllerNamespace: "test-namespace",
+				labels.ControllerName:      "test-controller",
 			},
 		},
 		{
-			// LEGACY-PREFIX-MIGRATION: a domain stamped with only the new pair
-			// (e.g. by a partially-migrated operator) must get the legacy pair
-			// backfilled. The clone-and-probe detects the missing legacy keys
-			// because EnsureLabels would change the copy.
-			name: "backfills legacy pair when only new pair present",
+			// LEGACY-PREFIX-MIGRATION (write-side cleanup): a domain stamped
+			// with the legacy pair by a pre-migration operator must shed it on
+			// next reconcile. The clone-and-probe detects the stray legacy
+			// keys because EnsureLabels would change the copy.
+			name: "removes legacy pair when present",
 			existingLabels: map[string]string{
-				labels.ControllerNamespace: "test-namespace",
-				labels.ControllerName:      "test-controller",
-				"custom-label":             "custom-value",
-			},
-			wantLabels: map[string]string{
 				labels.ControllerNamespace:       "test-namespace",
 				labels.ControllerName:            "test-controller",
 				labels.LegacyControllerNamespace: "test-namespace",
 				labels.LegacyControllerName:      "test-controller",
 				"custom-label":                   "custom-value",
 			},
+			wantLabels: map[string]string{
+				labels.ControllerNamespace: "test-namespace",
+				labels.ControllerName:      "test-controller",
+				"custom-label":             "custom-value",
+			},
 		},
 		{
 			// The clone-and-probe checks label values, not just presence, so a
-			// controller label carrying a stale value gets corrected on reconcile.
+			// controller label carrying a stale value gets corrected on
+			// reconcile, and the legacy pair is removed at the same time.
 			name: "corrects stale controller label value",
 			existingLabels: map[string]string{
 				labels.ControllerNamespace:       "test-namespace",
@@ -665,10 +658,8 @@ func TestManager_EnsureDomainExists_ControllerLabels(t *testing.T) {
 				labels.LegacyControllerName:      "stale-controller",
 			},
 			wantLabels: map[string]string{
-				labels.ControllerNamespace:       "test-namespace",
-				labels.ControllerName:            "test-controller",
-				labels.LegacyControllerNamespace: "test-namespace",
-				labels.LegacyControllerName:      "test-controller",
+				labels.ControllerNamespace: "test-namespace",
+				labels.ControllerName:      "test-controller",
 			},
 		},
 		{
@@ -677,11 +668,9 @@ func TestManager_EnsureDomainExists_ControllerLabels(t *testing.T) {
 				"custom-label": "custom-value",
 			},
 			wantLabels: map[string]string{
-				labels.ControllerNamespace:       "test-namespace",
-				labels.ControllerName:            "test-controller",
-				labels.LegacyControllerNamespace: "test-namespace",
-				labels.LegacyControllerName:      "test-controller",
-				"custom-label":                   "custom-value",
+				labels.ControllerNamespace: "test-namespace",
+				labels.ControllerName:      "test-controller",
+				"custom-label":             "custom-value",
 			},
 		},
 	}

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -7,16 +7,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// FinalizerName is the canonical ngrok operator finalizer. R1 of the
-// three-release finalizer rename does NOT write this key yet; it is only
-// matched on read so that an R2 operator can finish migrating objects an R1
-// operator may encounter. See docs/developer-guide/passivity-shims.md.
+// FinalizerName is the canonical ngrok operator finalizer. R2 of the
+// three-release finalizer rename writes this key. See
+// docs/developer-guide/passivity-shims.md.
 const FinalizerName = "ngrok.com/finalizer"
 
 // LEGACY-PREFIX-MIGRATION: BEGIN
-// LegacyFinalizerName is what R1 writes. R2 switches the write to
-// FinalizerName and removes LegacyFinalizerName. R3 deletes this constant
-// and the legacy branches in HasFinalizer / RemoveFinalizer below.
+// LegacyFinalizerName is what R1 wrote. R3 deletes this constant and the
+// legacy branches in HasFinalizer / RemoveFinalizer below.
 const LegacyFinalizerName = "k8s.ngrok.com/finalizer"
 
 // LEGACY-PREFIX-MIGRATION: END
@@ -29,18 +27,15 @@ func HasFinalizer(o client.Object) bool {
 		controllerutil.ContainsFinalizer(o, LegacyFinalizerName)
 }
 
-// AddFinalizer is intentionally asymmetric with HasFinalizer/RemoveFinalizer:
-// during R1 we add the legacy key only so that an in-place rollback to a
-// prior release can still drive object deletion (the prior release only
-// knows how to strip the legacy key). R2 switches this to:
-//
-//	added := controllerutil.AddFinalizer(o, FinalizerName)
-//	removed := controllerutil.RemoveFinalizer(o, LegacyFinalizerName)
-//	return added || removed
-//
-// Returns true if the finalizer was added.
+// AddFinalizer adds the canonical ngrok finalizer and removes the legacy one
+// left behind by a pre-migration (R1) operator. Returns true if the finalizer
+// was added.
 func AddFinalizer(o client.Object) bool {
-	return controllerutil.AddFinalizer(o, LegacyFinalizerName)
+	added := controllerutil.AddFinalizer(o, FinalizerName)
+	// LEGACY-PREFIX-MIGRATION: drop this removal in R3; a rollback to R1 is
+	// still safe because R1's HasFinalizer/RemoveFinalizer bridge both keys.
+	removed := controllerutil.RemoveFinalizer(o, LegacyFinalizerName)
+	return added || removed
 }
 
 // RemoveFinalizer removes both the new and legacy ngrok finalizers from the

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -238,9 +238,8 @@ func TestHasFinalizer(t *testing.T) {
 	}
 }
 
-// TestAddFinalizer asserts the R1 behavior: AddFinalizer writes the legacy
-// key only. In R2 this test must be updated to assert FinalizerName is the
-// written key and LegacyFinalizerName has been stripped.
+// TestAddFinalizer asserts the R2 behavior: AddFinalizer writes the new key
+// and strips the legacy key left behind by a pre-migration (R1) operator.
 func TestAddFinalizer(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -253,8 +252,8 @@ func TestAddFinalizer(t *testing.T) {
 			name:              "add to empty",
 			obj:               &netv1.Ingress{},
 			wantAdded:         true,
-			wantLegacyPresent: true,
-			wantNewPresent:    false,
+			wantLegacyPresent: false,
+			wantNewPresent:    true,
 		},
 		{
 			name: "add to existing",
@@ -264,19 +263,21 @@ func TestAddFinalizer(t *testing.T) {
 				},
 			},
 			wantAdded:         true,
-			wantLegacyPresent: true,
-			wantNewPresent:    false,
+			wantLegacyPresent: false,
+			wantNewPresent:    true,
 		},
 		{
-			name: "legacy already present",
+			name: "legacy present from prior R1 reconcile",
 			obj: &netv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{LegacyFinalizerName},
 				},
 			},
-			wantAdded:         false,
-			wantLegacyPresent: true,
-			wantNewPresent:    false,
+			// The new key gets added and the legacy key removed, so the add
+			// returns true either way.
+			wantAdded:         true,
+			wantLegacyPresent: false,
+			wantNewPresent:    true,
 		},
 		{
 			name: "new finalizer already present from prior R2 reconcile",
@@ -285,10 +286,8 @@ func TestAddFinalizer(t *testing.T) {
 					Finalizers: []string{FinalizerName},
 				},
 			},
-			// R1 still wants the legacy key on the object, so the add
-			// returns true even though HasFinalizer was already true.
-			wantAdded:         true,
-			wantLegacyPresent: true,
+			wantAdded:         false,
+			wantLegacyPresent: false,
 			wantNewPresent:    true,
 		},
 	}
@@ -391,11 +390,13 @@ func TestRegisterAndSyncFinalizer(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name          string
-		obj           client.Object
-		wantErr       bool
-		wantFinalizer bool
-		wantUpdated   bool
+		name              string
+		obj               client.Object
+		wantErr           bool
+		wantFinalizer     bool
+		wantUpdated       bool
+		wantLegacyPresent bool
+		wantNewPresent    bool
 	}{
 		{
 			name: "add finalizer to object without one",
@@ -405,9 +406,11 @@ func TestRegisterAndSyncFinalizer(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			wantErr:       false,
-			wantFinalizer: true,
-			wantUpdated:   true,
+			wantErr:           false,
+			wantFinalizer:     true,
+			wantUpdated:       true,
+			wantLegacyPresent: false,
+			wantNewPresent:    true,
 		},
 		{
 			name: "object already has legacy finalizer",
@@ -418,9 +421,13 @@ func TestRegisterAndSyncFinalizer(t *testing.T) {
 					Finalizers: []string{LegacyFinalizerName},
 				},
 			},
-			wantErr:       false,
-			wantFinalizer: true,
-			wantUpdated:   false,
+			// The new key gets added and the legacy key removed, so the
+			// object is still patched even though HasFinalizer was already true.
+			wantErr:           false,
+			wantFinalizer:     true,
+			wantUpdated:       true,
+			wantLegacyPresent: false,
+			wantNewPresent:    true,
 		},
 	}
 
@@ -444,9 +451,8 @@ func TestRegisterAndSyncFinalizer(t *testing.T) {
 			err = c.Get(ctx, client.ObjectKeyFromObject(tt.obj), &updated)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantFinalizer, HasFinalizer(&updated))
-			// LEGACY-PREFIX-MIGRATION: assert the R1 persistence contract — legacy key written, new key not. Flip in R2.
-			assert.True(t, hasRawFinalizer(&updated, LegacyFinalizerName), "persisted legacy key")
-			assert.False(t, hasRawFinalizer(&updated, FinalizerName), "no new key persisted")
+			assert.Equal(t, tt.wantLegacyPresent, hasRawFinalizer(&updated, LegacyFinalizerName), "legacy key presence")
+			assert.Equal(t, tt.wantNewPresent, hasRawFinalizer(&updated, FinalizerName), "new key presence")
 		})
 	}
 }

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -3261,7 +3261,7 @@ spec:
         - --enable-feature-gateway=true
         - --disable-reference-grants=false
         - "--description=The official ngrok Kubernetes Operator."
-        - --ingress-controller-name=k8s.ngrok.com/ingress-controller
+        - --ingress-controller-name=ngrok.com/ingress-controller
         - --zap-log-level=info
         - --zap-stacktrace-level=error
         - --zap-encoder=json
@@ -3315,7 +3315,7 @@ metadata:
     app.kubernetes.io/component: controller
   name: ngrok
 spec:
-  controller: k8s.ngrok.com/ingress-controller
+  controller: ngrok.com/ingress-controller
 ---
 # Source: ngrok-operator/templates/cleanup-hook/rbac.yaml
 apiVersion: v1

--- a/pkg/managerdriver/domains_backfill_test.go
+++ b/pkg/managerdriver/domains_backfill_test.go
@@ -18,10 +18,11 @@ import (
 	"github.com/ngrok/ngrok-operator/internal/controller/labels"
 )
 
-// LEGACY-PREFIX-MIGRATION: an existing Domain stamped with only the legacy
-// controller labels by a previous operator version must get the new label pair
-// backfilled by applyDomains. CreateOrPatch's Get overwrites the object
-// initializer, so the backfill has to happen inside the mutate function.
+// LEGACY-PREFIX-MIGRATION (write-side cleanup): an existing Domain stamped
+// with only the legacy controller labels by a previous operator version must
+// get the new label pair backfilled, and the legacy pair removed, by
+// applyDomains. CreateOrPatch's Get overwrites the object initializer, so
+// the backfill has to happen inside the mutate function.
 func TestApplyDomains_BackfillsLegacyOnlyDomain(t *testing.T) {
 	const (
 		controllerNamespace = "ngrok-system"
@@ -69,6 +70,8 @@ func TestApplyDomains_BackfillsLegacyOnlyDomain(t *testing.T) {
 	gotLabels := got.GetLabels()
 	assert.Equal(t, controllerName, gotLabels[labels.ControllerName], "new controller-name label backfilled")
 	assert.Equal(t, controllerNamespace, gotLabels[labels.ControllerNamespace], "new controller-namespace label backfilled")
-	assert.Equal(t, controllerName, gotLabels[labels.LegacyControllerName], "legacy controller-name label retained")
-	assert.Equal(t, controllerNamespace, gotLabels[labels.LegacyControllerNamespace], "legacy controller-namespace label retained")
+	_, hasLegacyName := gotLabels[labels.LegacyControllerName]
+	_, hasLegacyNamespace := gotLabels[labels.LegacyControllerNamespace]
+	assert.False(t, hasLegacyName, "legacy controller-name label removed")
+	assert.False(t, hasLegacyNamespace, "legacy controller-namespace label removed")
 }

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-gateway-tls-cross-namespace.yaml
@@ -103,9 +103,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -146,9 +144,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
+++ b/pkg/managerdriver/testdata/translator-disable-refgrants/gwapi-service-cross-namespace.yaml
@@ -89,9 +89,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -127,9 +125,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-same-namespace-svc-default-8080
       namespace: default
@@ -141,9 +137,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-cross-namespace-svc-other-8080
       namespace: other

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-all-namespaces.yaml
@@ -69,9 +69,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -100,9 +98,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-foo-8080
       namespace: foo

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-selector.yaml
@@ -79,9 +79,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -110,9 +108,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-foo-8080
       namespace: foo

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-valid-kinds.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-allowed-routes-valid-kinds.yaml
@@ -69,9 +69,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -100,9 +98,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation-new-prefix.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation-new-prefix.yaml
@@ -67,9 +67,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -100,9 +98,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-bindings-annotation.yaml
@@ -67,9 +67,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -100,9 +98,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-collapse-endpoints-multiple.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-collapse-endpoints-multiple.yaml
@@ -112,9 +112,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-8080
       namespace: default
@@ -170,9 +168,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-default-to-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-default-to-endpoints.yaml
@@ -66,9 +66,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-endpoints-non-collapsable.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-endpoints-non-collapsable.yaml
@@ -93,9 +93,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname-2.ngrok.io
       namespace: default
@@ -130,9 +128,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -168,9 +164,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default
@@ -182,9 +176,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-infrastructure.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-infrastructure.yaml
@@ -73,9 +73,7 @@ expected:
       annotations:
         annotation-key: annotation-val
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
         label-key: label-val
       name: test-gateway.default-test-hostname.ngrok.io
@@ -107,9 +105,7 @@ expected:
       annotations:
         annotation-key: annotation-val
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
         label-key: label-val
       name: e3b0c-test-service-1-default-8080

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-invalid-mapping-strategy.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-invalid-mapping-strategy.yaml
@@ -74,9 +74,7 @@ expected:
       annotations:
         annotation-key: annotation-val
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
         label-key: label-val
       name: e3b0c-test-service-1-default-8080

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-metadata-description-annotations.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-metadata-description-annotations.yaml
@@ -70,9 +70,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -103,9 +101,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-no-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-no-endpoints.yaml
@@ -75,9 +75,7 @@ expected:
       name: e3b0c-test-service-1-default-8080
       namespace: default
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
         label-key: label-val
       annotations:

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-new-prefix.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-new-prefix.yaml
@@ -104,9 +104,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -147,9 +145,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid-referencegrants.yaml
@@ -121,9 +121,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -164,9 +162,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-tls-valid.yaml
@@ -101,9 +101,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -144,9 +142,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-multi-gateway.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-multi-gateway.yaml
@@ -113,9 +113,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway-1.default-test-hostname-1.ngrok.io
       namespace: default
@@ -143,9 +141,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway-2.default-test-hostname-2.ngrok.io
       namespace: default
@@ -174,9 +170,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-mtls-3039d-8080
       namespace: default
@@ -191,9 +185,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-mtls-96179-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-refgrant.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid-refgrant.yaml
@@ -120,9 +120,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -158,9 +156,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-https-default-mtls-f2538-8443
       namespace: default
@@ -175,9 +171,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-http-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-gateway-upstream-valid.yaml
@@ -104,9 +104,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -142,9 +140,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-https-default-mtls-baff5-443
       namespace: default
@@ -159,9 +155,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-http-default-80
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-glob-hostname.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-glob-hostname.yaml
@@ -66,9 +66,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -97,9 +95,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-no-hostnames.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-no-hostnames.yaml
@@ -64,9 +64,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -95,9 +93,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-httproute-weighted-routes-with-rewrite.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-httproute-weighted-routes-with-rewrite.yaml
@@ -95,9 +95,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -169,9 +167,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default
@@ -183,9 +179,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-invalid-backendrefs.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-invalid-backendrefs.yaml
@@ -105,9 +105,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -136,9 +134,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-invalid-externalref-filters.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-invalid-externalref-filters.yaml
@@ -77,9 +77,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -108,9 +106,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-listener-port-and-protocol.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-listener-port-and-protocol.yaml
@@ -66,9 +66,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -97,9 +95,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-matching-rules.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-matching-rules.yaml
@@ -81,9 +81,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -117,9 +115,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-missing-filter-configs.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-missing-filter-configs.yaml
@@ -73,9 +73,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -104,9 +102,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-no-valid-referencegrants.yaml
@@ -96,9 +96,7 @@ expected:
       annotations:
         annotation-key: annotation-val
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
         label-key: label-val
       name: test-gateway.default-test-hostname.ngrok.io
@@ -130,9 +128,7 @@ expected:
       annotations:
         annotation-key: annotation-val
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
         label-key: label-val
       name: e3b0c-same-namespace-svc-default-8080

--- a/pkg/managerdriver/testdata/translator/gwapi-redirects.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-redirects.yaml
@@ -100,9 +100,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-request-headers.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-request-headers.yaml
@@ -88,9 +88,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -147,9 +145,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-request-mirror-not-supported.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-request-mirror-not-supported.yaml
@@ -74,9 +74,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -105,9 +103,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-response-headers.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-response-headers.yaml
@@ -88,9 +88,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -148,9 +146,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-rewrites.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-rewrites.yaml
@@ -84,9 +84,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-invalid-edges.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-invalid-edges.yaml
@@ -65,9 +65,7 @@ expected:
       name: e3b0c-test-service-1-default-11000
       namespace: default
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
     spec:
       url: tcp://test-hostname.ngrok.io:9000

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-multigateway.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-multigateway.yaml
@@ -92,9 +92,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default.9000-test-hostname.ngrok.io
       namespace: default
@@ -127,9 +125,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway-2.default.7000-test-hostname-2.ngrok.io
       namespace: default
@@ -163,9 +159,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-11000
       namespace: default
@@ -177,9 +171,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-12000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-multihost.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-multihost.yaml
@@ -80,9 +80,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default.9000-test-hostname.ngrok.io
       namespace: default
@@ -115,9 +113,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default.7000-test-hostname.ngrok.io
       namespace: default
@@ -150,9 +146,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default.9000-test-hostname-2.ngrok.io
       namespace: default
@@ -185,9 +179,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default.7000-test-hostname-2.ngrok.io
       namespace: default
@@ -221,9 +213,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-11000
       namespace: default
@@ -235,9 +225,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-12000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-simple.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-simple.yaml
@@ -60,9 +60,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-11000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-tls-upstream.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-tls-upstream.yaml
@@ -62,9 +62,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-11000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tcproute-weighted.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tcproute-weighted.yaml
@@ -75,9 +75,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-12000
       namespace: default
@@ -123,9 +121,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-11000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tls-tcp-routes-collapsed.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tls-tcp-routes-collapsed.yaml
@@ -101,9 +101,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-tcp-default-7000
       namespace: default
@@ -115,9 +113,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-tls-default-9000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multigateway.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multigateway.yaml
@@ -92,9 +92,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default.9000-test-hostname.ngrok.io
       namespace: default
@@ -127,9 +125,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway-2.default.7000-test-hostname-2.ngrok.io
       namespace: default
@@ -163,9 +159,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-11000
       namespace: default
@@ -177,9 +171,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-12000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multihost.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-multihost.yaml
@@ -80,9 +80,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default.9000-test-hostname.ngrok.io
       namespace: default
@@ -115,9 +113,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default.7000-test-hostname.ngrok.io
       namespace: default
@@ -150,9 +146,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default.9000-test-hostname-2.ngrok.io
       namespace: default
@@ -185,9 +179,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default.7000-test-hostname-2.ngrok.io
       namespace: default
@@ -221,9 +213,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-11000
       namespace: default
@@ -235,9 +225,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-12000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-simple.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-simple.yaml
@@ -60,9 +60,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-11000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-tcp-upstream.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-tcp-upstream.yaml
@@ -62,9 +62,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-11000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-tlsroute-weighted.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-tlsroute-weighted.yaml
@@ -75,9 +75,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-12000
       namespace: default
@@ -123,9 +121,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-11000
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-annotation.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-annotation.yaml
@@ -86,9 +86,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -127,9 +125,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-filter-tcp-error.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-trafficpolicy-filter-tcp-error.yaml
@@ -85,9 +85,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -116,9 +114,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
+++ b/pkg/managerdriver/testdata/translator/gwapi-valid-referencegrants.yaml
@@ -104,9 +104,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-gateway.default-test-hostname.ngrok.io
       namespace: default
@@ -142,9 +140,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-same-namespace-svc-default-8080
       namespace: default
@@ -156,9 +152,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-cross-namespace-svc-other-8080
       namespace: other

--- a/pkg/managerdriver/testdata/translator/ingress-app-protocols-new-prefix.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-app-protocols-new-prefix.yaml
@@ -108,9 +108,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-ingresses.ngrok.io
       namespace: default
@@ -160,9 +158,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-80
       namespace: default
@@ -175,9 +171,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default
@@ -189,9 +183,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-443
       namespace: default
@@ -204,9 +196,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-3-default-443
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-app-protocols.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-app-protocols.yaml
@@ -108,9 +108,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-ingresses.ngrok.io
       namespace: default
@@ -160,9 +158,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-80
       namespace: default
@@ -175,9 +171,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default
@@ -189,9 +183,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-443
       namespace: default
@@ -204,9 +196,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-3-default-443
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-default-backend-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-default-backend-conflict.yaml
@@ -97,9 +97,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-ingresses.ngrok.io
       namespace: default
@@ -133,9 +131,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations-conflict.yaml
@@ -88,9 +88,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: shared-host.ngrok.io
       namespace: default
@@ -128,9 +126,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-service-a-default-8080
       namespace: default
@@ -144,9 +140,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-service-b-default-9090
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations-default-backend.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations-default-backend.yaml
@@ -57,9 +57,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations-new-prefix.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations-new-prefix.yaml
@@ -52,9 +52,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-metadata-description-annotations.yaml
@@ -52,9 +52,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-namespace-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-namespace-conflict.yaml
@@ -87,9 +87,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-ingresses.ngrok.io
       namespace: aaa
@@ -118,9 +116,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-aaa-8080
       namespace: aaa

--- a/pkg/managerdriver/testdata/translator/ingress-no-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-no-endpoints.yaml
@@ -119,9 +119,7 @@ expected:
       name: e3b0c-test-service-1-default-8080
       namespace: default
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
     spec:
       url: https://test-ingresses.ngrok.io
@@ -189,9 +187,7 @@ expected:
       name: e3b0c-test-service-2-default-8080
       namespace: default
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
     spec:
       url: https://e3b0c-test-service-2-default-8080.internal

--- a/pkg/managerdriver/testdata/translator/ingress-pooling-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-pooling-conflict.yaml
@@ -89,9 +89,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-ingresses.ngrok.io
       namespace: default
@@ -121,9 +119,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-trafficpolicy-conflict.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-trafficpolicy-conflict.yaml
@@ -125,9 +125,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-ingresses.ngrok.io
       namespace: default
@@ -166,9 +164,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-valid-collapse-default-backend.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid-collapse-default-backend.yaml
@@ -74,9 +74,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-valid-collapse-simple.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid-collapse-simple.yaml
@@ -54,9 +54,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-valid-default-to-endpoints.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid-default-to-endpoints.yaml
@@ -117,9 +117,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default
@@ -185,9 +183,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-8080
       namespace: default

--- a/pkg/managerdriver/testdata/translator/ingress-valid.yaml
+++ b/pkg/managerdriver/testdata/translator/ingress-valid.yaml
@@ -117,9 +117,7 @@ expected:
     kind: CloudEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: test-ingresses.ngrok.io
       namespace: default
@@ -170,9 +168,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-1-default-8080
       namespace: default
@@ -184,9 +180,7 @@ expected:
     kind: AgentEndpoint
     metadata:
       labels:
-        k8s.ngrok.com/controller-name: test-manager-name
         ngrok.com/controller-name: test-manager-name
-        k8s.ngrok.com/controller-namespace: test-manager-namespace
         ngrok.com/controller-namespace: test-manager-namespace
       name: e3b0c-test-service-2-default-8080
       namespace: default

--- a/tests/chainsaw-uninstall/bindings-delete-policy/chainsaw-test.yaml
+++ b/tests/chainsaw-uninstall/bindings-delete-policy/chainsaw-test.yaml
@@ -98,7 +98,7 @@ spec:
                 name: bound-endpoint-test
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
 

--- a/tests/chainsaw-uninstall/bindings-retain-policy/chainsaw-test.yaml
+++ b/tests/chainsaw-uninstall/bindings-retain-policy/chainsaw-test.yaml
@@ -97,7 +97,7 @@ spec:
                 name: bound-endpoint-test
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
 

--- a/tests/chainsaw-uninstall/delete-policy-bundled-crds/chainsaw-test.yaml
+++ b/tests/chainsaw-uninstall/delete-policy-bundled-crds/chainsaw-test.yaml
@@ -111,7 +111,7 @@ spec:
                 name: uninstall-test-cloud-ep
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
 
@@ -126,7 +126,7 @@ spec:
                 name: uninstall-test-agent-ep
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (conditions[?type == 'Ready'] | [0].status): "True"
 
@@ -141,7 +141,7 @@ spec:
                 name: uninstall-test-ingress
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify HTTPRoute has finalizer
       try:
@@ -154,7 +154,7 @@ spec:
                 name: uninstall-test-httproute
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Gateway has finalizer
       try:
@@ -167,7 +167,7 @@ spec:
                 name: uninstall-test-gateway
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Ingress and Gateway created CloudEndpoints and AgentEndpoints
       try:

--- a/tests/chainsaw-uninstall/delete-policy-separate-crds/chainsaw-test.yaml
+++ b/tests/chainsaw-uninstall/delete-policy-separate-crds/chainsaw-test.yaml
@@ -123,7 +123,7 @@ spec:
                 name: uninstall-test-cloud-ep
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
 
@@ -138,7 +138,7 @@ spec:
                 name: uninstall-test-agent-ep
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (conditions[?type == 'Ready'] | [0].status): "True"
 
@@ -153,7 +153,7 @@ spec:
                 name: uninstall-test-ingress
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify HTTPRoute has finalizer
       try:
@@ -166,7 +166,7 @@ spec:
                 name: uninstall-test-httproute
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Gateway has finalizer
       try:
@@ -179,7 +179,7 @@ spec:
                 name: uninstall-test-gateway
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Ingress and Gateway created CloudEndpoints
       try:

--- a/tests/chainsaw-uninstall/multi-ingressclass-delete-policy/chainsaw-test.yaml
+++ b/tests/chainsaw-uninstall/multi-ingressclass-delete-policy/chainsaw-test.yaml
@@ -154,7 +154,7 @@ spec:
                 name: uninstall-test-ingress-a
                 namespace: namespace-a
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
         - assert:
             timeout: 2m
             resource:
@@ -164,7 +164,7 @@ spec:
                 name: uninstall-test-ingress-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Ingresses created CloudEndpoints and AgentEndpoints
       try:
@@ -282,7 +282,7 @@ spec:
                 name: uninstall-test-ingress-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify operator-b's endpoint STILL EXISTS in ngrok API
       try:

--- a/tests/chainsaw-uninstall/multi-ingressclass-retain-policy/chainsaw-test.yaml
+++ b/tests/chainsaw-uninstall/multi-ingressclass-retain-policy/chainsaw-test.yaml
@@ -157,7 +157,7 @@ spec:
                 name: uninstall-test-ingress-a
                 namespace: namespace-a
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
         - assert:
             timeout: 2m
             resource:
@@ -167,7 +167,7 @@ spec:
                 name: uninstall-test-ingress-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Ingresses created CloudEndpoints and AgentEndpoints
       try:
@@ -302,7 +302,7 @@ spec:
                 name: uninstall-test-ingress-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify operator-b's endpoint STILL EXISTS in ngrok API
       try:

--- a/tests/chainsaw-uninstall/multi-ns-delete-policy/chainsaw-test.yaml
+++ b/tests/chainsaw-uninstall/multi-ns-delete-policy/chainsaw-test.yaml
@@ -150,7 +150,7 @@ spec:
                 name: uninstall-test-cloud-ep-a
                 namespace: namespace-a
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
         - assert:
@@ -162,7 +162,7 @@ spec:
                 name: uninstall-test-cloud-ep-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
 
@@ -177,7 +177,7 @@ spec:
                 name: uninstall-test-ingress-a
                 namespace: namespace-a
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
         - assert:
             timeout: 2m
             resource:
@@ -187,7 +187,7 @@ spec:
                 name: uninstall-test-ingress-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Ingresses created CloudEndpoints (endpoints-verbose)
       try:
@@ -299,7 +299,7 @@ spec:
                 name: uninstall-test-cloud-ep-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
         - assert:
@@ -311,7 +311,7 @@ spec:
                 name: uninstall-test-ingress-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify operator-b's endpoints STILL EXIST in ngrok API
       try:

--- a/tests/chainsaw-uninstall/multi-ns-retain-policy/chainsaw-test.yaml
+++ b/tests/chainsaw-uninstall/multi-ns-retain-policy/chainsaw-test.yaml
@@ -150,7 +150,7 @@ spec:
                 name: uninstall-test-cloud-ep-a
                 namespace: namespace-a
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
         - assert:
@@ -162,7 +162,7 @@ spec:
                 name: uninstall-test-cloud-ep-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
 
@@ -177,7 +177,7 @@ spec:
                 name: uninstall-test-ingress-a
                 namespace: namespace-a
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
         - assert:
             timeout: 2m
             resource:
@@ -187,7 +187,7 @@ spec:
                 name: uninstall-test-ingress-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Ingresses created CloudEndpoints (endpoints-verbose)
       try:
@@ -317,7 +317,7 @@ spec:
                 name: uninstall-test-cloud-ep-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
         - assert:
@@ -329,7 +329,7 @@ spec:
                 name: uninstall-test-ingress-b
                 namespace: namespace-b
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify operator-b's endpoints STILL EXIST in ngrok API
       try:

--- a/tests/chainsaw-uninstall/retain-policy-bundled-crds/chainsaw-test.yaml
+++ b/tests/chainsaw-uninstall/retain-policy-bundled-crds/chainsaw-test.yaml
@@ -111,7 +111,7 @@ spec:
                 name: uninstall-test-cloud-ep
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
 
@@ -126,7 +126,7 @@ spec:
                 name: uninstall-test-agent-ep
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (conditions[?type == 'Ready'] | [0].status): "True"
 
@@ -141,7 +141,7 @@ spec:
                 name: uninstall-test-ingress
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify HTTPRoute has finalizer
       try:
@@ -154,7 +154,7 @@ spec:
                 name: uninstall-test-httproute
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Gateway has finalizer
       try:
@@ -167,7 +167,7 @@ spec:
                 name: uninstall-test-gateway
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Ingress and Gateway created CloudEndpoints and AgentEndpoints
       try:

--- a/tests/chainsaw-uninstall/retain-policy-separate-crds/chainsaw-test.yaml
+++ b/tests/chainsaw-uninstall/retain-policy-separate-crds/chainsaw-test.yaml
@@ -123,7 +123,7 @@ spec:
                 name: uninstall-test-cloud-ep
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (id != null): true
 
@@ -138,7 +138,7 @@ spec:
                 name: uninstall-test-agent-ep
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
               status:
                 (conditions[?type == 'Ready'] | [0].status): "True"
 
@@ -153,7 +153,7 @@ spec:
                 name: uninstall-test-ingress
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify HTTPRoute has finalizer
       try:
@@ -166,7 +166,7 @@ spec:
                 name: uninstall-test-httproute
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Gateway has finalizer
       try:
@@ -179,7 +179,7 @@ spec:
                 name: uninstall-test-gateway
                 namespace: uninstall-test
                 finalizers:
-                  - k8s.ngrok.com/finalizer
+                  - ngrok.com/finalizer
 
     - name: verify Ingress and Gateway created CloudEndpoints
       try:

--- a/tests/chainsaw/domain-controller-labels/chainsaw-test.yaml
+++ b/tests/chainsaw/domain-controller-labels/chainsaw-test.yaml
@@ -42,8 +42,8 @@ spec:
           metadata:
             name: (join('', ['dom-labels', $ngrokDomainSuffixDashes]))
             labels:
-              k8s.ngrok.com/controller-name: ngrok-operator-agent-manager
-              k8s.ngrok.com/controller-namespace: ngrok-operator
+              ngrok.com/controller-name: ngrok-operator-agent-manager
+              ngrok.com/controller-namespace: ngrok-operator
 
   - name: verify no update errors on agent endpoint
     try:

--- a/tests/chainsaw/finalizers/chainsaw-test.yaml
+++ b/tests/chainsaw/finalizers/chainsaw-test.yaml
@@ -18,4 +18,4 @@ spec:
           metadata:
             name: minimal-ingress-https
             finalizers:
-            - k8s.ngrok.com/finalizer
+            - ngrok.com/finalizer


### PR DESCRIPTION
## Summary
Second-release (R2) write-side cleanup for the `k8s.ngrok.com/` -> `ngrok.com/` prefix migration shipped in 0.24 (R1). Per the two/three-release patterns in `docs/developer-guide/passivity-shims.md`, this stops writing the legacy-prefixed key on new/updated objects while keeping dual-read support so already-reconciled objects and rollback stay safe.

- Controller labels (`internal/controller/labels`): `EnsureControllerLabels` now deletes the legacy-prefixed pair instead of dual-writing it. Dual-read (`HasControllerLabels`/selectors) is untouched.
- `ngrok.com/computed-url` Service annotation: write-side now writes only the new key and deletes the legacy one if present.
- BoundEndpoint-owned Service labels/annotations (bindings): dual-write dropped for the labels/annotations set on generated Services.
- Operator finalizer: `AddFinalizer` now writes only the new key and removes the legacy one (three-release finalizer pattern — `HasFinalizer`/`RemoveFinalizer` still bridge both keys, so a rollback to R1 stays safe).
- Helm: `ingress.controllerName` default flipped to `ngrok.com/ingress-controller` (IngressClass rollout-race deferral continues to recognize both values at read time).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` all clean
- [x] `go test ./...` green, including updated fixtures/tests across `internal/controller/labels`, `internal/controller/service`, `internal/controller/bindings`, `internal/util`, `internal/domain`, `pkg/managerdriver` (64 golden fixtures updated), `internal/controller/ngrok`, `internal/controller/gateway`
- [x] `helm unittest` green, snapshots regenerated (`helm/ngrok-operator`)
- [x] `tests/chainsaw*` fixtures updated to assert the new-prefix keys where objects are freshly created

K8SOP-303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changed**
  - Standardized generated resource metadata on the `ngrok.com` label namespace.
  - Existing legacy controller labels are now cleaned up during reconciliation.
  - Finalizers now use `ngrok.com/finalizer`, with legacy finalizers removed.
  - Computed service URL annotations migrate to the canonical key and remove legacy keys.
  - Generated services no longer write legacy ownership labels or endpoint URL annotations.

- **Documentation**
  - Updated migration guidance for legacy metadata cleanup and removable-code markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->