### PR TITLE
Cleanup: remove legacy IPPolicy RulesConfigured condition handling (K8SOP-307)

### DIFF
--- a/internal/controller/ingress/ippolicy_conditions.go
+++ b/internal/controller/ingress/ippolicy_conditions.go
@@ -14,10 +14,6 @@ const (
 	ConditionIPPolicyCreated         = "IPPolicyCreated"
 	ConditionIPPolicyRulesConfigured = "IPPolicyRulesConfigured"
 
-	// LEGACY-CONDITION-MIGRATION: delete this once all IPPolicies have been
-	// reconciled at least once past the ConditionIPPolicyRulesConfigured rename.
-	legacyConditionIPPolicyRulesConfigured = "RulesConfigured"
-
 	// condition reasons for IPPolicy
 	ReasonIPPolicyActive                  = "IPPolicyActive"
 	ReasonIPPolicyCreated                 = "IPPolicyCreated"
@@ -40,9 +36,6 @@ func setIPPolicyCreatedCondition(ipPolicy *ingressv1alpha1.IPPolicy, created boo
 // setIPPolicyRulesConfiguredCondition sets the RulesConfigured condition
 func setIPPolicyRulesConfiguredCondition(ipPolicy *ingressv1alpha1.IPPolicy, configured bool, reason, message string) {
 	conditions.Set(&ipPolicy.Status.Conditions, ipPolicy.Generation, ConditionIPPolicyRulesConfigured, configured, reason, message)
-	// LEGACY-CONDITION-MIGRATION: clear the pre-rename condition so it doesn't
-	// linger alongside the new one on IPPolicies that reconciled before the rename.
-	meta.RemoveStatusCondition(&ipPolicy.Status.Conditions, legacyConditionIPPolicyRulesConfigured)
 }
 
 // sets the Ready condition based on the other conditions

--- a/internal/controller/ingress/ippolicy_conditions_test.go
+++ b/internal/controller/ingress/ippolicy_conditions_test.go
@@ -105,31 +105,3 @@ func TestSetIPPolicyRulesConfiguredCondition(t *testing.T) {
 	assert.Equal(t, "Failed to configure IP Policy rules", condition.Message)
 	assert.Equal(t, int64(1), condition.ObservedGeneration)
 }
-
-// Tests that the pre-rename RulesConfigured condition is cleared once the
-// renamed IPPolicyRulesConfigured condition is set
-func TestSetIPPolicyRulesConfiguredCondition_ClearsLegacyCondition(t *testing.T) {
-	ipPolicy := &ingressv1alpha1.IPPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-ip-policy",
-			Generation: 1,
-		},
-		Status: ingressv1alpha1.IPPolicyStatus{
-			Conditions: []metav1.Condition{
-				{
-					Type:               legacyConditionIPPolicyRulesConfigured,
-					Status:             metav1.ConditionTrue,
-					Reason:             "RulesConfigured",
-					Message:            "IP Policy rules have been configured",
-					ObservedGeneration: 1,
-					LastTransitionTime: metav1.Now(),
-				},
-			},
-		},
-	}
-
-	setIPPolicyRulesConfiguredCondition(ipPolicy, true, ReasonIPPolicyRulesConfigured, "IP Policy rules have been configured")
-
-	assert.Nil(t, meta.FindStatusCondition(ipPolicy.Status.Conditions, legacyConditionIPPolicyRulesConfigured), "expected legacy RulesConfigured condition to be removed")
-	assert.NotNil(t, meta.FindStatusCondition(ipPolicy.Status.Conditions, ConditionIPPolicyRulesConfigured), "expected IPPolicyRulesConfigured condition to be set")
-}


### PR DESCRIPTION
## Summary
Undocumented-in-`passivity-shims.md` but tagged `LEGACY-CONDITION-MIGRATION` cleanup for the `RulesConfigured` -> `IPPolicyRulesConfigured` status condition rename.

- Deleted the `legacyConditionIPPolicyRulesConfigured` const and the `meta.RemoveStatusCondition` call in `setIPPolicyRulesConfiguredCondition`.

Why this is safe now: `conditions.Set` (`meta.SetStatusCondition`) only upserts the condition type it's given — it doesn't prune the rest of the slice, so this isn't "self-healing" in a general sense. What actually did the cleanup was the explicit `RemoveStatusCondition` call added alongside the original rename: every IPPolicy had the legacy condition stripped on its first reconcile after that release. Enough reconciles have happened since that no live object should still carry it, so the removal call has served its purpose and can go.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` clean
- [x] `go test ./...` green (removed the now-redundant `TestSetIPPolicyRulesConfiguredCondition_ClearsLegacyCondition` test)

K8SOP-307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the deprecated legacy IP policy status condition.
  * IP policy status now uses only the current rules-configured condition.
  * Aligned IP policy status reporting with the current condition naming, providing a more consistent status experience for users and tools that monitor IP policy configuration.
  * Removed outdated references associated with the legacy condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->