### PR TITLE
chore(dependencies): Bump go to 1.27

### DIFF
--- a/cmd/agent-manager.go
+++ b/cmd/agent-manager.go
@@ -156,21 +156,20 @@ func runAgentController(_ context.Context, opts agentManagerOpts) error {
 		WebhookServer:          webhook.NewServer(webhook.Options{Port: 9443}),
 		HealthProbeBindAddress: opts.probeAddr,
 		LeaderElection:         false,
-	}
 
-	// The KubernetesOperator CR is a singleton owned by the operator and always
-	// lives in the release namespace, regardless of `watchNamespace`. Pin its
-	// cache scope to the release namespace so the drain state checker can always
-	// read it, and so RBAC for it can stay narrowly scoped to the release namespace.
-	options.Cache = cache.Options{
-		ByObject: map[client.Object]cache.ByObject{
-			&ngrokv1alpha1.KubernetesOperator{}: {
-				Namespaces: map[string]cache.Config{
-					opts.namespace: {},
+		// The KubernetesOperator CR is a singleton owned by the operator and always
+		// lives in the release namespace, regardless of `watchNamespace`. Pin its
+		// cache scope to the release namespace so the drain state checker can always
+		// read it, and so RBAC for it can stay narrowly scoped to the release namespace.
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&ngrokv1alpha1.KubernetesOperator{}: {
+					Namespaces: map[string]cache.Config{
+						opts.namespace: {},
+					},
 				},
 			},
-		},
-	}
+		}}
 	if opts.watchNamespace != "" {
 		setupLog.Info("watching namespace", "namespace", opts.watchNamespace)
 		options.Cache.DefaultNamespaces = map[string]cache.Config{

--- a/cmd/api-manager.go
+++ b/cmd/api-manager.go
@@ -71,7 +71,6 @@ import (
 	"github.com/ngrok/ngrok-operator/internal/util"
 	"github.com/ngrok/ngrok-operator/internal/version"
 	"github.com/ngrok/ngrok-operator/pkg/managerdriver"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	// +kubebuilder:scaffold:imports
 )
@@ -444,21 +443,20 @@ func loadManager(k8sConfig *rest.Config, opts apiManagerOpts) (manager.Manager, 
 		HealthProbeBindAddress: opts.probeAddr,
 		LeaderElection:         opts.electionID != "",
 		LeaderElectionID:       opts.electionID,
-	}
 
-	// The KubernetesOperator CR is a singleton owned by the operator and always
-	// lives in the release namespace, regardless of `watchNamespace`. Pin its
-	// cache scope to the release namespace so the controller can always list/watch
-	// it, and so RBAC for it can stay narrowly scoped to the release namespace.
-	options.Cache = cache.Options{
-		ByObject: map[client.Object]cache.ByObject{
-			&ngrokv1alpha1.KubernetesOperator{}: {
-				Namespaces: map[string]cache.Config{
-					opts.namespace: {},
+		// The KubernetesOperator CR is a singleton owned by the operator and always
+		// lives in the release namespace, regardless of `watchNamespace`. Pin its
+		// cache scope to the release namespace so the controller can always list/watch
+		// it, and so RBAC for it can stay narrowly scoped to the release namespace.
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&ngrokv1alpha1.KubernetesOperator{}: {
+					Namespaces: map[string]cache.Config{
+						opts.namespace: {},
+					},
 				},
 			},
-		},
-	}
+		}}
 	if opts.ingressWatchNamespace != "" {
 		options.Cache.DefaultNamespaces = map[string]cache.Config{
 			opts.ingressWatchNamespace: {},
@@ -793,10 +791,8 @@ func enableBindingsFeatureSet(_ context.Context, opts apiManagerOpts, mgr ctrl.M
 
 func createKubernetesOperator(ctx context.Context, client client.Client, opts apiManagerOpts) error {
 	k8sOperator := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      opts.releaseName,
-			Namespace: opts.namespace,
-		},
+		Name:      opts.releaseName,
+		Namespace: opts.namespace,
 	}
 	_, err := controllerutil.CreateOrUpdate(ctx, client, k8sOperator, func() error {
 		k8sOperator.Spec = ngrokv1alpha1.KubernetesOperatorSpec{

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785975029,
-        "narHash": "sha256-X44cn5rzytELc3NNoQsh0aLkjWA/QzPfc6HPQmsG3sU=",
+        "lastModified": 1787209939,
+        "narHash": "sha256-WvvHR4kSQLAbtouMC/ruZ5UpLwlUcY3K4FAllMN+yGk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "70ce234312134a463ba7728e94da2486a1d237ac",
+        "rev": "391b592eb44808b3bd0cb80bb71b63a5a118b8bb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,51 @@
           };
         };
 
+        # Tools that parse our source with their own embedded go/types must be
+        # built with the same Go toolchain we target. A tool built with go1.26
+        # rejects go1.27 source outright ("method must have no type parameters"
+        # for generic methods; golangci-lint refuses to start at all). Drop
+        # these overrides once nixpkgs builds them with go 1.27 by default.
+        goVersion = pkgs.go_1_27;
+
+        # Each package names its Go builder differently, so the override arg
+        # differs too; nixpkgs pins golangci-lint to a specific Go version on
+        # purpose (see the comment in its package.nix).
+        #
+        # Building against go 1.27 is necessary but not sufficient: golangci-lint
+        # 2.12.2 vendors honnef.co/go/tools v0.7.0 (staticcheck 2026.1), whose IR
+        # builder panics on go 1.27 syntax ("unexpected expr: *ast.KeyValueExpr"
+        # -- embedded-field struct initializers) while analyzing the go 1.27
+        # stdlib, which takes down the whole run. 2.13.1 vendors v0.8.0
+        # (staticcheck 2026.2), the first release to support go 1.27.
+        #
+        # nixpkgs master already has 2.13.1; nixpkgs-unstable does not yet. Drop
+        # this whole binding -- override and overrideAttrs both -- once it lands,
+        # since master also renames the builder arg to buildGo127Module.
+        golangci-lint =
+          (pkgs.golangci-lint.override { buildGo126Module = pkgs.buildGo127Module; }).overrideAttrs
+            (_: {
+              version = "2.13.1";
+              src = pkgs.fetchFromGitHub {
+                owner = "golangci";
+                repo = "golangci-lint";
+                tag = "v2.13.1";
+                hash = "sha256-8nWHSMAwIILfKMPfxWKMimxWt9N+kUsZEAaoAOPbRBE=";
+              };
+              vendorHash = "sha256-yZRqfht5rY2yyoZNtYttE57sB7EYjk71yrKw8dLYzNk=";
+            });
+        kubernetes-controller-tools = pkgs.kubernetes-controller-tools.override {
+          buildGoModule = pkgs.buildGo127Module;
+        };
+        # goimports parses our source too, and `go` here is the toolchain it
+        # wraps itself with. Note: go-tools (staticcheck) is deliberately NOT
+        # rebuilt against go 1.27 -- its own test suite fails under 1.27 for the
+        # same reason golangci-lint's vendored copy does (see .golangci.yml).
+        gotools = pkgs.gotools.override {
+          buildGoModule = pkgs.buildGo127Module;
+          go = pkgs.go_1_27;
+        };
+
         readmeGeneratorForHelm = pkgs.buildNpmPackage {
           pname = "readme-generator-for-helm";
           version = "2.6.1";
@@ -80,7 +125,7 @@
             with pkgs;
             [
               bashInteractive
-              go_1_26
+              goVersion
               go-tools
               golangci-lint
               gotools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ngrok/ngrok-operator
 
-go 1.26.3
+go 1.27
 
 require (
 	github.com/docker/docker v28.5.2+incompatible

--- a/internal/annotations/annotations_test.go
+++ b/internal/annotations/annotations_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	networking "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestExtractNgrokTrafficPolicyFromAnnotations(t *testing.T) {
@@ -86,11 +85,9 @@ func TestExtractNgrokTrafficPolicyFromAnnotations(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "test-ingress",
-					Namespace:   "default",
-					Annotations: tc.annotations,
-				},
+				Name:        "test-ingress",
+				Namespace:   "default",
+				Annotations: tc.annotations,
 			}
 
 			policy, err := annotations.ExtractNgrokTrafficPolicyFromAnnotations(obj)
@@ -173,11 +170,9 @@ func TestExtractUseEndpointPooling(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "test-ingress",
-					Namespace:   "default",
-					Annotations: tc.annotations,
-				},
+				Name:        "test-ingress",
+				Namespace:   "default",
+				Annotations: tc.annotations,
 			}
 
 			useEndpoints, err := annotations.ExtractUseEndpointPooling(obj)
@@ -262,11 +257,9 @@ func TestExtractUseBindings(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "test-ingress",
-					Namespace:   "default",
-					Annotations: tc.annotations,
-				},
+				Name:        "test-ingress",
+				Namespace:   "default",
+				Annotations: tc.annotations,
 			}
 
 			binding, err := annotations.ExtractUseBindings(obj)
@@ -318,11 +311,9 @@ func TestExtractURL(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "test-ingress",
-					Namespace:   "default",
-					Annotations: tc.annotations,
-				},
+				Name:        "test-ingress",
+				Namespace:   "default",
+				Annotations: tc.annotations,
 			}
 
 			got, err := annotations.ExtractURL(obj)
@@ -399,11 +390,9 @@ func TestExtractComputedURL(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "test-ingress",
-					Namespace:   "default",
-					Annotations: tc.annotations,
-				},
+				Name:        "test-ingress",
+				Namespace:   "default",
+				Annotations: tc.annotations,
 			}
 
 			got, err := annotations.ExtractComputedURL(obj)
@@ -458,11 +447,9 @@ func TestExtractMetadata(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "test-ingress",
-					Namespace:   "default",
-					Annotations: tc.annotations,
-				},
+				Name:        "test-ingress",
+				Namespace:   "default",
+				Annotations: tc.annotations,
 			}
 			got, err := annotations.ExtractMetadata(obj)
 			require.NoError(t, err)
@@ -510,11 +497,9 @@ func TestExtractDescription(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "test-ingress",
-					Namespace:   "default",
-					Annotations: tc.annotations,
-				},
+				Name:        "test-ingress",
+				Namespace:   "default",
+				Annotations: tc.annotations,
 			}
 			got, err := annotations.ExtractDescription(obj)
 			require.NoError(t, err)

--- a/internal/annotations/parser/parser_test.go
+++ b/internal/annotations/parser/parser_test.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ngrok/ngrok-operator/internal/errors"
 )
 
 func objWithAnnotations(anns map[string]string) client.Object {
-	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: anns}}
+	return &corev1.Pod{Annotations: anns}
 }
 
 func TestGetStringAnnotationDualRead(t *testing.T) {

--- a/internal/annotations/testutil/ingress.go
+++ b/internal/annotations/testutil/ingress.go
@@ -4,30 +4,25 @@ package testutil
 import (
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewIngress() *networking.Ingress {
 	return &networking.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-ingress",
-			Namespace: v1.NamespaceDefault,
-		},
+		Name:      "test-ingress",
+		Namespace: v1.NamespaceDefault,
 		Spec: networking.IngressSpec{
 			Rules: []networking.IngressRule{
 				{
 					Host: "test.ngrok.app",
-					IngressRuleValue: networking.IngressRuleValue{
-						HTTP: &networking.HTTPIngressRuleValue{
-							Paths: []networking.HTTPIngressPath{
-								{
-									Path: "/foo",
-									Backend: networking.IngressBackend{
-										Service: &networking.IngressServiceBackend{
-											Name: "foo",
-											Port: networking.ServiceBackendPort{
-												Number: 80,
-											},
+					HTTP: &networking.HTTPIngressRuleValue{
+						Paths: []networking.HTTPIngressPath{
+							{
+								Path: "/foo",
+								Backend: networking.IngressBackend{
+									Service: &networking.IngressServiceBackend{
+										Name: "foo",
+										Port: networking.ServiceBackendPort{
+											Number: 80,
 										},
 									},
 								},

--- a/internal/controller/agent/agent_endpoint_conditions_test.go
+++ b/internal/controller/agent/agent_endpoint_conditions_test.go
@@ -14,11 +14,9 @@ import (
 // Helper function to create a test AgentEndpoint
 func createTestAgentEndpoint(name, namespace string) *ngrokv1alpha1.AgentEndpoint {
 	return &ngrokv1alpha1.AgentEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  namespace,
-			Generation: 1,
-		},
+		Name:       name,
+		Namespace:  namespace,
+		Generation: 1,
 		Status: ngrokv1alpha1.AgentEndpointStatus{
 			Conditions: []metav1.Condition{},
 		},

--- a/internal/controller/agent/agent_endpoint_controller.go
+++ b/internal/controller/agent/agent_endpoint_controller.go
@@ -323,10 +323,8 @@ func (r *AgentEndpointReconciler) findAgentEndpointForTrafficPolicy(ctx context.
 	var requests []ctrl.Request
 	for _, aep := range agentEndpointList.Items {
 		requests = append(requests, ctrl.Request{
-			NamespacedName: client.ObjectKey{
-				Name:      aep.Name,
-				Namespace: aep.Namespace,
-			},
+			Name:      aep.Name,
+			Namespace: aep.Namespace,
 		})
 	}
 

--- a/internal/controller/agent/agent_endpoint_controller_test.go
+++ b/internal/controller/agent/agent_endpoint_controller_test.go
@@ -86,9 +86,7 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		// Create namespace for testing
 		ns := &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-			},
+			Name: namespace,
 		}
 		Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
 
@@ -101,9 +99,7 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		// Clean up namespace
 		if namespace != "" {
 			ns := &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: namespace,
-				},
+				Name: namespace,
 			}
 			err := k8sClient.Delete(context.Background(), ns)
 			Expect(err).NotTo(HaveOccurred())
@@ -113,10 +109,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 	Context("Basic endpoint operations", func() {
 		It("should successfully reconcile TCP endpoint", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcp-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "tcp-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://1.tcp.ngrok.io:12345",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -160,10 +154,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should not create domain CR for custom TCP endpoint", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcp-custom-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "tcp-custom-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://1.2.3.4:25565",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -207,10 +199,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should not update LastTransitionTime on re-reconcile when ready state unchanged", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "stable-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "stable-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://1.tcp.ngrok.io:12345",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -274,10 +264,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should handle internal endpoints without domain creation", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "internal-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "internal-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "https://test.internal",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -307,10 +295,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should create domain CR for custom domains", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "custom-domain-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "custom-domain-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "https://custom.example.com",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -345,10 +331,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should handle endpoint creation failure", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "failing-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "failing-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://2.tcp.ngrok.io:54321",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -377,10 +361,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should handle endpoint deletion", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "delete-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "delete-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://3.tcp.ngrok.io:11111",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -424,10 +406,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 	Context("Traffic policy handling", func() {
 		It("should handle inline traffic policy", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "inline-policy-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "inline-policy-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://4.tcp.ngrok.io:44444",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -473,10 +453,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		It("should resolve traffic policy reference", func(ctx SpecContext) {
 			// Create traffic policy
 			trafficPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "referenced-policy",
-					Namespace: namespace,
-				},
+				Name:      "referenced-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"on_http_request":[{"name":"rate-limit"}]}`),
 				},
@@ -484,10 +462,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, trafficPolicy)).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ref-policy-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "ref-policy-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://5.tcp.ngrok.io:55555",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -534,10 +510,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should handle missing traffic policy reference", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "missing-policy-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "missing-policy-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://6.tcp.ngrok.io:66666",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -569,10 +543,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		It("should reject both inline and reference policy at validation", func() {
 			// This should be caught by k8s validation, so we expect the Create to fail
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid-policy-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "invalid-policy-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://7.tcp.ngrok.io:77777",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -595,10 +567,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		It("should successfully apply traffic policy", func(ctx SpecContext) {
 			// Create a traffic policy
 			trafficPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-policy",
-					Namespace: namespace,
-				},
+				Name:      "test-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"inbound":[{"type":"deny"}]}`),
 				},
@@ -606,10 +576,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, trafficPolicy)).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-endpoint-with-policy",
-					Namespace: namespace,
-				},
+				Name:      "test-endpoint-with-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://10.tcp.ngrok.io:10101",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -660,10 +628,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		It("should reconcile when traffic policy is updated", func(ctx SpecContext) {
 			// Create a traffic policy
 			trafficPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "update-policy",
-					Namespace: namespace,
-				},
+				Name:      "update-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"inbound":[{"type":"deny"}]}`),
 				},
@@ -671,10 +637,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, trafficPolicy)).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "update-policy-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "update-policy-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://11.tcp.ngrok.io:11111",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -736,10 +700,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 	Context("when AgentEndpoint creation fails", func() {
 		It("should set appropriate error conditions", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "failing-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "failing-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://12.tcp.ngrok.io:12121",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -781,10 +743,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 	Context("when AgentEndpoint is deleted", func() {
 		It("should call delete on the mock driver", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "delete-test-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "delete-test-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://13.tcp.ngrok.io:13131",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -829,10 +789,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 	Context("Client certificate handling", func() {
 		It("should handle missing client certificate secret", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "missing-cert-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "missing-cert-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://8.tcp.ngrok.io:88888",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -862,10 +820,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		It("should handle invalid certificate data", func(ctx SpecContext) {
 			// Create secret with invalid cert data
 			secret := &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid-cert",
-					Namespace: namespace,
-				},
+				Name:      "invalid-cert",
+				Namespace: namespace,
 				Data: map[string][]byte{
 					"tls.crt": []byte("invalid-cert-data"),
 					"tls.key": []byte("invalid-key-data"),
@@ -874,10 +830,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid-cert-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "invalid-cert-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://9.tcp.ngrok.io:99999",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -907,10 +861,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		It("should handle missing tls.crt in secret", func(ctx SpecContext) {
 			// Create secret missing tls.crt
 			secret := &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-crt-secret",
-					Namespace: namespace,
-				},
+				Name:      "no-crt-secret",
+				Namespace: namespace,
 				Data: map[string][]byte{
 					"tls.key": []byte("some-key-data"),
 				},
@@ -918,10 +870,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-crt-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "no-crt-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://10.tcp.ngrok.io:10000",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -953,8 +903,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		It("should wire the server certificate through to the driver", func(ctx SpecContext) {
 			certPEM, keyPEM := generateSelfSignedTLSPEM()
 			serverSecret := &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-term-server", Namespace: namespace},
-				Type:       v1.SecretTypeTLS,
+				Name: "tls-term-server", Namespace: namespace,
+				Type: v1.SecretTypeTLS,
 				Data: map[string][]byte{
 					"tls.crt": certPEM,
 					"tls.key": keyPEM,
@@ -963,7 +913,7 @@ var _ = Describe("AgentEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, serverSecret)).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-term-ok", Namespace: namespace},
+				Name: "tls-term-ok", Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "tls://tls-term-ok.example.com",
 					Upstream: ngrokv1alpha1.EndpointUpstream{URL: "http://test-service:80"},
@@ -991,7 +941,7 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should set ConfigError when the server cert Secret is missing", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-term-missing", Namespace: namespace},
+				Name: "tls-term-missing", Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "tls://tls-term-missing.example.com",
 					Upstream: ngrokv1alpha1.EndpointUpstream{URL: "http://test-service:80"},
@@ -1017,8 +967,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should set ConfigError when tls.crt is malformed", func(ctx SpecContext) {
 			Expect(k8sClient.Create(ctx, &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-term-bad", Namespace: namespace},
-				Type:       v1.SecretTypeTLS,
+				Name: "tls-term-bad", Namespace: namespace,
+				Type: v1.SecretTypeTLS,
 				Data: map[string][]byte{
 					"tls.crt": []byte("not a real cert"),
 					"tls.key": []byte("not a real key"),
@@ -1026,7 +976,7 @@ var _ = Describe("AgentEndpoint Controller", func() {
 			})).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-term-bad-aep", Namespace: namespace},
+				Name: "tls-term-bad-aep", Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "tls://tls-term-bad.example.com",
 					Upstream: ngrokv1alpha1.EndpointUpstream{URL: "http://test-service:80"},
@@ -1051,17 +1001,17 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		It("should set ConfigError when the mTLS CA Secret is missing ca.crt", func(ctx SpecContext) {
 			certPEM, keyPEM := generateSelfSignedTLSPEM()
 			Expect(k8sClient.Create(ctx, &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-term-mtls-server", Namespace: namespace},
-				Type:       v1.SecretTypeTLS,
-				Data:       map[string][]byte{"tls.crt": certPEM, "tls.key": keyPEM},
+				Name: "tls-term-mtls-server", Namespace: namespace,
+				Type: v1.SecretTypeTLS,
+				Data: map[string][]byte{"tls.crt": certPEM, "tls.key": keyPEM},
 			})).To(Succeed())
 			Expect(k8sClient.Create(ctx, &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-term-mtls-no-ca", Namespace: namespace},
-				Data:       map[string][]byte{"other": []byte("nope")},
+				Name: "tls-term-mtls-no-ca", Namespace: namespace,
+				Data: map[string][]byte{"other": []byte("nope")},
 			})).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-term-mtls-bad", Namespace: namespace},
+				Name: "tls-term-mtls-bad", Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "tls://tls-term-mtls-bad.example.com",
 					Upstream: ngrokv1alpha1.EndpointUpstream{URL: "http://test-service:80"},
@@ -1089,18 +1039,18 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		It("should wire mTLS mode through to the driver", func(ctx SpecContext) {
 			certPEM, keyPEM := generateSelfSignedTLSPEM()
 			Expect(k8sClient.Create(ctx, &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-mode-server", Namespace: namespace},
-				Type:       v1.SecretTypeTLS,
-				Data:       map[string][]byte{"tls.crt": certPEM, "tls.key": keyPEM},
+				Name: "tls-mode-server", Namespace: namespace,
+				Type: v1.SecretTypeTLS,
+				Data: map[string][]byte{"tls.crt": certPEM, "tls.key": keyPEM},
 			})).To(Succeed())
 			// Reuse the same self-signed cert as a CA bundle for the test.
 			Expect(k8sClient.Create(ctx, &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-mode-ca", Namespace: namespace},
-				Data:       map[string][]byte{"ca.crt": certPEM},
+				Name: "tls-mode-ca", Namespace: namespace,
+				Data: map[string][]byte{"ca.crt": certPEM},
 			})).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-mode-request", Namespace: namespace},
+				Name: "tls-mode-request", Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "tls://tls-mode-request.example.com",
 					Upstream: ngrokv1alpha1.EndpointUpstream{URL: "http://test-service:80"},
@@ -1132,7 +1082,7 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should reject https:// urls when tlsTermination is set", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "tls-term-bad-url", Namespace: namespace},
+				Name: "tls-term-bad-url", Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "https://tls-term-bad-url.example.com",
 					Upstream: ngrokv1alpha1.EndpointUpstream{URL: "http://test-service:80"},
@@ -1155,10 +1105,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should reconcile TCP endpoint automatically using Eventually", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcp-runtime-auto",
-					Namespace: namespace,
-				},
+				Name:      "tcp-runtime-auto",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://99.tcp.ngrok.io:99999",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -1203,10 +1151,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should handle endpoint creation failure with runtime controller", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fail-runtime-auto",
-					Namespace: namespace,
-				},
+				Name:      "fail-runtime-auto",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://98.tcp.ngrok.io:98989",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -1236,10 +1182,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should not infinitely requeue when the ngrok API rejects the traffic policy", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "policy-rejected-runtime",
-					Namespace: namespace,
-				},
+				Name:      "policy-rejected-runtime",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://99.tcp.ngrok.io:99999",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -1299,10 +1243,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 
 		It("should handle endpoint deletion with runtime controller", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "delete-runtime-auto",
-					Namespace: namespace,
-				},
+				Name:      "delete-runtime-auto",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://97.tcp.ngrok.io:97979",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -1348,10 +1290,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 		It("should reconcile traffic policy reference with runtime controller", func(ctx SpecContext) {
 			// Create traffic policy first
 			trafficPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "runtime-auto-policy",
-					Namespace: namespace,
-				},
+				Name:      "runtime-auto-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"on_http_request":[{"name":"rate-limit"}]}`),
 				},
@@ -1359,10 +1299,8 @@ var _ = Describe("AgentEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, trafficPolicy)).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "policy-runtime-auto",
-					Namespace: namespace,
-				},
+				Name:      "policy-runtime-auto",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://96.tcp.ngrok.io:96969",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -1467,10 +1405,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 		It("should reconcile when client certificate secret is created after AgentEndpoint", func(ctx SpecContext) {
 			// Create AgentEndpoint first, without the certificate secret existing yet
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cert-watch-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "cert-watch-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://cert-watch.tcp.ngrok.io:12345",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -1505,11 +1441,9 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 
 			By("Creating the client certificate secret")
 			certSecret := &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "watch-test-cert",
-					Namespace: namespace,
-				},
-				Type: v1.SecretTypeTLS,
+				Name:      "watch-test-cert",
+				Namespace: namespace,
+				Type:      v1.SecretTypeTLS,
 				Data: map[string][]byte{
 					"tls.crt": []byte(testCert),
 					"tls.key": []byte(testKey),
@@ -1547,10 +1481,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 	Context("Domain handling", func() {
 		It("should skip domain creation for Kubernetes-bound endpoint", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "k8s-bound-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "k8s-bound-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "http://aws.demo",
 					Bindings: []string{"kubernetes"},
@@ -1612,10 +1544,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 			BeforeEach(func(ctx SpecContext) {
 				By("Creating a domain that would be stale")
 				staleDomain = &ingressv1alpha1.Domain{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stale-domain-ref",
-						Namespace: namespace,
-					},
+					Name:      "stale-domain-ref",
+					Namespace: namespace,
 					Spec: ingressv1alpha1.DomainSpec{
 						Domain: "test.default",
 					},
@@ -1623,10 +1553,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 				Expect(k8sClient.Create(ctx, staleDomain)).To(Succeed())
 
 				agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "k8s-binding-with-stale-ref",
-						Namespace: namespace,
-					},
+					Name:      "k8s-binding-with-stale-ref",
+					Namespace: namespace,
 					Spec: ngrokv1alpha1.AgentEndpointSpec{
 						URL:      "http://test.default",
 						Bindings: []string{"kubernetes"},
@@ -1665,10 +1593,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 
 		It("should create endpoint even when domain is not ready", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "test-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "http://example.com",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -1763,10 +1689,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 
 		It("should reconcile endpoint when domain status becomes ready", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-domain-reconcile",
-					Namespace: namespace,
-				},
+				Name:      "test-domain-reconcile",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "https://test-reconcile.example.com",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -1840,10 +1764,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 
 		It("should clear stale domainRef when endpoint has kubernetes binding", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "endpoint-with-stale-ref",
-					Namespace: namespace,
-				},
+				Name:      "endpoint-with-stale-ref",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "http://stale.example.com",
 					Bindings: []string{"kubernetes"},
@@ -1904,10 +1826,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 		It("should delete stale domain when endpoint has kubernetes binding and domainRef", func(ctx SpecContext) {
 			// Create domain first
 			staleDomain := &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "stale-to-delete-example-com",
-					Namespace: namespace,
-				},
+				Name:      "stale-to-delete-example-com",
+				Namespace: namespace,
 				Spec: ingressv1alpha1.DomainSpec{
 					Domain: "stale-to-delete.example.com",
 				},
@@ -1915,10 +1835,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 			Expect(k8sClient.Create(ctx, staleDomain)).To(Succeed())
 
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "endpoint-triggers-domain-delete",
-					Namespace: namespace,
-				},
+				Name:      "endpoint-triggers-domain-delete",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "https://stale-to-delete.example.com",
 					Bindings: []string{"kubernetes"},
@@ -1991,10 +1909,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 		It("should handle multiple Kubernetes-bound endpoints with same domain", func(ctx SpecContext) {
 			endpoints := []*ngrokv1alpha1.AgentEndpoint{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "k8s-endpoint-1",
-						Namespace: namespace,
-					},
+					Name:      "k8s-endpoint-1",
+					Namespace: namespace,
 					Spec: ngrokv1alpha1.AgentEndpointSpec{
 						URL:      "http://aws.demo",
 						Bindings: []string{"kubernetes"},
@@ -2004,10 +1920,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "k8s-endpoint-2",
-						Namespace: namespace,
-					},
+					Name:      "k8s-endpoint-2",
+					Namespace: namespace,
 					Spec: ngrokv1alpha1.AgentEndpointSpec{
 						URL:      "http://aws.demo",
 						Bindings: []string{"kubernetes"},
@@ -2063,10 +1977,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 		It("should reject endpoint with multiple bindings", func() {
 			// This should be caught by k8s validation (MaxItems=1), so we expect the Create to fail
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid-multiple-bindings",
-					Namespace: namespace,
-				},
+				Name:      "invalid-multiple-bindings",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "http://test.demo",
 					Bindings: []string{"public", "internal"}, // Multiple bindings should be rejected
@@ -2086,10 +1998,8 @@ cCzFoVcb6XWg4MpPeZ25v+xA
 
 		It("should accept endpoint with single binding", func(ctx SpecContext) {
 			agentEndpoint = &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "valid-single-binding",
-					Namespace: namespace,
-				},
+				Name:      "valid-single-binding",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL:      "http://test.demo",
 					Bindings: []string{"internal"}, // Single binding is valid

--- a/internal/controller/agent/namespace_filter_test.go
+++ b/internal/controller/agent/namespace_filter_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ngrok/ngrok-operator/pkg/agent"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -50,10 +49,8 @@ var _ = Describe("AgentEndpoint Controller Namespace Filtering", func() {
 		It("should only reconcile AgentEndpoints in the watched namespace", func(ctx SpecContext) {
 			// Create AgentEndpoint in watched namespace
 			watchedEndpoint := &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "watched-endpoint",
-					Namespace: watchedNamespace,
-				},
+				Name:      "watched-endpoint",
+				Namespace: watchedNamespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://1.tcp.ngrok.io:12345",
 					Upstream: ngrokv1alpha1.EndpointUpstream{
@@ -64,10 +61,8 @@ var _ = Describe("AgentEndpoint Controller Namespace Filtering", func() {
 
 			// Create AgentEndpoint in unwatched namespace
 			unwatchedEndpoint := &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "unwatched-endpoint",
-					Namespace: unwatchedNamespace,
-				},
+				Name:      "unwatched-endpoint",
+				Namespace: unwatchedNamespace,
 				Spec: ngrokv1alpha1.AgentEndpointSpec{
 					URL: "tcp://2.tcp.ngrok.io:12346",
 					Upstream: ngrokv1alpha1.EndpointUpstream{

--- a/internal/controller/agent/suite_test.go
+++ b/internal/controller/agent/suite_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -130,9 +129,7 @@ var _ = BeforeSuite(func() {
 	// Create namespaces for namespace filtering tests
 	for _, ns := range []string{watchedNamespace, unwatchedNamespace} {
 		namespace := &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ns,
-			},
+			Name: ns,
 		}
 		err = k8sClient.Create(context.Background(), namespace)
 		if err != nil {

--- a/internal/controller/base_controller.go
+++ b/internal/controller/base_controller.go
@@ -207,8 +207,7 @@ func (self *BaseController[T]) ReconcileStatus(ctx context.Context, obj T, origE
 
 // CtrlResultForErr is a helper function to convert an error into a ctrl.Result passing through ngrok error mappings
 func CtrlResultForErr(err error) (ctrl.Result, error) {
-	var nerr *ngrok.Error
-	if errors.As(err, &nerr) {
+	if nerr, ok := errors.AsType[*ngrok.Error](err); ok {
 		switch {
 		case nerr.StatusCode >= 500:
 			return ctrl.Result{}, err
@@ -229,8 +228,7 @@ func CtrlResultForErr(err error) (ctrl.Result, error) {
 	}
 
 	// if error was because of status update, requeue for 10 seconds
-	var serr StatusError
-	if errors.As(err, &serr) {
+	if serr, ok := errors.AsType[StatusError](err); ok {
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, serr
 	}
 

--- a/internal/controller/base_controller_test.go
+++ b/internal/controller/base_controller_test.go
@@ -63,7 +63,7 @@ func TestBaseController_Reconcile_ObjectNotFound(t *testing.T) {
 	}
 
 	result, err := bc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "nonexistent", Namespace: "default"},
+		Name: "nonexistent", Namespace: "default",
 	}, &netv1.Ingress{})
 
 	assert.NoError(t, err)
@@ -76,10 +76,8 @@ func TestBaseController_Reconcile_DrainState(t *testing.T) {
 	require.NoError(t, scheme.AddToScheme(s))
 
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-ingress",
-			Namespace: "default",
-		},
+		Name:      "test-ingress",
+		Namespace: "default",
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).Build()
@@ -98,7 +96,7 @@ func TestBaseController_Reconcile_DrainState(t *testing.T) {
 	}
 
 	result, err := bc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "test-ingress", Namespace: "default"},
+		Name: "test-ingress", Namespace: "default",
 	}, &netv1.Ingress{})
 
 	assert.NoError(t, err)
@@ -113,12 +111,10 @@ func TestBaseController_Reconcile_DrainState_AllowsDelete(t *testing.T) {
 
 	now := metav1.NewTime(time.Now())
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "test-ingress",
-			Namespace:         "default",
-			DeletionTimestamp: &now,
-			Finalizers:        []string{util.FinalizerName},
-		},
+		Name:              "test-ingress",
+		Namespace:         "default",
+		DeletionTimestamp: &now,
+		Finalizers:        []string{util.FinalizerName},
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).Build()
@@ -137,7 +133,7 @@ func TestBaseController_Reconcile_DrainState_AllowsDelete(t *testing.T) {
 	}
 
 	result, err := bc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "test-ingress", Namespace: "default"},
+		Name: "test-ingress", Namespace: "default",
 	}, &netv1.Ingress{})
 
 	assert.NoError(t, err)
@@ -151,10 +147,8 @@ func TestBaseController_Reconcile_Create(t *testing.T) {
 	require.NoError(t, scheme.AddToScheme(s))
 
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-ingress",
-			Namespace: "default",
-		},
+		Name:      "test-ingress",
+		Namespace: "default",
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).Build()
@@ -176,7 +170,7 @@ func TestBaseController_Reconcile_Create(t *testing.T) {
 	}
 
 	result, err := bc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "test-ingress", Namespace: "default"},
+		Name: "test-ingress", Namespace: "default",
 	}, &netv1.Ingress{})
 
 	assert.NoError(t, err)
@@ -190,10 +184,8 @@ func TestBaseController_Reconcile_Update(t *testing.T) {
 	require.NoError(t, scheme.AddToScheme(s))
 
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-ingress",
-			Namespace: "default",
-		},
+		Name:      "test-ingress",
+		Namespace: "default",
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).Build()
@@ -215,7 +207,7 @@ func TestBaseController_Reconcile_Update(t *testing.T) {
 	}
 
 	result, err := bc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "test-ingress", Namespace: "default"},
+		Name: "test-ingress", Namespace: "default",
 	}, &netv1.Ingress{})
 
 	assert.NoError(t, err)
@@ -230,12 +222,10 @@ func TestBaseController_Reconcile_Delete(t *testing.T) {
 
 	now := metav1.NewTime(time.Now())
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "test-ingress",
-			Namespace:         "default",
-			DeletionTimestamp: &now,
-			Finalizers:        []string{util.FinalizerName},
-		},
+		Name:              "test-ingress",
+		Namespace:         "default",
+		DeletionTimestamp: &now,
+		Finalizers:        []string{util.FinalizerName},
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).Build()
@@ -253,7 +243,7 @@ func TestBaseController_Reconcile_Delete(t *testing.T) {
 	}
 
 	result, err := bc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "test-ingress", Namespace: "default"},
+		Name: "test-ingress", Namespace: "default",
 	}, &netv1.Ingress{})
 
 	assert.NoError(t, err)
@@ -268,12 +258,10 @@ func TestBaseController_Reconcile_Delete_NotFound(t *testing.T) {
 
 	now := metav1.NewTime(time.Now())
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "test-ingress",
-			Namespace:         "default",
-			DeletionTimestamp: &now,
-			Finalizers:        []string{util.FinalizerName},
-		},
+		Name:              "test-ingress",
+		Namespace:         "default",
+		DeletionTimestamp: &now,
+		Finalizers:        []string{util.FinalizerName},
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).Build()
@@ -292,7 +280,7 @@ func TestBaseController_Reconcile_Delete_NotFound(t *testing.T) {
 	}
 
 	result, err := bc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "test-ingress", Namespace: "default"},
+		Name: "test-ingress", Namespace: "default",
 	}, &netv1.Ingress{})
 
 	assert.NoError(t, err)
@@ -305,11 +293,9 @@ func TestBaseController_ReconcileStatus_SetsObservedGeneration(t *testing.T) {
 	require.NoError(t, ingressv1alpha1.AddToScheme(s))
 
 	domain := &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-domain",
-			Namespace:  "default",
-			Generation: 3,
-		},
+		Name:       "test-domain",
+		Namespace:  "default",
+		Generation: 3,
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(domain).WithStatusSubresource(domain).Build()
@@ -335,11 +321,9 @@ func TestBaseController_ReconcileStatus_NoObservedGenerationSetter(t *testing.T)
 	require.NoError(t, scheme.AddToScheme(s))
 
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-ingress",
-			Namespace:  "default",
-			Generation: 2,
-		},
+		Name:       "test-ingress",
+		Namespace:  "default",
+		Generation: 2,
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).WithStatusSubresource(ingress).Build()
@@ -481,10 +465,8 @@ func TestBaseController_Reconcile_CreateError(t *testing.T) {
 	require.NoError(t, scheme.AddToScheme(s))
 
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-ingress",
-			Namespace: "default",
-		},
+		Name:      "test-ingress",
+		Namespace: "default",
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).Build()
@@ -501,7 +483,7 @@ func TestBaseController_Reconcile_CreateError(t *testing.T) {
 	}
 
 	result, err := bc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "test-ingress", Namespace: "default"},
+		Name: "test-ingress", Namespace: "default",
 	}, &netv1.Ingress{})
 
 	assert.NoError(t, err)
@@ -514,10 +496,8 @@ func TestBaseController_Reconcile_UpdateError(t *testing.T) {
 	require.NoError(t, scheme.AddToScheme(s))
 
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-ingress",
-			Namespace: "default",
-		},
+		Name:      "test-ingress",
+		Namespace: "default",
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).Build()
@@ -534,7 +514,7 @@ func TestBaseController_Reconcile_UpdateError(t *testing.T) {
 	}
 
 	result, err := bc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "test-ingress", Namespace: "default"},
+		Name: "test-ingress", Namespace: "default",
 	}, &netv1.Ingress{})
 
 	assert.Error(t, err)
@@ -547,10 +527,8 @@ func TestBaseController_Reconcile_CustomErrResult(t *testing.T) {
 	require.NoError(t, scheme.AddToScheme(s))
 
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-ingress",
-			Namespace: "default",
-		},
+		Name:      "test-ingress",
+		Namespace: "default",
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ingress).Build()
@@ -570,7 +548,7 @@ func TestBaseController_Reconcile_CustomErrResult(t *testing.T) {
 	}
 
 	result, err := bc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "test-ingress", Namespace: "default"},
+		Name: "test-ingress", Namespace: "default",
 	}, &netv1.Ingress{})
 
 	assert.NoError(t, err)

--- a/internal/controller/bindings/boundendpoint_conditions_test.go
+++ b/internal/controller/bindings/boundendpoint_conditions_test.go
@@ -12,11 +12,9 @@ import (
 
 func createTestBoundEndpoint(name, namespace string) *bindingsv1alpha1.BoundEndpoint {
 	return &bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  namespace,
-			Generation: 1,
-		},
+		Name:       name,
+		Namespace:  namespace,
+		Generation: 1,
 		Status: bindingsv1alpha1.BoundEndpointStatus{
 			Conditions: []metav1.Condition{},
 		},

--- a/internal/controller/bindings/boundendpoint_controller.go
+++ b/internal/controller/bindings/boundendpoint_controller.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -357,7 +356,7 @@ func (r *BoundEndpointReconciler) deleteBoundEndpointServices(ctx context.Contex
 
 	targetService, upstreamService := r.convertBoundEndpointToServices(cr)
 
-	targetNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetService.Namespace}}
+	targetNamespace := &v1.Namespace{Name: targetService.Namespace}
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: targetNamespace.Name}, targetNamespace); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to get Target Namespace")
@@ -423,12 +422,10 @@ func (r *BoundEndpointReconciler) convertBoundEndpointToServices(boundEndpoint *
 	// targetService represents the user's configured endpoint binding as a Service
 	// Clients will send requests to this service: <scheme>://<service>.<namespace>:<port>
 	targetService := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        boundEndpoint.Spec.Target.Service,
-			Namespace:   boundEndpoint.Spec.Target.Namespace,
-			Labels:      targetLabels,
-			Annotations: targetAnnotations,
-		},
+		Name:        boundEndpoint.Spec.Target.Service,
+		Namespace:   boundEndpoint.Spec.Target.Namespace,
+		Labels:      targetLabels,
+		Annotations: targetAnnotations,
 		Spec: v1.ServiceSpec{
 			Type:                  v1.ServiceTypeExternalName,
 			ExternalName:          endpointURL,
@@ -456,12 +453,10 @@ func (r *BoundEndpointReconciler) convertBoundEndpointToServices(boundEndpoint *
 	// Target Service will point to this Service via an ExternalName
 	// This Service will point to the Pod Forwarders' containers on a dedicated allocated port
 	upstreamService := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        boundEndpoint.Name,
-			Namespace:   boundEndpoint.Namespace,
-			Labels:      upstreamLabels,
-			Annotations: upstreamAnnotations,
-		},
+		Name:        boundEndpoint.Name,
+		Namespace:   boundEndpoint.Namespace,
+		Labels:      upstreamLabels,
+		Annotations: upstreamAnnotations,
 		Spec: v1.ServiceSpec{
 			Type:                  v1.ServiceTypeClusterIP,
 			InternalTrafficPolicy: &internalTrafficPolicy,
@@ -502,10 +497,8 @@ func (r *BoundEndpointReconciler) findBoundEndpointsForNamespace(ctx context.Con
 	requests := make([]reconcile.Request, len(boundEndpoints.Items))
 	for i, binding := range boundEndpoints.Items {
 		requests[i] = reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: binding.Namespace,
-				Name:      binding.Name,
-			},
+			Namespace: binding.Namespace,
+			Name:      binding.Name,
 		}
 		log.WithValues("endpoint-binding", map[string]string{
 			"namespace": binding.Namespace,
@@ -545,10 +538,8 @@ func (r *BoundEndpointReconciler) findBoundEndpointsForService(ctx context.Conte
 
 	return []reconcile.Request{
 		{
-			NamespacedName: types.NamespacedName{
-				Namespace: epb.Namespace,
-				Name:      epb.Name,
-			},
+			Namespace: epb.Namespace,
+			Name:      epb.Name,
 		},
 	}
 }

--- a/internal/controller/bindings/boundendpoint_controller_test.go
+++ b/internal/controller/bindings/boundendpoint_controller_test.go
@@ -30,7 +30,6 @@ import (
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_convertBoundEndpointToServices(t *testing.T) {
@@ -41,10 +40,8 @@ func Test_convertBoundEndpointToServices(t *testing.T) {
 	}
 
 	boundEndpoint := &bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "abc123", // hashed/unique name
-			Namespace: "ngrok-op",
-		},
+		Name:      "abc123", // hashed/unique name
+		Namespace: "ngrok-op",
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			Scheme: "https",
 			Target: bindingsv1alpha1.EndpointTarget{
@@ -154,10 +151,8 @@ func Test_convertBoundEndpointToServices_HTTP(t *testing.T) {
 	}
 
 	boundEndpoint := &bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-http",
-			Namespace: "ngrok-op",
-		},
+		Name:      "test-http",
+		Namespace: "ngrok-op",
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			Scheme: "http",
 			Target: bindingsv1alpha1.EndpointTarget{
@@ -193,10 +188,8 @@ func Test_convertBoundEndpointToServices_TCP(t *testing.T) {
 	}
 
 	boundEndpoint := &bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-tcp",
-			Namespace: "ngrok-op",
-		},
+		Name:      "test-tcp",
+		Namespace: "ngrok-op",
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			Scheme: "tcp",
 			Target: bindingsv1alpha1.EndpointTarget{

--- a/internal/controller/bindings/boundendpoint_integration_test.go
+++ b/internal/controller/bindings/boundendpoint_integration_test.go
@@ -374,10 +374,8 @@ var _ = Describe("BoundEndpoint Controller", func() {
 	Context("Schema validation", func() {
 		It("should reject a BoundEndpoint without endpointURL", func(ctx SpecContext) {
 			be := &bindingsv1alpha1.BoundEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "missing-endpoint-url",
-					Namespace: pollerController.Namespace,
-				},
+				Name:      "missing-endpoint-url",
+				Namespace: pollerController.Namespace,
 				Spec: bindingsv1alpha1.BoundEndpointSpec{
 					Scheme: "https",
 					Port:   8080,

--- a/internal/controller/bindings/boundendpoint_poller.go
+++ b/internal/controller/bindings/boundendpoint_poller.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -394,14 +393,10 @@ func (r *BoundEndpointPoller) createBinding(ctx context.Context, desired binding
 	}
 
 	toCreate := &bindingsv1alpha1.BoundEndpoint{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "bindings.ngrok.com/v1alpha1",
-			Kind:       "BoundEndpoint",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: r.Namespace,
-		},
+		APIVersion: "bindings.ngrok.com/v1alpha1",
+		Kind:       "BoundEndpoint",
+		Name:       name,
+		Namespace:  r.Namespace,
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			EndpointURL: desired.Spec.EndpointURL,
 			Scheme:      desired.Spec.Scheme,

--- a/internal/controller/bindings/boundendpoint_poller_test.go
+++ b/internal/controller/bindings/boundendpoint_poller_test.go
@@ -6,11 +6,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v7"
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Test_BoundEndpointPoller_Start_InitializesPortAllocator mirrors how the poller
@@ -42,9 +40,7 @@ func Test_BoundEndpointPoller_filterBoundEndpointActions(t *testing.T) {
 	// some example BoundEndpoints we can use for test cases
 	uriExample1 := "http://service1.namespace1:8080"
 	epdExample1 := bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: hashURL(uriExample1),
-		},
+		Name: hashURL(uriExample1),
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			EndpointURL: uriExample1,
 		},
@@ -52,9 +48,7 @@ func Test_BoundEndpointPoller_filterBoundEndpointActions(t *testing.T) {
 
 	uriExample2 := "https://service2.namespace2:443"
 	epdExample2 := bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: hashURL(uriExample2),
-		},
+		Name: hashURL(uriExample2),
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			EndpointURL: uriExample2,
 		},
@@ -62,20 +56,16 @@ func Test_BoundEndpointPoller_filterBoundEndpointActions(t *testing.T) {
 
 	uriExample3 := "https://service3.namespace3:443"
 	epdExample3 := bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: hashURL(uriExample3),
-		},
+		Name: hashURL(uriExample3),
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			EndpointURL: uriExample3,
 		},
 	}
 
 	epdExample4 := bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			// Name does not match example3 on puprose
-			// to test if re-names trigger delete/create rather than update
-			Name: "abcd1234-abcd-1234-abcd-1234abcd1234",
-		},
+		// Name does not match example3 on puprose
+		// to test if re-names trigger delete/create rather than update
+		Name: "abcd1234-abcd-1234-abcd-1234abcd1234",
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			EndpointURL: uriExample3, // example 3 on purpose, see Name
 		},
@@ -188,9 +178,7 @@ func Test_BoundEndpointPoller_boundEndpointNeedsUpdate(t *testing.T) {
 	// some example BoundEndpoints we can use for test cases
 	uriExample1 := "http://service1.namespace1:8080"
 	epdExample1 := bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: hashURL(uriExample1),
-		},
+		Name: hashURL(uriExample1),
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			EndpointURL: uriExample1,
 			Target: bindingsv1alpha1.EndpointTarget{
@@ -204,16 +192,14 @@ func Test_BoundEndpointPoller_boundEndpointNeedsUpdate(t *testing.T) {
 			HashedName: hashURL(uriExample1),
 			Endpoints: []bindingsv1alpha1.BindingEndpoint{
 				{
-					Ref: ngrok.Ref{ID: "ep_abc123", URI: "example-uri"},
+					ID: "ep_abc123", URI: "example-uri",
 				},
 			},
 		},
 	}
 
 	epdExample1NewMetadata := bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: hashURL(uriExample1),
-		},
+		Name: hashURL(uriExample1),
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			EndpointURL: uriExample1,
 			Target: bindingsv1alpha1.EndpointTarget{
@@ -235,16 +221,14 @@ func Test_BoundEndpointPoller_boundEndpointNeedsUpdate(t *testing.T) {
 			HashedName: hashURL(uriExample1),
 			Endpoints: []bindingsv1alpha1.BindingEndpoint{
 				{
-					Ref: ngrok.Ref{ID: "ep_abc123", URI: "example-uri"},
+					ID: "ep_abc123", URI: "example-uri",
 				},
 			},
 		},
 	}
 
 	epdExample1EmptyMetadata := bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: hashURL(uriExample1),
-		},
+		Name: hashURL(uriExample1),
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			EndpointURL: uriExample1,
 			Target: bindingsv1alpha1.EndpointTarget{
@@ -262,7 +246,7 @@ func Test_BoundEndpointPoller_boundEndpointNeedsUpdate(t *testing.T) {
 			HashedName: hashURL(uriExample1),
 			Endpoints: []bindingsv1alpha1.BindingEndpoint{
 				{
-					Ref: ngrok.Ref{ID: "ep_abc123", URI: "example-uri"},
+					ID: "ep_abc123", URI: "example-uri",
 				},
 			},
 		},
@@ -270,9 +254,7 @@ func Test_BoundEndpointPoller_boundEndpointNeedsUpdate(t *testing.T) {
 
 	uriExample2 := "https://service2.namespace2:443"
 	epdExample2 := bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: hashURL(uriExample2),
-		},
+		Name: hashURL(uriExample2),
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			EndpointURL: uriExample2,
 			Target: bindingsv1alpha1.EndpointTarget{
@@ -286,16 +268,14 @@ func Test_BoundEndpointPoller_boundEndpointNeedsUpdate(t *testing.T) {
 			HashedName: hashURL(uriExample2),
 			Endpoints: []bindingsv1alpha1.BindingEndpoint{
 				{
-					Ref: ngrok.Ref{ID: "ep_def456", URI: "example-uri"},
+					ID: "ep_def456", URI: "example-uri",
 				},
 			},
 		},
 	}
 
 	epdExample2NewStatus := bindingsv1alpha1.BoundEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: hashURL(uriExample2),
-		},
+		Name: hashURL(uriExample2),
 		Spec: bindingsv1alpha1.BoundEndpointSpec{
 			EndpointURL: uriExample2,
 			Target: bindingsv1alpha1.EndpointTarget{
@@ -309,13 +289,13 @@ func Test_BoundEndpointPoller_boundEndpointNeedsUpdate(t *testing.T) {
 			HashedName: hashURL(uriExample2),
 			Endpoints: []bindingsv1alpha1.BindingEndpoint{
 				{
-					Ref: ngrok.Ref{ID: "ep_def456", URI: "example-uri"},
+					ID: "ep_def456", URI: "example-uri",
 				},
 				{
-					Ref: ngrok.Ref{ID: "ep_xyz999", URI: "example-uri"},
+					ID: "ep_xyz999", URI: "example-uri",
 				},
 				{
-					Ref: ngrok.Ref{ID: "ep_www000", URI: "example-uri"},
+					ID: "ep_www000", URI: "example-uri",
 				},
 			},
 		},

--- a/internal/controller/bindings/forwarder_controller_test.go
+++ b/internal/controller/bindings/forwarder_controller_test.go
@@ -17,7 +17,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -74,11 +73,9 @@ func TestLoadTLSCertificate(t *testing.T) {
 	assert.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tls-secret",
-			Namespace: "default",
-		},
-		Type: v1.SecretTypeTLS,
+		Name:      "tls-secret",
+		Namespace: "default",
+		Type:      v1.SecretTypeTLS,
 		Data: map[string][]byte{
 			"tls.crt": certPEM,
 			"tls.key": keyPEM,
@@ -125,12 +122,10 @@ func generateTestTLSMaterial() (certPEM, keyPEM []byte, err error) {
 var _ = Describe("podIdentityFromPod", func() {
 	var (
 		pod *v1.Pod = &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				UID:         "uid123",
-				Name:        "pod1",
-				Namespace:   "default",
-				Annotations: map[string]string{},
-			},
+			UID:         "uid123",
+			Name:        "pod1",
+			Namespace:   "default",
+			Annotations: map[string]string{},
 		}
 	)
 
@@ -172,13 +167,13 @@ var _ = Describe("ForwarderReconciler field indexer integration", func() {
 	It("registers the pod IP field indexer in SetupWithManager and lists pods by IP", func() {
 		// create namespace and pod via mgr client so the manager's cache can observe them
 		ns := &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-namespace-" + utilrand.String(6)},
+			Name: "test-namespace-" + utilrand.String(6),
 		}
 		Expect(k8sManager.GetClient().Create(ctx, ns)).To(Succeed())
 
 		pod := &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-pod-" + utilrand.String(6), Namespace: ns.Name},
-			Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "test-container", Image: "nginx"}}},
+			Name: "test-pod-" + utilrand.String(6), Namespace: ns.Name,
+			Spec: v1.PodSpec{Containers: []v1.Container{{Name: "test-container", Image: "nginx"}}},
 		}
 		Expect(k8sManager.GetClient().Create(ctx, pod)).To(Succeed())
 

--- a/internal/controller/bindings/suite_test.go
+++ b/internal/controller/bindings/suite_test.go
@@ -39,7 +39,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -109,9 +108,7 @@ var _ = BeforeSuite(func() {
 
 	// Create the operator namespace that the poller will use
 	operatorNs := &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "ngrok-op",
-		},
+		Name: "ngrok-op",
 	}
 	err = k8sClient.Create(ctx, operatorNs)
 	Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/gateway/gateway_controller_test.go
+++ b/internal/controller/gateway/gateway_controller_test.go
@@ -387,9 +387,7 @@ var _ = Describe("secretReferencedByGateway", func() {
 		namespace := "test-ns-" + rand.String(5)
 
 		ns := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-			},
+			Name: namespace,
 		}
 		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
@@ -419,11 +417,9 @@ var _ = Describe("secretReferencedByGateway", func() {
 		Expect(k8sClient.Create(ctx, &gw)).To(Succeed())
 
 		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: namespace,
-			},
-			Type: corev1.SecretTypeTLS,
+			Name:      secretName,
+			Namespace: namespace,
+			Type:      corev1.SecretTypeTLS,
 			Data: map[string][]byte{
 				"tls.crt": []byte("cert"),
 				"tls.key": []byte("key"),

--- a/internal/controller/gateway/gatewayclass_controller.go
+++ b/internal/controller/gateway/gatewayclass_controller.go
@@ -194,10 +194,8 @@ func (r *GatewayClassReconciler) findGatewayClassForGateway(_ context.Context, o
 	log.V(1).Info("Enqueueing request for gatewayclass")
 	return []reconcile.Request{
 		{
-			NamespacedName: client.ObjectKey{
-				Namespace: "",
-				Name:      string(gw.Spec.GatewayClassName),
-			},
+			Namespace: "",
+			Name:      string(gw.Spec.GatewayClassName),
 		},
 	}
 }

--- a/internal/controller/gateway/gatewayclass_controller_test.go
+++ b/internal/controller/gateway/gatewayclass_controller_test.go
@@ -30,7 +30,6 @@ import (
 	testutils "github.com/ngrok/ngrok-operator/internal/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -91,10 +90,8 @@ var _ = Describe("GatewayClass controller", func() {
 			// Create a Gateway that references the GatewayClass. This should cause the finalizer to be set.
 			By("creating a new Gateway")
 			gateway := &gatewayv1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-gateway",
-					Namespace: "default",
-				},
+				Name:      "test-gateway",
+				Namespace: "default",
 				Spec: gatewayv1.GatewaySpec{
 					GatewayClassName: gatewayv1.ObjectName(gatewayClass.Name),
 					Listeners: []gatewayv1.Listener{

--- a/internal/controller/gateway/httproute_controller.go
+++ b/internal/controller/gateway/httproute_controller.go
@@ -398,10 +398,8 @@ func (r *HTTPRouteReconciler) findHTTPRouteForGateway(ctx context.Context, o cli
 			}
 
 			requests = append(requests, reconcile.Request{
-				NamespacedName: client.ObjectKey{
-					Namespace: route.Namespace,
-					Name:      route.Name,
-				},
+				Namespace: route.Namespace,
+				Name:      route.Name,
 			})
 			break // Only enqueue the route once per parentRef
 		}

--- a/internal/controller/gateway/httproute_controller_test.go
+++ b/internal/controller/gateway/httproute_controller_test.go
@@ -142,10 +142,8 @@ var _ = Describe("HTTPRoute controller", Ordered, func() {
 				CreateGatewayAndWaitForAcceptance(ctx, gw, timeout, interval)
 
 				route = &gatewayv1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testutils.RandomName("httproute"),
-						Namespace: "default",
-					},
+					Name:      testutils.RandomName("httproute"),
+					Namespace: "default",
 					Spec: gatewayv1.HTTPRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{
 							ParentRefs: []gatewayv1.ParentReference{
@@ -282,10 +280,8 @@ var _ = Describe("HTTPRoute controller", Ordered, func() {
 				Expect(k8sClient.Create(ctx, service)).To(Succeed())
 
 				route = &gatewayv1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testutils.RandomName("httproute"),
-						Namespace: "default",
-					},
+					Name:      testutils.RandomName("httproute"),
+					Namespace: "default",
 					Spec: gatewayv1.HTTPRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{
 							ParentRefs: []gatewayv1.ParentReference{
@@ -341,10 +337,8 @@ var _ = Describe("HTTPRoute controller", Ordered, func() {
 				Expect(k8sClient.Create(ctx, unmanagedGateway)).To(Succeed())
 
 				route = &gatewayv1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testutils.RandomName("httproute"),
-						Namespace: "default",
-					},
+					Name:      testutils.RandomName("httproute"),
+					Namespace: "default",
 					Spec: gatewayv1.HTTPRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{
 							ParentRefs: []gatewayv1.ParentReference{

--- a/internal/controller/gateway/routes_test.go
+++ b/internal/controller/gateway/routes_test.go
@@ -125,10 +125,8 @@ var _ = Describe("routeReferencesNgrokGateway", Ordered, func() {
 
 		BeforeEach(func(ctx SpecContext) {
 			gw = &gatewayv1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testutils.RandomName("gw"),
-					Namespace: "default",
-				},
+				Name:      testutils.RandomName("gw"),
+				Namespace: "default",
 				Spec: gatewayv1.GatewaySpec{
 					GatewayClassName: gatewayv1.ObjectName(unmanagedGatewayClass.Name),
 					Listeners: []gatewayv1.Listener{

--- a/internal/controller/gateway/tcproute_controller_test.go
+++ b/internal/controller/gateway/tcproute_controller_test.go
@@ -30,7 +30,6 @@ import (
 	testutils "github.com/ngrok/ngrok-operator/internal/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -67,10 +66,8 @@ var _ = Describe("TCPRoute controller", Ordered, func() {
 				CreateGatewayAndWaitForAcceptance(ctx, gw, timeout, interval)
 
 				route = &gatewayv1alpha2.TCPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testutils.RandomName("tcproute"),
-						Namespace: "default",
-					},
+					Name:      testutils.RandomName("tcproute"),
+					Namespace: "default",
 					Spec: gatewayv1alpha2.TCPRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{
 							ParentRefs: []gatewayv1.ParentReference{{
@@ -79,10 +76,8 @@ var _ = Describe("TCPRoute controller", Ordered, func() {
 						},
 						Rules: []gatewayv1alpha2.TCPRouteRule{{
 							BackendRefs: []gatewayv1alpha2.BackendRef{{
-								BackendObjectReference: gatewayv1.BackendObjectReference{
-									Name: gatewayv1.ObjectName("example-svc"),
-									Port: ptr.To[int32](8080),
-								},
+								Name: gatewayv1.ObjectName("example-svc"),
+								Port: ptr.To[int32](8080),
 							}},
 						}},
 					},
@@ -143,10 +138,8 @@ var _ = Describe("TCPRoute controller", Ordered, func() {
 				Expect(k8sClient.Create(ctx, unmanagedGateway)).To(Succeed())
 
 				route = &gatewayv1alpha2.TCPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testutils.RandomName("tcproute"),
-						Namespace: "default",
-					},
+					Name:      testutils.RandomName("tcproute"),
+					Namespace: "default",
 					Spec: gatewayv1alpha2.TCPRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{
 							ParentRefs: []gatewayv1.ParentReference{{
@@ -155,10 +148,8 @@ var _ = Describe("TCPRoute controller", Ordered, func() {
 						},
 						Rules: []gatewayv1alpha2.TCPRouteRule{{
 							BackendRefs: []gatewayv1alpha2.BackendRef{{
-								BackendObjectReference: gatewayv1.BackendObjectReference{
-									Name: gatewayv1.ObjectName("example-svc"),
-									Port: ptr.To[int32](8080),
-								},
+								Name: gatewayv1.ObjectName("example-svc"),
+								Port: ptr.To[int32](8080),
 							}},
 						}},
 					},

--- a/internal/controller/gateway/tlsroute_controller_test.go
+++ b/internal/controller/gateway/tlsroute_controller_test.go
@@ -30,7 +30,6 @@ import (
 	testutils "github.com/ngrok/ngrok-operator/internal/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -67,10 +66,8 @@ var _ = Describe("TLSRoute controller", Ordered, func() {
 				CreateGatewayAndWaitForAcceptance(ctx, gw, timeout, interval)
 
 				route = &gatewayv1alpha2.TLSRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testutils.RandomName("tlsroute"),
-						Namespace: "default",
-					},
+					Name:      testutils.RandomName("tlsroute"),
+					Namespace: "default",
 					Spec: gatewayv1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{
 							ParentRefs: []gatewayv1.ParentReference{{
@@ -79,10 +76,8 @@ var _ = Describe("TLSRoute controller", Ordered, func() {
 						},
 						Rules: []gatewayv1alpha2.TLSRouteRule{{
 							BackendRefs: []gatewayv1alpha2.BackendRef{{
-								BackendObjectReference: gatewayv1.BackendObjectReference{
-									Name: gatewayv1.ObjectName("example-svc"),
-									Port: ptr.To[int32](8080),
-								},
+								Name: gatewayv1.ObjectName("example-svc"),
+								Port: ptr.To[int32](8080),
 							}},
 						}},
 					},
@@ -143,10 +138,8 @@ var _ = Describe("TLSRoute controller", Ordered, func() {
 				Expect(k8sClient.Create(ctx, unmanagedGateway)).To(Succeed())
 
 				route = &gatewayv1alpha2.TLSRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testutils.RandomName("tlsroute"),
-						Namespace: "default",
-					},
+					Name:      testutils.RandomName("tlsroute"),
+					Namespace: "default",
 					Spec: gatewayv1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{
 							ParentRefs: []gatewayv1.ParentReference{{
@@ -155,10 +148,8 @@ var _ = Describe("TLSRoute controller", Ordered, func() {
 						},
 						Rules: []gatewayv1alpha2.TLSRouteRule{{
 							BackendRefs: []gatewayv1alpha2.BackendRef{{
-								BackendObjectReference: gatewayv1.BackendObjectReference{
-									Name: gatewayv1.ObjectName("example-svc"),
-									Port: ptr.To[int32](8080),
-								},
+								Name: gatewayv1.ObjectName("example-svc"),
+								Port: ptr.To[int32](8080),
 							}},
 						}},
 					},

--- a/internal/controller/ingress/domain_conditions_test.go
+++ b/internal/controller/ingress/domain_conditions_test.go
@@ -16,10 +16,8 @@ import (
 // Helper function to create a test domain
 func createTestDomain(name, domainName, id string) *ingressv1alpha1.Domain {
 	return &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Generation: 1,
-		},
+		Name:       name,
+		Generation: 1,
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: domainName,
 		},

--- a/internal/controller/ingress/domain_controller.go
+++ b/internal/controller/ingress/domain_controller.go
@@ -152,7 +152,7 @@ func (r *DomainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Requeue if the domain is not ready
 	if !IsDomainReady(domain) {
 		// Requeue the event relying on the controllers custom RateLimiter for exponential backoff
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{Requeue: true}, nil //nolint:staticcheck
 	}
 
 	return result, nil

--- a/internal/controller/ingress/domain_controller_test.go
+++ b/internal/controller/ingress/domain_controller_test.go
@@ -72,10 +72,8 @@ var _ = Describe("DomainReconciler", func() {
 
 		JustBeforeEach(func() {
 			domain = &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-domain",
-					Namespace: namespace,
-				},
+				Name:      "test-domain",
+				Namespace: namespace,
 				Spec: ingressv1alpha1.DomainSpec{
 					Domain: domainName,
 				},
@@ -222,10 +220,8 @@ var _ = Describe("DomainReconciler", func() {
 		When("the domain creation succeeds", func() {
 			It("should set success conditions and create the domain", func() {
 				domain := &ingressv1alpha1.Domain{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("test-domain-%s", rand.String(10)),
-						Namespace: namespace,
-					},
+					Name:      fmt.Sprintf("test-domain-%s", rand.String(10)),
+					Namespace: namespace,
 					Spec: ingressv1alpha1.DomainSpec{
 						Domain: fmt.Sprintf("test-domain-%s.%s", rand.String(10), NgrokManagedDomainSuffix),
 					},
@@ -268,10 +264,8 @@ var _ = Describe("DomainReconciler", func() {
 
 			It("should set error conditions and not create the domain", func() {
 				domain := &ingressv1alpha1.Domain{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("test-domain-%s", rand.String(10)),
-						Namespace: namespace,
-					},
+					Name:      fmt.Sprintf("test-domain-%s", rand.String(10)),
+					Namespace: namespace,
 					Spec: ingressv1alpha1.DomainSpec{
 						Domain: fmt.Sprintf("test-domain-%s.%s", rand.String(10), NgrokManagedDomainSuffix),
 					},
@@ -311,10 +305,8 @@ var _ = Describe("DomainReconciler", func() {
 				Namespace: namespace,
 			}
 			domain = &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-				},
+				Name:      name,
+				Namespace: namespace,
 				Spec: ingressv1alpha1.DomainSpec{
 					Description: "starting description",
 					Metadata:    commonv1alpha1.MetadataFromLegacyString("starting metadata"),
@@ -566,10 +558,8 @@ var _ = Describe("DomainReconciler", func() {
 		JustBeforeEach(func() {
 			By("Creating the domain")
 			domain = &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-domain",
-					Namespace: namespace,
-				},
+				Name:      "test-domain",
+				Namespace: namespace,
 				Spec: ingressv1alpha1.DomainSpec{
 					ReclaimPolicy: reclaimPolicy,
 					Domain:        fmt.Sprintf("test-domain-%s.%s", rand.String(10), NgrokManagedDomainSuffix),
@@ -685,10 +675,8 @@ var _ = Describe("DomainReconciler", func() {
 				Namespace: namespace,
 			}
 			domain = &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-				},
+				Name:      name,
+				Namespace: namespace,
 				Spec: ingressv1alpha1.DomainSpec{
 					Domain: domainName,
 				},
@@ -760,10 +748,8 @@ var _ = Describe("DomainReconciler", func() {
 				Namespace: namespace,
 			}
 			domain = &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-				},
+				Name:      name,
+				Namespace: namespace,
 				Spec: ingressv1alpha1.DomainSpec{
 					Domain: domainName,
 				},
@@ -812,10 +798,8 @@ var _ = Describe("DomainReconciler", func() {
 	Describe("Internal Domain Handling", func() {
 		It("should skip reconciliation and not reserve .internal TLD domains in ngrok", func() {
 			domain := &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-internal-domain-%s", rand.String(10)),
-					Namespace: namespace,
-				},
+				Name:      fmt.Sprintf("test-internal-domain-%s", rand.String(10)),
+				Namespace: namespace,
 				Spec: ingressv1alpha1.DomainSpec{
 					Domain: "my-service.namespace.internal",
 				},
@@ -855,10 +839,8 @@ var _ = Describe("DomainReconciler", func() {
 
 		It("should remove finalizer from .INTERNAL TLD domains allowing clean deletion", func() {
 			domain := &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-internal-upper-%s", rand.String(10)),
-					Namespace: namespace,
-				},
+				Name:      fmt.Sprintf("test-internal-upper-%s", rand.String(10)),
+				Namespace: namespace,
 				Spec: ingressv1alpha1.DomainSpec{
 					Domain: "my-service.namespace.INTERNAL",
 				},
@@ -888,10 +870,8 @@ var _ = Describe("DomainReconciler", func() {
 		It("should NOT delete domains that contain 'internal' as a subdomain", func() {
 			// This is NOT an internal domain - it just has "internal" as a subdomain
 			domain := &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-not-internal-%s", rand.String(10)),
-					Namespace: namespace,
-				},
+				Name:      fmt.Sprintf("test-not-internal-%s", rand.String(10)),
+				Namespace: namespace,
 				Spec: ingressv1alpha1.DomainSpec{
 					Domain: fmt.Sprintf("service.internal.%s", CustomDomainSuffix),
 				},
@@ -937,10 +917,8 @@ var _ = Describe("DomainReconciler", func() {
 				Namespace: namespace,
 			}
 			domain = &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-				},
+				Name:      name,
+				Namespace: namespace,
 				Spec: ingressv1alpha1.DomainSpec{
 					Domain: "ngrok.com", // This should fail to create
 				},

--- a/internal/controller/ingress/ippolicy_conditions_test.go
+++ b/internal/controller/ingress/ippolicy_conditions_test.go
@@ -13,10 +13,8 @@ import (
 // Tests that ipPolicy condition ready is set correctly
 func TestSetIPPolicyReadyCondition(t *testing.T) {
 	ipPolicy := &ingressv1alpha1.IPPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-ip-policy",
-			Generation: 1,
-		},
+		Name:       "test-ip-policy",
+		Generation: 1,
 	}
 
 	setIPPolicyReadyCondition(ipPolicy, true, ReasonIPPolicyActive, "IP Policy is active")
@@ -45,10 +43,8 @@ func TestSetIPPolicyReadyCondition(t *testing.T) {
 // Tests that ipPolicy condition created is set correctly
 func TestSetIPPolicyCreatedCondition(t *testing.T) {
 	ipPolicy := &ingressv1alpha1.IPPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-ip-policy",
-			Generation: 1,
-		},
+		Name:       "test-ip-policy",
+		Generation: 1,
 	}
 
 	setIPPolicyCreatedCondition(ipPolicy, true, ReasonIPPolicyCreated, "IP Policy has been created")
@@ -77,10 +73,8 @@ func TestSetIPPolicyCreatedCondition(t *testing.T) {
 // Tests that ipPolicy condition rules configured is set correctly
 func TestSetIPPolicyRulesConfiguredCondition(t *testing.T) {
 	ipPolicy := &ingressv1alpha1.IPPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-ip-policy",
-			Generation: 1,
-		},
+		Name:       "test-ip-policy",
+		Generation: 1,
 	}
 
 	setIPPolicyRulesConfiguredCondition(ipPolicy, true, ReasonIPPolicyRulesConfigured, "IP Policy rules have been configured")
@@ -110,10 +104,8 @@ func TestSetIPPolicyRulesConfiguredCondition(t *testing.T) {
 // renamed IPPolicyRulesConfigured condition is set
 func TestSetIPPolicyRulesConfiguredCondition_ClearsLegacyCondition(t *testing.T) {
 	ipPolicy := &ingressv1alpha1.IPPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-ip-policy",
-			Generation: 1,
-		},
+		Name:       "test-ip-policy",
+		Generation: 1,
 		Status: ingressv1alpha1.IPPolicyStatus{
 			Conditions: []metav1.Condition{
 				{

--- a/internal/controller/ingress/ippolicy_controllers_test.go
+++ b/internal/controller/ingress/ippolicy_controllers_test.go
@@ -34,7 +34,7 @@ var _ = Describe("IPPolicyReconciler", func() {
 
 	It("creates IPPolicy and configures rules", func() {
 		ip := &ingressv1alpha1.IPPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-ip-policy", Namespace: "default"},
+			Name: "test-ip-policy", Namespace: "default",
 			Spec: ingressv1alpha1.IPPolicySpec{
 				Metadata: commonv1alpha1.MetadataFromLegacyString("test"),
 			},
@@ -58,7 +58,7 @@ var _ = Describe("IPPolicyReconciler", func() {
 
 	It("updates existing rule descriptions", func() {
 		ip := &ingressv1alpha1.IPPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-ip-policy-update", Namespace: "default"},
+			Name: "test-ip-policy-update", Namespace: "default",
 			Spec: ingressv1alpha1.IPPolicySpec{
 				Metadata: commonv1alpha1.MetadataFromLegacyString("test"),
 			},
@@ -94,7 +94,7 @@ var _ = Describe("IPPolicyReconciler", func() {
 
 	It("deletes obsolete rules", func() {
 		ip := &ingressv1alpha1.IPPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-ip-policy-del", Namespace: "default"},
+			Name: "test-ip-policy-del", Namespace: "default",
 			Spec: ingressv1alpha1.IPPolicySpec{
 				Metadata: commonv1alpha1.MetadataFromLegacyString("test"),
 			},
@@ -132,7 +132,7 @@ var _ = Describe("IPPolicyReconciler", func() {
 	It("sets Created condition for existing IP Policy", func() {
 		By("creating an IP Policy")
 		ip := &ingressv1alpha1.IPPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-existing-policy", Namespace: "default"},
+			Name: "test-existing-policy", Namespace: "default",
 			Spec: ingressv1alpha1.IPPolicySpec{
 				Metadata: commonv1alpha1.MetadataFromLegacyString("test"),
 			},
@@ -175,7 +175,7 @@ var _ = Describe("IPPolicyReconciler", func() {
 	It("sets Created condition for existing IP Policy with rules", func() {
 		By("creating an IPPolicy resource with rules")
 		ip := &ingressv1alpha1.IPPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-existing-policy-rules", Namespace: "default"},
+			Name: "test-existing-policy-rules", Namespace: "default",
 			Spec: ingressv1alpha1.IPPolicySpec{
 				Metadata: commonv1alpha1.MetadataFromLegacyString("test"),
 			},
@@ -280,7 +280,7 @@ var _ = Describe("IPPolicyDiff", func() {
 var _ = Describe("IPPolicy schema validation", func() {
 	newPolicy := func(name, cidr string) *ingressv1alpha1.IPPolicy {
 		return &ingressv1alpha1.IPPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Name: name, Namespace: "default",
 			Spec: ingressv1alpha1.IPPolicySpec{
 				Rules: []ingressv1alpha1.IPPolicyRule{{CIDR: cidr, Action: "allow"}},
 			},

--- a/internal/controller/labels/controller_test.go
+++ b/internal/controller/labels/controller_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -59,11 +58,9 @@ func TestHasControllerLabels(t *testing.T) {
 		{
 			name: "object has matching labels",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerNamespace: "ngrok-operator",
-						ControllerName:      "my-controller",
-					},
+				Labels: map[string]string{
+					ControllerNamespace: "ngrok-operator",
+					ControllerName:      "my-controller",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -73,9 +70,7 @@ func TestHasControllerLabels(t *testing.T) {
 		{
 			name: "object has nil labels",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: nil,
-				},
+				Labels: nil,
 			},
 			controllerNamespace: "ngrok-operator",
 			controllerName:      "my-controller",
@@ -84,11 +79,9 @@ func TestHasControllerLabels(t *testing.T) {
 		{
 			name: "object has wrong namespace label",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerNamespace: "other-namespace",
-						ControllerName:      "my-controller",
-					},
+				Labels: map[string]string{
+					ControllerNamespace: "other-namespace",
+					ControllerName:      "my-controller",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -98,11 +91,9 @@ func TestHasControllerLabels(t *testing.T) {
 		{
 			name: "object has wrong name label",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerNamespace: "ngrok-operator",
-						ControllerName:      "other-controller",
-					},
+				Labels: map[string]string{
+					ControllerNamespace: "ngrok-operator",
+					ControllerName:      "other-controller",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -112,10 +103,8 @@ func TestHasControllerLabels(t *testing.T) {
 		{
 			name: "object missing namespace label",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerName: "my-controller",
-					},
+				Labels: map[string]string{
+					ControllerName: "my-controller",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -125,10 +114,8 @@ func TestHasControllerLabels(t *testing.T) {
 		{
 			name: "object missing name label",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerNamespace: "ngrok-operator",
-					},
+				Labels: map[string]string{
+					ControllerNamespace: "ngrok-operator",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -138,12 +125,10 @@ func TestHasControllerLabels(t *testing.T) {
 		{
 			name: "object has matching labels with additional labels",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerNamespace: "ngrok-operator",
-						ControllerName:      "my-controller",
-						"app":               "my-app",
-					},
+				Labels: map[string]string{
+					ControllerNamespace: "ngrok-operator",
+					ControllerName:      "my-controller",
+					"app":               "my-app",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -172,9 +157,7 @@ func TestEnsureControllerLabels(t *testing.T) {
 		{
 			name: "adds labels to object with nil labels (dual-write)",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: nil,
-				},
+				Labels: nil,
 			},
 			controllerNamespace: "ngrok-operator",
 			controllerName:      "my-controller",
@@ -189,9 +172,7 @@ func TestEnsureControllerLabels(t *testing.T) {
 		{
 			name: "adds labels to object with empty labels (dual-write)",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{},
-				},
+				Labels: map[string]string{},
 			},
 			controllerNamespace: "ngrok-operator",
 			controllerName:      "my-controller",
@@ -206,10 +187,8 @@ func TestEnsureControllerLabels(t *testing.T) {
 		{
 			name: "preserves existing labels and adds controller labels (dual-write)",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app": "my-app",
-					},
+				Labels: map[string]string{
+					"app": "my-app",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -226,13 +205,11 @@ func TestEnsureControllerLabels(t *testing.T) {
 		{
 			name: "returns false when both new and legacy labels already match",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerNamespace:       "ngrok-operator",
-						ControllerName:            "my-controller",
-						LegacyControllerNamespace: "ngrok-operator",
-						LegacyControllerName:      "my-controller",
-					},
+				Labels: map[string]string{
+					ControllerNamespace:       "ngrok-operator",
+					ControllerName:            "my-controller",
+					LegacyControllerNamespace: "ngrok-operator",
+					LegacyControllerName:      "my-controller",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -248,11 +225,9 @@ func TestEnsureControllerLabels(t *testing.T) {
 		{
 			name: "ensure-sets legacy pair when only new pair is present",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerNamespace: "ngrok-operator",
-						ControllerName:      "my-controller",
-					},
+				Labels: map[string]string{
+					ControllerNamespace: "ngrok-operator",
+					ControllerName:      "my-controller",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -268,12 +243,10 @@ func TestEnsureControllerLabels(t *testing.T) {
 		{
 			name: "ensure-sets new pair when only legacy pair is present (R1 keeps legacy)",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						LegacyControllerNamespace: "ngrok-operator",
-						LegacyControllerName:      "my-controller",
-						"app":                     "my-app",
-					},
+				Labels: map[string]string{
+					LegacyControllerNamespace: "ngrok-operator",
+					LegacyControllerName:      "my-controller",
+					"app":                     "my-app",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -290,13 +263,11 @@ func TestEnsureControllerLabels(t *testing.T) {
 		{
 			name: "updates namespace label when different",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerNamespace:       "old-namespace",
-						ControllerName:            "my-controller",
-						LegacyControllerNamespace: "old-namespace",
-						LegacyControllerName:      "my-controller",
-					},
+				Labels: map[string]string{
+					ControllerNamespace:       "old-namespace",
+					ControllerName:            "my-controller",
+					LegacyControllerNamespace: "old-namespace",
+					LegacyControllerName:      "my-controller",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -312,13 +283,11 @@ func TestEnsureControllerLabels(t *testing.T) {
 		{
 			name: "updates name label when different",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerNamespace:       "ngrok-operator",
-						ControllerName:            "old-controller",
-						LegacyControllerNamespace: "ngrok-operator",
-						LegacyControllerName:      "old-controller",
-					},
+				Labels: map[string]string{
+					ControllerNamespace:       "ngrok-operator",
+					ControllerName:            "old-controller",
+					LegacyControllerNamespace: "ngrok-operator",
+					LegacyControllerName:      "old-controller",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -334,11 +303,9 @@ func TestEnsureControllerLabels(t *testing.T) {
 		{
 			name: "adds missing namespace label",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerName:       "my-controller",
-						LegacyControllerName: "my-controller",
-					},
+				Labels: map[string]string{
+					ControllerName:       "my-controller",
+					LegacyControllerName: "my-controller",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -354,11 +321,9 @@ func TestEnsureControllerLabels(t *testing.T) {
 		{
 			name: "adds missing name label",
 			obj: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						ControllerNamespace:       "ngrok-operator",
-						LegacyControllerNamespace: "ngrok-operator",
-					},
+				Labels: map[string]string{
+					ControllerNamespace:       "ngrok-operator",
+					LegacyControllerNamespace: "ngrok-operator",
 				},
 			},
 			controllerNamespace: "ngrok-operator",
@@ -440,19 +405,15 @@ func TestControllerLabelValues(t *testing.T) {
 		clv := ControllerLabelValues{Namespace: "ngrok-operator", Name: "my-controller"}
 
 		objWithLabels := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					ControllerNamespace: "ngrok-operator",
-					ControllerName:      "my-controller",
-				},
+			Labels: map[string]string{
+				ControllerNamespace: "ngrok-operator",
+				ControllerName:      "my-controller",
 			},
 		}
 		assert.True(t, clv.HasLabels(objWithLabels))
 
 		objWithoutLabels := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: nil,
-			},
+			Labels: nil,
 		}
 		assert.False(t, clv.HasLabels(objWithoutLabels))
 	})
@@ -461,9 +422,7 @@ func TestControllerLabelValues(t *testing.T) {
 		clv := ControllerLabelValues{Namespace: "ngrok-operator", Name: "my-controller"}
 
 		obj := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: nil,
-			},
+			Labels: nil,
 		}
 		modified := clv.EnsureLabels(obj)
 		assert.True(t, modified)
@@ -491,26 +450,26 @@ func TestControllerLabelValues(t *testing.T) {
 
 func TestHasControllerLabels_DualPrefix(t *testing.T) {
 	t.Run("matches legacy prefix", func(t *testing.T) {
-		obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+		obj := &corev1.ConfigMap{Labels: map[string]string{
 			LegacyControllerNamespace: "ngrok-operator",
 			LegacyControllerName:      "my-controller",
-		}}}
+		}}
 		assert.True(t, HasControllerLabels(obj, "ngrok-operator", "my-controller"))
 	})
 
 	t.Run("matches new prefix", func(t *testing.T) {
-		obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+		obj := &corev1.ConfigMap{Labels: map[string]string{
 			ControllerNamespace: "ngrok-operator",
 			ControllerName:      "my-controller",
-		}}}
+		}}
 		assert.True(t, HasControllerLabels(obj, "ngrok-operator", "my-controller"))
 	})
 
 	t.Run("no match when both partial", func(t *testing.T) {
-		obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+		obj := &corev1.ConfigMap{Labels: map[string]string{
 			ControllerNamespace:  "ngrok-operator",
 			LegacyControllerName: "my-controller",
-		}}}
+		}}
 		assert.False(t, HasControllerLabels(obj, "ngrok-operator", "my-controller"),
 			"requires a full pair on one prefix; partials must not cross-match")
 	})
@@ -519,11 +478,11 @@ func TestHasControllerLabels_DualPrefix(t *testing.T) {
 func TestEnsureControllerLabels_R1KeepsLegacy(t *testing.T) {
 	// R1 dual-writes: an object that arrives with only the legacy pair must
 	// be promoted to having both pairs, not have the legacy pair removed.
-	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+	obj := &corev1.ConfigMap{Labels: map[string]string{
 		LegacyControllerNamespace: "ngrok-operator",
 		LegacyControllerName:      "my-controller",
 		"app":                     "my-app",
-	}}}
+	}}
 
 	modified := EnsureControllerLabels(obj, "ngrok-operator", "my-controller")
 	assert.True(t, modified)

--- a/internal/controller/ngrok/cloudendpoint_conditions_test.go
+++ b/internal/controller/ngrok/cloudendpoint_conditions_test.go
@@ -14,11 +14,9 @@ import (
 // Helper function to create a test CloudEndpoint
 func createTestCloudEndpoint(name, namespace string) *ngrokv1alpha1.CloudEndpoint {
 	return &ngrokv1alpha1.CloudEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  namespace,
-			Generation: 1,
-		},
+		Name:       name,
+		Namespace:  namespace,
+		Generation: 1,
 		Status: ngrokv1alpha1.CloudEndpointStatus{
 			Conditions: []metav1.Condition{},
 		},

--- a/internal/controller/ngrok/cloudendpoint_controller.go
+++ b/internal/controller/ngrok/cloudendpoint_controller.go
@@ -498,7 +498,7 @@ func (r *CloudEndpointReconciler) findCloudEndpointForTrafficPolicy(ctx context.
 
 	requests := make([]ctrl.Request, 0, len(list.Items))
 	for _, clep := range list.Items {
-		requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKey{Name: clep.Name, Namespace: clep.Namespace}})
+		requests = append(requests, ctrl.Request{Name: clep.Name, Namespace: clep.Namespace})
 	}
 	return requests
 }

--- a/internal/controller/ngrok/cloudendpoint_controller_test.go
+++ b/internal/controller/ngrok/cloudendpoint_controller_test.go
@@ -60,9 +60,7 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		// Create namespace for testing
 		ns := &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-			},
+			Name: namespace,
 		}
 		Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
 
@@ -74,9 +72,7 @@ var _ = Describe("CloudEndpoint Controller", func() {
 		// Clean up namespace
 		if namespace != "" {
 			ns := &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: namespace,
-				},
+				Name: namespace,
 			}
 			_ = k8sClient.Delete(context.Background(), ns)
 		}
@@ -85,10 +81,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 	Context("Basic endpoint operations", func() {
 		It("should successfully create a cloud endpoint with internal domain", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "test-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:         "https://test.internal",
 					Description: "Test endpoint",
@@ -117,10 +111,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		It("should successfully create a cloud endpoint with TCP URL", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcp-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "tcp-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:         "tcp://1.tcp.ngrok.io:12345",
 					Description: "TCP test endpoint",
@@ -157,10 +149,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		It("should not create domain CR for custom TCP endpoint", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcp-custom-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "tcp-custom-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:         "tcp://1.2.3.4:25565",
 					Description: "Custom TCP test endpoint",
@@ -196,10 +186,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 		It("R1: legacy spec.trafficPolicyName-only manifest resolves via in-memory normalization", func(ctx SpecContext) {
 			// Create traffic policy first
 			trafficPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-policy",
-					Namespace: namespace,
-				},
+				Name:      "test-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"on_http_request":[{"name":"rate-limit"}]}`),
 				},
@@ -207,15 +195,13 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, trafficPolicy)).To(Succeed())
 
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "policy-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "policy-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:               "https://policy-test.internal",
 					Description:       "Endpoint with policy",
 					Metadata:          commonv1alpha1.MetadataFromLegacyString("{}"),
-					TrafficPolicyName: "test-policy",
+					TrafficPolicyName: "test-policy", //nolint:staticcheck // SA1019: exercises the deprecated field's migration path
 				},
 			}
 
@@ -234,10 +220,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		It("should handle endpoint with trafficPolicy.targetRef", func(ctx SpecContext) {
 			trafficPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "new-shape-policy",
-					Namespace: namespace,
-				},
+				Name:      "new-shape-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"on_http_request":[{"name":"rate-limit"}]}`),
 				},
@@ -245,10 +229,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, trafficPolicy)).To(Succeed())
 
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "new-shape-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "new-shape-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL: "https://new-shape.internal",
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
@@ -278,14 +260,12 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			// the deprecated `policy` field is set, the resolver still
 			// produces the policy JSON. Cleanup release removes this test.
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "legacy-policy-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "legacy-policy-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL: "https://legacy-policy.internal",
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
-						Policy: json.RawMessage(`{"on_http_request":[{"name":"legacy"}]}`),
+						Policy: json.RawMessage(`{"on_http_request":[{"name":"legacy"}]}`), //nolint:staticcheck // SA1019: exercises the deprecated field's migration path
 					},
 				},
 			}
@@ -306,10 +286,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		It("should handle endpoint deletion", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "delete-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "delete-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:         fmt.Sprintf("https://delete-%s.internal", rand.String(8)),
 					Description: "Endpoint to delete",
@@ -349,10 +327,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			mockClientset.Endpoints().(*nmockapi.EndpointsClient).SetCreateError(errors.New("API error"))
 
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "error-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "error-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:         "https://error.internal",
 					Description: "Error endpoint",
@@ -393,10 +369,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			// migration guide recommends keeping `trafficPolicyName`
 			// alone until the rollback floor moves past 0.24.
 			canonicalPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "canonical-policy",
-					Namespace: namespace,
-				},
+				Name:      "canonical-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"on_http_request":[{"name":"canonical"}]}`),
 				},
@@ -404,15 +378,13 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, canonicalPolicy)).To(Succeed())
 
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "both-fields-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "both-fields-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:               "https://both-fields.internal",
 					Description:       "Both legacy and canonical fields set",
 					Metadata:          commonv1alpha1.MetadataFromLegacyString("{}"),
-					TrafficPolicyName: "ignored-legacy-name",
+					TrafficPolicyName: "ignored-legacy-name", //nolint:staticcheck // SA1019: exercises the deprecated field's migration path
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
 						Reference: &ngrokv1alpha1.K8sObjectRef{Name: "canonical-policy"},
 					},
@@ -446,10 +418,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			// coexist with either canonical field during R1; only the
 			// inline+targetRef union is rejected.
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid-tp-union-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "invalid-tp-union-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL: "https://invalid-tp-union.internal",
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
@@ -469,15 +439,13 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			// the deprecated nested `policy` field for rollback while
 			// the R1+ operator uses the new `inline` field.
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "policy-and-inline-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "policy-and-inline-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL: "https://policy-and-inline.internal",
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
 						Inline: json.RawMessage(`{"on_http_request":[{"name":"canonical-inline"}]}`),
-						Policy: json.RawMessage(`{"on_http_request":[{"name":"legacy-policy"}]}`),
+						Policy: json.RawMessage(`{"on_http_request":[{"name":"legacy-policy"}]}`), //nolint:staticcheck // SA1019: exercises the deprecated field's migration path
 					},
 				},
 			}
@@ -504,16 +472,16 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			// `trafficPolicy: {}` silently detach a policy that the user
 			// declared via the legacy `trafficPolicyName` field.
 			legacyPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: "fallback-legacy", Namespace: namespace},
-				Spec:       ngrokv1alpha1.NgrokTrafficPolicySpec{Policy: []byte(`{"on_http_request":[{"name":"fallback-rule"}]}`)},
+				Name: "fallback-legacy", Namespace: namespace,
+				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{Policy: []byte(`{"on_http_request":[{"name":"fallback-rule"}]}`)},
 			}
 			Expect(k8sClient.Create(ctx, legacyPolicy)).To(Succeed())
 
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "fallback-endpoint", Namespace: namespace},
+				Name: "fallback-endpoint", Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:               "https://fallback.internal",
-					TrafficPolicyName: "fallback-legacy",
+					TrafficPolicyName: "fallback-legacy", //nolint:staticcheck // SA1019: exercises the deprecated field's migration path
 					// Empty struct mimics a templating system emitting `{}`.
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{},
 				},
@@ -544,22 +512,22 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			// (still keeping the legacy for rollback). The attached
 			// policy must reflect the canonical field after the update.
 			legacyPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: "transition-legacy", Namespace: namespace},
-				Spec:       ngrokv1alpha1.NgrokTrafficPolicySpec{Policy: []byte(`{"on_http_request":[{"name":"from-legacy"}]}`)},
+				Name: "transition-legacy", Namespace: namespace,
+				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{Policy: []byte(`{"on_http_request":[{"name":"from-legacy"}]}`)},
 			}
 			Expect(k8sClient.Create(ctx, legacyPolicy)).To(Succeed())
 
 			canonicalPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: "transition-canonical", Namespace: namespace},
-				Spec:       ngrokv1alpha1.NgrokTrafficPolicySpec{Policy: []byte(`{"on_http_request":[{"name":"from-canonical"}]}`)},
+				Name: "transition-canonical", Namespace: namespace,
+				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{Policy: []byte(`{"on_http_request":[{"name":"from-canonical"}]}`)},
 			}
 			Expect(k8sClient.Create(ctx, canonicalPolicy)).To(Succeed())
 
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "transition-endpoint", Namespace: namespace},
+				Name: "transition-endpoint", Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:               "https://transition.internal",
-					TrafficPolicyName: "transition-legacy",
+					TrafficPolicyName: "transition-legacy", //nolint:staticcheck // SA1019: exercises the deprecated field's migration path
 				},
 			}
 
@@ -603,10 +571,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 	Context("Metadata format", func() {
 		It("should serialize map-form metadata to a sorted JSON object string for the ngrok API", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "metadata-map-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "metadata-map-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:      "https://metadata-map.internal",
 					Metadata: commonv1alpha1.MetadataFromMap(map[string]string{"team": "platform", "owned-by": "ngrok-operator"}),
@@ -632,10 +598,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 		// once the raw JSON string form is no longer accepted.
 		It("should pass legacy string-form metadata through to the ngrok API verbatim", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "metadata-legacy-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "metadata-legacy-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:      "https://metadata-legacy.internal",
 					Metadata: commonv1alpha1.MetadataFromLegacyString(`{"owned-by":"ngrok-operator"}`),
@@ -662,10 +626,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 	Context("Endpoint updates", func() {
 		It("should successfully update endpoint description and metadata", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "update-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "update-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:         "https://update-test.internal",
 					Description: "Original description",
@@ -708,10 +670,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 		It("should successfully update traffic policy", func(ctx SpecContext) {
 			// Create initial traffic policy
 			trafficPolicy1 := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "policy-v1",
-					Namespace: namespace,
-				},
+				Name:      "policy-v1",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"on_http_request":[{"name":"log"}]}`),
 				},
@@ -719,15 +679,13 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, trafficPolicy1)).To(Succeed())
 
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "policy-update-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "policy-update-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:               "https://policy-update.internal",
 					Description:       "Endpoint with updatable policy",
 					Metadata:          commonv1alpha1.MetadataFromLegacyString("{}"),
-					TrafficPolicyName: "policy-v1",
+					TrafficPolicyName: "policy-v1", //nolint:staticcheck // SA1019: exercises the deprecated field's migration path
 				},
 			}
 
@@ -745,10 +703,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 			By("Creating new traffic policy")
 			trafficPolicy2 := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "policy-v2",
-					Namespace: namespace,
-				},
+				Name:      "policy-v2",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"on_http_request":[{"name":"rate-limit"}]}`),
 				},
@@ -774,10 +730,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		It("should recreate endpoint when update returns 404", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "recreate-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "recreate-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:         "https://recreate-test.internal",
 					Description: "Endpoint to recreate",
@@ -836,10 +790,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			// once in update(), so the recreated endpoint must still carry
 			// the correct policy content.
 			trafficPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "recreate-legacy-policy",
-					Namespace: namespace,
-				},
+				Name:      "recreate-legacy-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"on_http_request":[{"name":"recreate-legacy"}]}`),
 				},
@@ -847,13 +799,11 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			Expect(k8sClient.Create(ctx, trafficPolicy)).To(Succeed())
 
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "recreate-legacy-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "recreate-legacy-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:               "https://recreate-legacy.internal",
-					TrafficPolicyName: "recreate-legacy-policy",
+					TrafficPolicyName: "recreate-legacy-policy", //nolint:staticcheck // SA1019: exercises the deprecated field's migration path
 				},
 			}
 
@@ -912,10 +862,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		It("should update URL successfully", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "url-update-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "url-update-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:         "https://original-url.internal",
 					Description: "Endpoint with updatable URL",
@@ -954,10 +902,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		It("should handle update errors gracefully", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "update-error-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "update-error-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:         "https://update-error.internal",
 					Description: "Endpoint for error testing",
@@ -1006,10 +952,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 	Context("Domain handling", func() {
 		It("should skip domain creation for Kubernetes-bound endpoint", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "k8s-bound-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "k8s-bound-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:      "http://aws.demo",
 					Bindings: []string{"kubernetes"},
@@ -1062,10 +1006,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 		It("should clear stale domainRef for internal domain endpoint", func(ctx SpecContext) {
 			staleDomainName := "stale-domain-ref"
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "internal-with-stale-ref",
-					Namespace: namespace,
-				},
+				Name:      "internal-with-stale-ref",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL: "http://test.internal",
 				},
@@ -1095,10 +1037,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		It("should create endpoint even when domain is not ready", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-endpoint",
-					Namespace: namespace,
-				},
+				Name:      "test-endpoint",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL: "http://example.com",
 				},
@@ -1187,10 +1127,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		It("should not call the ngrok API update while domain is not ready", func(ctx SpecContext) {
 			cloudEndpoint = &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-unnecessary-updates",
-					Namespace: namespace,
-				},
+				Name:      "no-unnecessary-updates",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL: "http://no-update-spam.example.com",
 				},
@@ -1220,20 +1158,16 @@ var _ = Describe("CloudEndpoint Controller", func() {
 			// Use different URLs to avoid pooling issues in mock
 			endpoints := []*ngrokv1alpha1.CloudEndpoint{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "k8s-endpoint-1",
-						Namespace: namespace,
-					},
+					Name:      "k8s-endpoint-1",
+					Namespace: namespace,
 					Spec: ngrokv1alpha1.CloudEndpointSpec{
 						URL:      "http://aws1.demo",
 						Bindings: []string{"kubernetes"},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "k8s-endpoint-2",
-						Namespace: namespace,
-					},
+					Name:      "k8s-endpoint-2",
+					Namespace: namespace,
 					Spec: ngrokv1alpha1.CloudEndpointSpec{
 						URL:      "http://aws2.demo",
 						Bindings: []string{"kubernetes"},
@@ -1282,10 +1216,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 		It("should reject endpoint with multiple bindings", func() {
 			// This should be caught by k8s validation (MaxItems=1), so we expect the Create to fail
 			cloudEndpoint := &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid-multiple-bindings",
-					Namespace: namespace,
-				},
+				Name:      "invalid-multiple-bindings",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:      "http://test.demo",
 					Bindings: []string{"public", "kubernetes"}, // Multiple bindings should be rejected
@@ -1302,10 +1234,8 @@ var _ = Describe("CloudEndpoint Controller", func() {
 
 		It("should accept endpoint with single binding", func(ctx SpecContext) {
 			cloudEndpoint := &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "valid-single-binding",
-					Namespace: namespace,
-				},
+				Name:      "valid-single-binding",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL:      "http://test-internal.demo",
 					Bindings: []string{"internal"}, // Single binding is valid

--- a/internal/controller/ngrok/cloudendpoint_controller_unit_test.go
+++ b/internal/controller/ngrok/cloudendpoint_controller_unit_test.go
@@ -195,14 +195,14 @@ func TestIndexCloudEndpointTrafficPolicyRefs(t *testing.T) {
 		{
 			name: "no policy configured returns nil",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+				Namespace: "ns",
 			},
 			want: nil,
 		},
 		{
 			name: "canonical targetRef indexes namespace/name in the endpoint's namespace",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+				Namespace: "ns",
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
 						Reference: &ngrokv1alpha1.K8sObjectRef{Name: "policy"},
@@ -214,7 +214,7 @@ func TestIndexCloudEndpointTrafficPolicyRefs(t *testing.T) {
 		{
 			name: "canonical inline returns nil (no external ref to watch)",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+				Namespace: "ns",
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
 						Inline: json.RawMessage(`{"on_http_request":[]}`),
@@ -226,7 +226,7 @@ func TestIndexCloudEndpointTrafficPolicyRefs(t *testing.T) {
 		{
 			name: "canonical inline + legacy trafficPolicyName returns nil — canonical wins, do not index legacy",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+				Namespace: "ns",
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					TrafficPolicyName: "legacy-ignored", //nolint:staticcheck // test of deprecated field
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
@@ -239,7 +239,7 @@ func TestIndexCloudEndpointTrafficPolicyRefs(t *testing.T) {
 		{
 			name: "legacy nested policy + legacy trafficPolicyName returns nil — canonical-equivalent wins",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+				Namespace: "ns",
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					TrafficPolicyName: "legacy-ignored", //nolint:staticcheck // test of deprecated field
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
@@ -252,7 +252,7 @@ func TestIndexCloudEndpointTrafficPolicyRefs(t *testing.T) {
 		{
 			name: "canonical targetRef + legacy trafficPolicyName indexes only the canonical ref",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+				Namespace: "ns",
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					TrafficPolicyName: "legacy-ignored", //nolint:staticcheck // test of deprecated field
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
@@ -265,7 +265,7 @@ func TestIndexCloudEndpointTrafficPolicyRefs(t *testing.T) {
 		{
 			name: "empty trafficPolicy{} alongside legacy trafficPolicyName falls back to legacy",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+				Namespace: "ns",
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					TrafficPolicyName: "legacy-name", //nolint:staticcheck // test of deprecated field
 					TrafficPolicy:     &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{},
@@ -276,7 +276,7 @@ func TestIndexCloudEndpointTrafficPolicyRefs(t *testing.T) {
 		{
 			name: "legacy trafficPolicyName only (no canonical) indexes legacy",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+				Namespace: "ns",
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					TrafficPolicyName: "legacy-name", //nolint:staticcheck // test of deprecated field
 				},
@@ -316,17 +316,15 @@ func TestNormalizeLegacyTrafficPolicy_EventSuppression(t *testing.T) {
 		{
 			name: "operator-managed via controller OwnerReference (Service path) — suppressed",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns",
-					Name:      "service-owned",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: "v1",
-							Kind:       "Service",
-							Name:       "my-service",
-							UID:        "uid-123",
-							Controller: new(true),
-						},
+				Namespace: "ns",
+				Name:      "service-owned",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "Service",
+						Name:       "my-service",
+						UID:        "uid-123",
+						Controller: new(true),
 					},
 				},
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
@@ -342,13 +340,11 @@ func TestNormalizeLegacyTrafficPolicy_EventSuppression(t *testing.T) {
 		{
 			name: "operator-managed via controller labels (managerdriver path) — suppressed",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns",
-					Name:      "managerdriver-owned",
-					Labels: map[string]string{
-						labels.ControllerName:      operatorName,
-						labels.ControllerNamespace: operatorNamespace,
-					},
+				Namespace: "ns",
+				Name:      "managerdriver-owned",
+				Labels: map[string]string{
+					labels.ControllerName:      operatorName,
+					labels.ControllerNamespace: operatorNamespace,
 				},
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL: "https://managerdriver-owned.internal",
@@ -363,10 +359,8 @@ func TestNormalizeLegacyTrafficPolicy_EventSuppression(t *testing.T) {
 		{
 			name: "user-authored (no controller ref, no operator labels) — event emitted",
 			clep: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns",
-					Name:      "user-authored",
-				},
+				Namespace: "ns",
+				Name:      "user-authored",
 				Spec: ngrokv1alpha1.CloudEndpointSpec{
 					URL: "https://user-authored.internal",
 					TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
@@ -439,16 +433,16 @@ func TestUpdate_RecreateOn404_DoesNotDoubleNormalizeLegacyPolicy(t *testing.T) {
 	require.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	trafficPolicy := &ngrokv1alpha1.NgrokTrafficPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-policy", Namespace: "ns"},
+		Name: "my-policy", Namespace: "ns",
 		Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 			Policy: json.RawMessage(`{"on_http_request":[{"name":"legacy"}]}`),
 		},
 	}
 	clep := &ngrokv1alpha1.CloudEndpoint{
-		ObjectMeta: metav1.ObjectMeta{Name: "legacy-only", Namespace: "ns"},
+		Name: "legacy-only", Namespace: "ns",
 		Spec: ngrokv1alpha1.CloudEndpointSpec{
 			URL:               "https://legacy-only.internal",
-			TrafficPolicyName: "my-policy",
+			TrafficPolicyName: "my-policy", //nolint:staticcheck // SA1019: exercises the deprecated field's migration path
 		},
 		// A Status.ID the mock ngrok clientset doesn't know about, so
 		// Endpoints().Get returns 404 and update() falls through to create.

--- a/internal/controller/ngrok/kubernetesoperator_controller.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller.go
@@ -41,7 +41,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -316,8 +315,7 @@ func (r *KubernetesOperatorReconciler) updateStatus(ctx context.Context, ko *ngr
 	if err != nil {
 		errMessage = err.Error()
 
-		var ngrokErr *ngrok.Error
-		if errors.As(err, &ngrokErr) {
+		if ngrokErr, ok := errors.AsType[*ngrok.Error](err); ok {
 			if ngrokErr.Msg != "" {
 				errMessage = ngrokErr.Msg
 			}
@@ -530,11 +528,9 @@ func (r *KubernetesOperatorReconciler) findOrCreateTLSSecret(ctx context.Context
 	}
 
 	secret = &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ko.Spec.Binding.TlsSecretName,
-			Namespace: r.K8sOpNamespace,
-		},
-		Type: v1.SecretTypeTLS,
+		Name:      ko.Spec.Binding.TlsSecretName,
+		Namespace: r.K8sOpNamespace,
+		Type:      v1.SecretTypeTLS,
 	}
 
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {

--- a/internal/controller/ngrok/kubernetesoperator_controller_test.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller_test.go
@@ -71,10 +71,8 @@ var _ = Describe("KubernetesOperator Controller", Ordered, func() {
 
 	It("should register successfully with ingress feature enabled", func(ctx SpecContext) {
 		ko := &ngrokv1alpha1.KubernetesOperator{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      k8sOpName,
-				Namespace: controllerNamespace,
-			},
+			Name:      k8sOpName,
+			Namespace: controllerNamespace,
 			Spec: ngrokv1alpha1.KubernetesOperatorSpec{
 				Description:     "test operator",
 				Metadata:        commonv1alpha1.MetadataFromLegacyString(`{"owned-by":"test"}`),
@@ -140,10 +138,8 @@ var _ = Describe("KubernetesOperator Controller", Ordered, func() {
 
 	It("should report and recover from an invalid bindings configuration", func(ctx SpecContext) {
 		ko := &ngrokv1alpha1.KubernetesOperator{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      k8sOpName,
-				Namespace: controllerNamespace,
-			},
+			Name:      k8sOpName,
+			Namespace: controllerNamespace,
 			Spec: ngrokv1alpha1.KubernetesOperatorSpec{
 				Description:     "test operator with nil binding",
 				Metadata:        commonv1alpha1.MetadataFromLegacyString(`{"owned-by":"test"}`),
@@ -212,10 +208,8 @@ var _ = Describe("KubernetesOperator Controller", Ordered, func() {
 		const holdFinalizer = "test.ngrok.com/hold"
 
 		ko := &ngrokv1alpha1.KubernetesOperator{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      k8sOpName,
-				Namespace: controllerNamespace,
-			},
+			Name:      k8sOpName,
+			Namespace: controllerNamespace,
 			Spec: ngrokv1alpha1.KubernetesOperatorSpec{
 				Description:     "drain lifecycle envtest",
 				Metadata:        commonv1alpha1.MetadataFromLegacyString(`{"owned-by":"test"}`),
@@ -227,11 +221,9 @@ var _ = Describe("KubernetesOperator Controller", Ordered, func() {
 			},
 		}
 		service := &v1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:       "drain-lifecycle",
-				Namespace:  controllerNamespace,
-				Finalizers: []string{util.LegacyFinalizerName},
-			},
+			Name:       "drain-lifecycle",
+			Namespace:  controllerNamespace,
+			Finalizers: []string{util.LegacyFinalizerName},
 			Spec: v1.ServiceSpec{
 				Ports: []v1.ServicePort{{Port: 80}},
 			},

--- a/internal/controller/ngrok/kubernetesoperator_controller_unit_test.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller_unit_test.go
@@ -143,11 +143,9 @@ func TestUpdateStatus_Conditions(t *testing.T) {
 			require.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 			ko := &ngrokv1alpha1.KubernetesOperator{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "ko",
-					Namespace:  "test-ns",
-					Generation: 2,
-				},
+				Name:       "ko",
+				Namespace:  "test-ns",
+				Generation: 2,
 			}
 
 			fakeClient := fake.NewClientBuilder().
@@ -203,11 +201,9 @@ func TestUpdate_ExistingOperatorConfigurationFailureRemainsRegistered(t *testing
 	require.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "ko",
-			Namespace:  "test-ns",
-			Generation: 2,
-		},
+		Name:       "ko",
+		Namespace:  "test-ns",
+		Generation: 2,
 		Spec: ngrokv1alpha1.KubernetesOperatorSpec{
 			EnabledFeatures: []string{ngrokv1alpha1.KubernetesOperatorFeatureBindings},
 		},
@@ -249,11 +245,9 @@ func TestUpdate_ExistingOperatorConfigurationFailureRemainsRegistered(t *testing
 func TestKubernetesOperatorReconcilePredicate(t *testing.T) {
 	now := metav1.Now()
 	base := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "ko",
-			Namespace:  "test-ns",
-			Generation: 1,
-		},
+		Name:       "ko",
+		Namespace:  "test-ns",
+		Generation: 1,
 	}
 
 	tests := []struct {
@@ -395,11 +389,9 @@ func TestInvalidateTLSSecretCSR(t *testing.T) {
 	assert.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tls-secret",
-			Namespace: "test-ns",
-		},
-		Type: v1.SecretTypeTLS,
+		Name:      "tls-secret",
+		Namespace: "test-ns",
+		Type:      v1.SecretTypeTLS,
 		Data: map[string][]byte{
 			"tls.key": []byte("key"),
 			"tls.crt": []byte("cert"),
@@ -412,10 +404,8 @@ func TestInvalidateTLSSecretCSR(t *testing.T) {
 	}
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ko",
-			Namespace: "test-ns",
-		},
+		Name:      "ko",
+		Namespace: "test-ns",
 		Spec: ngrokv1alpha1.KubernetesOperatorSpec{
 			Binding: &ngrokv1alpha1.KubernetesOperatorBinding{
 				TlsSecretName: "tls-secret",
@@ -442,11 +432,9 @@ func TestReconcileBindingCertRenewalRequeueAfter(t *testing.T) {
 	assert.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tls-secret",
-			Namespace: "test-ns",
-		},
-		Type: v1.SecretTypeTLS,
+		Name:      "tls-secret",
+		Namespace: "test-ns",
+		Type:      v1.SecretTypeTLS,
 		Data: map[string][]byte{
 			"tls.key": []byte("key"),
 			"tls.crt": []byte("cert"),
@@ -472,10 +460,8 @@ func TestReconcileBindingCertRenewalRequeueAfter(t *testing.T) {
 	}
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ko",
-			Namespace: "test-ns",
-		},
+		Name:      "ko",
+		Namespace: "test-ns",
 		Spec: ngrokv1alpha1.KubernetesOperatorSpec{
 			EnabledFeatures: []string{ngrokv1alpha1.KubernetesOperatorFeatureBindings},
 			Binding: &ngrokv1alpha1.KubernetesOperatorBinding{
@@ -502,11 +488,9 @@ func TestReconcileBindingCertRenewalInvalidatesCSR(t *testing.T) {
 	assert.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tls-secret",
-			Namespace: "test-ns",
-		},
-		Type: v1.SecretTypeTLS,
+		Name:      "tls-secret",
+		Namespace: "test-ns",
+		Type:      v1.SecretTypeTLS,
 		Data: map[string][]byte{
 			"tls.key": []byte("key"),
 			"tls.crt": []byte("cert"),
@@ -533,10 +517,8 @@ func TestReconcileBindingCertRenewalInvalidatesCSR(t *testing.T) {
 	}
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ko",
-			Namespace: "test-ns",
-		},
+		Name:      "ko",
+		Namespace: "test-ns",
 		Spec: ngrokv1alpha1.KubernetesOperatorSpec{
 			EnabledFeatures: []string{ngrokv1alpha1.KubernetesOperatorFeatureBindings},
 			Binding: &ngrokv1alpha1.KubernetesOperatorBinding{

--- a/internal/controller/ngrok/ngroktrafficpolicy_conditions_test.go
+++ b/internal/controller/ngrok/ngroktrafficpolicy_conditions_test.go
@@ -55,7 +55,7 @@ func TestSetTrafficPolicyConditions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tp := &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{Generation: 3},
+				Generation: 3,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: json.RawMessage(tt.policy),
 				},
@@ -83,7 +83,7 @@ func TestSetTrafficPolicyConditions(t *testing.T) {
 // post-mutation value, even when something actually changed.
 func TestStatusChangeDetection(t *testing.T) {
 	tp := &ngrokv1alpha1.NgrokTrafficPolicy{
-		ObjectMeta: metav1.ObjectMeta{Generation: 1},
+		Generation: 1,
 		Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 			Policy: json.RawMessage(`{"on_http_request":[{"actions":[{"type":"deny"}]}]}`),
 		},

--- a/internal/controller/service/controller.go
+++ b/internal/controller/service/controller.go
@@ -54,7 +54,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -357,10 +356,8 @@ func (r *ServiceReconciler) findServicesForTrafficPolicy(ctx context.Context, po
 		svcNamespace := svc.GetNamespace()
 		svcName := svc.GetName()
 		requests[i] = reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: svcNamespace,
-				Name:      svcName,
-			},
+			Namespace: svcNamespace,
+			Name:      svcName,
 		}
 		log.V(3).Info("Triggering reconciliation for service", "namespace", svcNamespace, "name", svcName)
 	}
@@ -548,14 +545,12 @@ func (r *ServiceReconciler) buildEndpoints(ctx context.Context, svc *corev1.Serv
 	// For the default/collapse strategy, make a single AgentEndpoint
 	case ir.IRMappingStrategy_EndpointsCollapsed:
 		agentEndpoint := &ngrokv1alpha1.AgentEndpoint{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: svc.Name + "-",
-				Namespace:    svc.Namespace,
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(svc, corev1.SchemeGroupVersion.WithKind("Service")),
-				},
-				Labels: r.ControllerLabels.Labels(),
+			GenerateName: svc.Name + "-",
+			Namespace:    svc.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(svc, corev1.SchemeGroupVersion.WithKind("Service")),
 			},
+			Labels: r.ControllerLabels.Labels(),
 			Spec: ngrokv1alpha1.AgentEndpointSpec{
 				URL:      computedEndpointURL,
 				Bindings: useBindings,
@@ -584,14 +579,12 @@ func (r *ServiceReconciler) buildEndpoints(ctx context.Context, svc *corev1.Serv
 		}
 
 		cloudEndpoint := &ngrokv1alpha1.CloudEndpoint{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: svc.Name + "-",
-				Namespace:    svc.Namespace,
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(svc, corev1.SchemeGroupVersion.WithKind("Service")),
-				},
-				Labels: r.ControllerLabels.Labels(),
+			GenerateName: svc.Name + "-",
+			Namespace:    svc.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(svc, corev1.SchemeGroupVersion.WithKind("Service")),
 			},
+			Labels: r.ControllerLabels.Labels(),
 			Spec: ngrokv1alpha1.CloudEndpointSpec{
 				URL:            computedEndpointURL,
 				Bindings:       useBindings,
@@ -602,21 +595,19 @@ func (r *ServiceReconciler) buildEndpoints(ctx context.Context, svc *corev1.Serv
 				// only `policy` survives. Drop the `Policy` write in the cleanup release.
 				TrafficPolicy: &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
 					Inline: rawPolicy,
-					Policy: rawPolicy,
+					Policy: rawPolicy, //nolint:staticcheck // SA1019: deliberate legacy dual-write, see above
 				},
 			},
 		}
 		objects = append(objects, cloudEndpoint)
 
 		agentEndpoint := &ngrokv1alpha1.AgentEndpoint{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: svc.Name + "-internal-",
-				Namespace:    svc.Namespace,
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(svc, corev1.SchemeGroupVersion.WithKind("Service")),
-				},
-				Labels: r.ControllerLabels.Labels(),
+			GenerateName: svc.Name + "-internal-",
+			Namespace:    svc.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(svc, corev1.SchemeGroupVersion.WithKind("Service")),
 			},
+			Labels: r.ControllerLabels.Labels(),
 			Spec: ngrokv1alpha1.AgentEndpointSpec{
 				URL: internalURL,
 				Upstream: ngrokv1alpha1.EndpointUpstream{

--- a/internal/controller/service/controller_test.go
+++ b/internal/controller/service/controller_test.go
@@ -144,11 +144,9 @@ var _ = Describe("ServiceController", func() {
 
 	JustBeforeEach(func() {
 		svc = &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        fmt.Sprintf("test-service-%d", rand.IntN(100000)),
-				Namespace:   namespace,
-				Annotations: map[string]string{},
-			},
+			Name:        fmt.Sprintf("test-service-%d", rand.IntN(100000)),
+			Namespace:   namespace,
+			Annotations: map[string]string{},
 			Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeLoadBalancer,
 				Ports: []corev1.ServicePort{
@@ -469,10 +467,8 @@ var _ = Describe("ServiceController", func() {
 					BeforeEach(func() {
 						policyName = fmt.Sprintf("test-policy-collapsed-%d", rand.IntN(100000))
 						policy = &ngrokv1alpha1.NgrokTrafficPolicy{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      policyName,
-								Namespace: namespace,
-							},
+							Name:      policyName,
+							Namespace: namespace,
 							Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 								Policy: json.RawMessage(`{"on_tcp_connect": [{"actions": [{"type": "restrict-ips", "config": {"deny": ["5.6.7.8/32"]}}]}]}`),
 							},
@@ -681,10 +677,8 @@ var _ = Describe("ServiceController", func() {
 
 					By("creating a Domain CRD for the ngrok domain")
 					domain := &ingressv1alpha1.Domain{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      domainName,
-							Namespace: namespace,
-						},
+						Name:      domainName,
+						Namespace: namespace,
 						Spec: ingressv1alpha1.DomainSpec{
 							Domain: tlsDomain,
 						},
@@ -797,10 +791,8 @@ var _ = Describe("ServiceController", func() {
 					By("creating a Domain CRD with CNAME target in status")
 					domainName := strings.ReplaceAll(customDomain, ".", "-")
 					domain := &ingressv1alpha1.Domain{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      domainName,
-							Namespace: namespace,
-						},
+						Name:      domainName,
+						Namespace: namespace,
 						Spec: ingressv1alpha1.DomainSpec{
 							Domain: customDomain,
 						},
@@ -861,10 +853,8 @@ var _ = Describe("ServiceController", func() {
 				BeforeEach(func() {
 					policyName = fmt.Sprintf("test-policy-%d", rand.IntN(100000))
 					policy = &ngrokv1alpha1.NgrokTrafficPolicy{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      policyName,
-							Namespace: namespace,
-						},
+						Name:      policyName,
+						Namespace: namespace,
 						Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 							Policy: json.RawMessage(`{"on_tcp_connect": [{"actions": [{"type": "restrict-ips", "config": {"deny": ["1.2.3.4/32"]}}]}]}`),
 						},
@@ -948,17 +938,15 @@ var _ = Describe("ServiceController", func() {
 					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(svc), fetched)).To(Succeed())
 
 					extraClep := &ngrokv1alpha1.CloudEndpoint{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("%s-extra", svc.Name),
-							Namespace: namespace,
-							OwnerReferences: []metav1.OwnerReference{
-								{
-									APIVersion: "v1",
-									Kind:       "Service",
-									Name:       fetched.Name,
-									UID:        fetched.UID,
-									Controller: new(true),
-								},
+						Name:      fmt.Sprintf("%s-extra", svc.Name),
+						Namespace: namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "v1",
+								Kind:       "Service",
+								Name:       fetched.Name,
+								UID:        fetched.UID,
+								Controller: new(true),
 							},
 						},
 						Spec: ngrokv1alpha1.CloudEndpointSpec{

--- a/internal/controller/util_test.go
+++ b/internal/controller/util_test.go
@@ -48,9 +48,7 @@ func TestIsUpsert(t *testing.T) {
 		{
 			name: "with deletion timestamp",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					DeletionTimestamp: &now,
-				},
+				DeletionTimestamp: &now,
 			},
 			want: false,
 		},
@@ -78,9 +76,7 @@ func TestIsDelete(t *testing.T) {
 		{
 			name: "with deletion timestamp",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					DeletionTimestamp: &now,
-				},
+				DeletionTimestamp: &now,
 			},
 			want: true,
 		},
@@ -121,9 +117,7 @@ func TestAddAnnotations(t *testing.T) {
 		{
 			name: "add to existing",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"existing": "annotation"},
-				},
+				Annotations: map[string]string{"existing": "annotation"},
 			},
 			annotations:     map[string]string{"key": "value"},
 			wantAnnotations: map[string]string{"existing": "annotation", "key": "value"},
@@ -131,9 +125,7 @@ func TestAddAnnotations(t *testing.T) {
 		{
 			name: "overwrite existing",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"key": "old"},
-				},
+				Annotations: map[string]string{"key": "old"},
 			},
 			annotations:     map[string]string{"key": "new"},
 			wantAnnotations: map[string]string{"key": "new"},

--- a/internal/deprecation/deprecation_test.go
+++ b/internal/deprecation/deprecation_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -66,7 +65,7 @@ func TestScanAnnotations(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rec := &fakeRecorder{}
-			obj := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: tc.annotations}}
+			obj := &corev1.Service{Annotations: tc.annotations}
 			ScanAnnotations(logr.Discard(), rec, obj)
 			assert.Len(t, rec.events, tc.wantReasons)
 			for _, ev := range rec.events {
@@ -83,9 +82,8 @@ func TestScanAnnotations(t *testing.T) {
 }
 
 func TestScanAnnotationsNilRecorderDoesNotPanic(_ *testing.T) {
-	obj := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-		Annotations: map[string]string{"k8s.ngrok.com/url": "tcp://x"},
-	}}
+	obj := &corev1.Service{
+		Annotations: map[string]string{"k8s.ngrok.com/url": "tcp://x"}}
 	ScanAnnotations(logr.Discard(), nil, obj)
 }
 

--- a/internal/domain/manager.go
+++ b/internal/domain/manager.go
@@ -263,10 +263,8 @@ func (m *Manager) checkExistingDomain(endpoint ngrokv1alpha1.EndpointWithDomain,
 // createNewDomain creates a new Domain CRD
 func (m *Manager) createNewDomain(ctx context.Context, endpoint ngrokv1alpha1.EndpointWithDomain, domain, hyphenatedDomain string) (*DomainResult, error) {
 	newDomain := &ingressv1alpha1.Domain{
-		ObjectMeta: ctrl.ObjectMeta{
-			Name:      hyphenatedDomain,
-			Namespace: endpoint.GetNamespace(),
-		},
+		Name:      hyphenatedDomain,
+		Namespace: endpoint.GetNamespace(),
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: domain,
 		},

--- a/internal/domain/manager_test.go
+++ b/internal/domain/manager_test.go
@@ -54,10 +54,8 @@ func newTestManagerWithOpts(t *testing.T, opts []ManagerOption, objs ...client.O
 
 func createTestEndpoint(name, namespace, url string) *ngrokv1alpha1.AgentEndpoint {
 	return &ngrokv1alpha1.AgentEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: ngrokv1alpha1.AgentEndpointSpec{
 			URL: url,
 		},
@@ -69,10 +67,8 @@ func createTestEndpoint(name, namespace, url string) *ngrokv1alpha1.AgentEndpoin
 
 func createReadyDomain(name, namespace, domainName string) *ingressv1alpha1.Domain {
 	return &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: domainName,
 		},
@@ -92,10 +88,8 @@ func createReadyDomain(name, namespace, domainName string) *ingressv1alpha1.Doma
 
 func createNotReadyDomain(name, namespace, domainName string) *ingressv1alpha1.Domain {
 	return &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: domainName,
 		},
@@ -272,10 +266,8 @@ func TestManager_EnsureDomainExists_ExistingDomainNotReady(t *testing.T) {
 
 func TestManager_EnsureDomainExists_ExistingDomainNoReadyCondition(t *testing.T) {
 	existingDomain := &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
+		Name:      "example-com",
+		Namespace: "default",
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: "example.com",
 		},
@@ -371,17 +363,17 @@ func TestManager_EnsureDomainExists_SkipsKubernetesBinding(t *testing.T) {
 		{
 			name: "AgentEndpoint",
 			endpoint: &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "k8s-bound-endpoint", Namespace: "default"},
-				Spec:       ngrokv1alpha1.AgentEndpointSpec{URL: "http://aws.demo", Bindings: []string{"kubernetes"}},
-				Status:     ngrokv1alpha1.AgentEndpointStatus{Conditions: []metav1.Condition{}},
+				Name: "k8s-bound-endpoint", Namespace: "default",
+				Spec:   ngrokv1alpha1.AgentEndpointSpec{URL: "http://aws.demo", Bindings: []string{"kubernetes"}},
+				Status: ngrokv1alpha1.AgentEndpointStatus{Conditions: []metav1.Condition{}},
 			},
 		},
 		{
 			name: "CloudEndpoint",
 			endpoint: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "k8s-bound-endpoint", Namespace: "default"},
-				Spec:       ngrokv1alpha1.CloudEndpointSpec{URL: "http://aws.demo", Bindings: []string{"kubernetes"}},
-				Status:     ngrokv1alpha1.CloudEndpointStatus{Conditions: []metav1.Condition{}},
+				Name: "k8s-bound-endpoint", Namespace: "default",
+				Spec:   ngrokv1alpha1.CloudEndpointSpec{URL: "http://aws.demo", Bindings: []string{"kubernetes"}},
+				Status: ngrokv1alpha1.CloudEndpointStatus{Conditions: []metav1.Condition{}},
 			},
 		},
 	}
@@ -411,17 +403,17 @@ func TestManager_EnsureDomainExists_SkipsInternalBinding(t *testing.T) {
 		{
 			name: "AgentEndpoint",
 			endpoint: &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "internal-bound-endpoint", Namespace: "default"},
-				Spec:       ngrokv1alpha1.AgentEndpointSpec{URL: "http://internal.demo", Bindings: []string{"internal"}},
-				Status:     ngrokv1alpha1.AgentEndpointStatus{Conditions: []metav1.Condition{}},
+				Name: "internal-bound-endpoint", Namespace: "default",
+				Spec:   ngrokv1alpha1.AgentEndpointSpec{URL: "http://internal.demo", Bindings: []string{"internal"}},
+				Status: ngrokv1alpha1.AgentEndpointStatus{Conditions: []metav1.Condition{}},
 			},
 		},
 		{
 			name: "CloudEndpoint",
 			endpoint: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "internal-bound-endpoint", Namespace: "default"},
-				Spec:       ngrokv1alpha1.CloudEndpointSpec{URL: "http://internal.demo", Bindings: []string{"internal"}},
-				Status:     ngrokv1alpha1.CloudEndpointStatus{Conditions: []metav1.Condition{}},
+				Name: "internal-bound-endpoint", Namespace: "default",
+				Spec:   ngrokv1alpha1.CloudEndpointSpec{URL: "http://internal.demo", Bindings: []string{"internal"}},
+				Status: ngrokv1alpha1.CloudEndpointStatus{Conditions: []metav1.Condition{}},
 			},
 		},
 	}
@@ -451,33 +443,33 @@ func TestManager_EnsureDomainExists_SkipsTCPURLs(t *testing.T) {
 		{
 			name: "AgentEndpoint with tcp ngrok URL",
 			endpoint: &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "tcp-endpoint", Namespace: "default"},
-				Spec:       ngrokv1alpha1.AgentEndpointSpec{URL: "tcp://1.tcp.ngrok.io:12345"},
-				Status:     ngrokv1alpha1.AgentEndpointStatus{Conditions: []metav1.Condition{}},
+				Name: "tcp-endpoint", Namespace: "default",
+				Spec:   ngrokv1alpha1.AgentEndpointSpec{URL: "tcp://1.tcp.ngrok.io:12345"},
+				Status: ngrokv1alpha1.AgentEndpointStatus{Conditions: []metav1.Condition{}},
 			},
 		},
 		{
 			name: "AgentEndpoint with custom tcp URL",
 			endpoint: &ngrokv1alpha1.AgentEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "tcp-custom-endpoint", Namespace: "default"},
-				Spec:       ngrokv1alpha1.AgentEndpointSpec{URL: "tcp://custom.example.com:8080"},
-				Status:     ngrokv1alpha1.AgentEndpointStatus{Conditions: []metav1.Condition{}},
+				Name: "tcp-custom-endpoint", Namespace: "default",
+				Spec:   ngrokv1alpha1.AgentEndpointSpec{URL: "tcp://custom.example.com:8080"},
+				Status: ngrokv1alpha1.AgentEndpointStatus{Conditions: []metav1.Condition{}},
 			},
 		},
 		{
 			name: "CloudEndpoint with tcp ngrok URL",
 			endpoint: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "tcp-endpoint", Namespace: "default"},
-				Spec:       ngrokv1alpha1.CloudEndpointSpec{URL: "tcp://1.tcp.ngrok.io:12345"},
-				Status:     ngrokv1alpha1.CloudEndpointStatus{Conditions: []metav1.Condition{}},
+				Name: "tcp-endpoint", Namespace: "default",
+				Spec:   ngrokv1alpha1.CloudEndpointSpec{URL: "tcp://1.tcp.ngrok.io:12345"},
+				Status: ngrokv1alpha1.CloudEndpointStatus{Conditions: []metav1.Condition{}},
 			},
 		},
 		{
 			name: "CloudEndpoint with custom tcp URL",
 			endpoint: &ngrokv1alpha1.CloudEndpoint{
-				ObjectMeta: metav1.ObjectMeta{Name: "tcp-custom-endpoint", Namespace: "default"},
-				Spec:       ngrokv1alpha1.CloudEndpointSpec{URL: "tcp://custom.example.com:8080"},
-				Status:     ngrokv1alpha1.CloudEndpointStatus{Conditions: []metav1.Condition{}},
+				Name: "tcp-custom-endpoint", Namespace: "default",
+				Spec:   ngrokv1alpha1.CloudEndpointSpec{URL: "tcp://custom.example.com:8080"},
+				Status: ngrokv1alpha1.CloudEndpointStatus{Conditions: []metav1.Condition{}},
 			},
 		},
 	}
@@ -504,8 +496,8 @@ func TestManager_EnsureDomainExists_KubernetesBinding_DeletesStaleDomain(t *test
 	manager, c := newTestManager(t, existingDomain)
 
 	endpoint := &ngrokv1alpha1.AgentEndpoint{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-endpoint", Namespace: "default"},
-		Spec:       ngrokv1alpha1.AgentEndpointSpec{URL: "http://example.com", Bindings: []string{"kubernetes"}},
+		Name: "test-endpoint", Namespace: "default",
+		Spec: ngrokv1alpha1.AgentEndpointSpec{URL: "http://example.com", Bindings: []string{"kubernetes"}},
 		Status: ngrokv1alpha1.AgentEndpointStatus{
 			DomainRef:  &ngrokv1alpha1.K8sObjectRefOptionalNamespace{Name: "example-com"},
 			Conditions: []metav1.Condition{},
@@ -555,7 +547,7 @@ func TestEndpointReferencesDomain(t *testing.T) {
 				ep.Status.DomainRef = &ngrokv1alpha1.K8sObjectRefOptionalNamespace{Name: "example-com", Namespace: &ns}
 				return ep
 			},
-			domain: &ingressv1alpha1.Domain{ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: "default"}},
+			domain: &ingressv1alpha1.Domain{Name: "example-com", Namespace: "default"},
 			want:   true,
 		},
 		{
@@ -565,7 +557,7 @@ func TestEndpointReferencesDomain(t *testing.T) {
 				ep.Status.DomainRef = &ngrokv1alpha1.K8sObjectRefOptionalNamespace{Name: "example-com", Namespace: nil}
 				return ep
 			},
-			domain: &ingressv1alpha1.Domain{ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: "default"}},
+			domain: &ingressv1alpha1.Domain{Name: "example-com", Namespace: "default"},
 			want:   true,
 		},
 		{
@@ -576,7 +568,7 @@ func TestEndpointReferencesDomain(t *testing.T) {
 				ep.Status.DomainRef = &ngrokv1alpha1.K8sObjectRefOptionalNamespace{Name: "example-com", Namespace: &emptyNs}
 				return ep
 			},
-			domain: &ingressv1alpha1.Domain{ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: "default"}},
+			domain: &ingressv1alpha1.Domain{Name: "example-com", Namespace: "default"},
 			want:   true,
 		},
 		{
@@ -587,7 +579,7 @@ func TestEndpointReferencesDomain(t *testing.T) {
 				ep.Status.DomainRef = &ngrokv1alpha1.K8sObjectRefOptionalNamespace{Name: "example-com", Namespace: &ns}
 				return ep
 			},
-			domain: &ingressv1alpha1.Domain{ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: "default"}},
+			domain: &ingressv1alpha1.Domain{Name: "example-com", Namespace: "default"},
 			want:   false,
 		},
 		{
@@ -598,7 +590,7 @@ func TestEndpointReferencesDomain(t *testing.T) {
 				ep.Status.DomainRef = &ngrokv1alpha1.K8sObjectRefOptionalNamespace{Name: "different-domain", Namespace: &ns}
 				return ep
 			},
-			domain: &ingressv1alpha1.Domain{ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: "default"}},
+			domain: &ingressv1alpha1.Domain{Name: "example-com", Namespace: "default"},
 			want:   false,
 		},
 		{
@@ -606,7 +598,7 @@ func TestEndpointReferencesDomain(t *testing.T) {
 			endpoint: func() *ngrokv1alpha1.AgentEndpoint {
 				return createTestEndpoint("test-endpoint", "default", "https://example.com")
 			},
-			domain: &ingressv1alpha1.Domain{ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: "default"}},
+			domain: &ingressv1alpha1.Domain{Name: "example-com", Namespace: "default"},
 			want:   false,
 		},
 	}

--- a/internal/drain/drain_test.go
+++ b/internal/drain/drain_test.go
@@ -34,7 +34,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -112,11 +111,9 @@ func TestDrainer_DrainUserResource(t *testing.T) {
 	require.NoError(t, netv1.AddToScheme(scheme))
 
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-ingress",
-			Namespace:  "default",
-			Finalizers: []string{util.FinalizerName},
-		},
+		Name:       "test-ingress",
+		Namespace:  "default",
+		Finalizers: []string{util.FinalizerName},
 	}
 
 	c := fake.NewClientBuilder().
@@ -144,10 +141,8 @@ func TestDrainer_DrainOperatorResource(t *testing.T) {
 	// when Delete is called. In a real cluster, the controller would handle
 	// removing the finalizer after cleanup, but we can't simulate that here.
 	domain := &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-domain",
-			Namespace: "ngrok-operator",
-		},
+		Name:      "test-domain",
+		Namespace: "ngrok-operator",
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: "test.ngrok.io",
 		},
@@ -179,11 +174,9 @@ func TestDrainer_DrainOperatorResource_RetainMode(t *testing.T) {
 	require.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	domain := &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-domain",
-			Namespace:  "ngrok-operator",
-			Finalizers: []string{util.FinalizerName},
-		},
+		Name:       "test-domain",
+		Namespace:  "ngrok-operator",
+		Finalizers: []string{util.FinalizerName},
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: "test.ngrok.io",
 		},
@@ -242,33 +235,27 @@ func TestDrainer_DrainUserCreatedResources_NoControllerLabels(t *testing.T) {
 	require.NoError(t, gatewayv1alpha2.Install(scheme))
 
 	ipPolicy := &ingressv1alpha1.IPPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "user-created-ippolicy",
-			Namespace:  "default",
-			Finalizers: []string{util.FinalizerName},
-		},
+		Name:       "user-created-ippolicy",
+		Namespace:  "default",
+		Finalizers: []string{util.FinalizerName},
 		Spec: ingressv1alpha1.IPPolicySpec{
 			Description: "User-created IP Policy without controller labels",
 		},
 	}
 
 	cloudEndpoint := &ngrokv1alpha1.CloudEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "user-created-cloudendpoint",
-			Namespace:  "default",
-			Finalizers: []string{util.FinalizerName},
-		},
+		Name:       "user-created-cloudendpoint",
+		Namespace:  "default",
+		Finalizers: []string{util.FinalizerName},
 		Spec: ngrokv1alpha1.CloudEndpointSpec{
 			URL: "https://example.ngrok.io",
 		},
 	}
 
 	agentEndpoint := &ngrokv1alpha1.AgentEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "user-created-agentendpoint",
-			Namespace:  "default",
-			Finalizers: []string{util.FinalizerName},
-		},
+		Name:       "user-created-agentendpoint",
+		Namespace:  "default",
+		Finalizers: []string{util.FinalizerName},
 		Spec: ngrokv1alpha1.AgentEndpointSpec{
 			URL: "https://example.ngrok.io",
 		},
@@ -318,18 +305,14 @@ func TestDrainer_SkipsResourcesWithoutFinalizer(t *testing.T) {
 	require.NoError(t, gatewayv1alpha2.Install(scheme))
 
 	ipPolicyWithFinalizer := &ingressv1alpha1.IPPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "with-finalizer",
-			Namespace:  "default",
-			Finalizers: []string{util.FinalizerName},
-		},
+		Name:       "with-finalizer",
+		Namespace:  "default",
+		Finalizers: []string{util.FinalizerName},
 	}
 
 	ipPolicyWithoutFinalizer := &ingressv1alpha1.IPPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "without-finalizer",
-			Namespace: "default",
-		},
+		Name:      "without-finalizer",
+		Namespace: "default",
 	}
 
 	fakeClient := fake.NewClientBuilder().
@@ -453,11 +436,9 @@ func TestDrainer_DrainOperatorResource_AlreadyDeleted(t *testing.T) {
 		Build()
 
 	domain := &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "already-deleted",
-			Namespace:  "ngrok-operator",
-			Finalizers: []string{util.FinalizerName},
-		},
+		Name:       "already-deleted",
+		Namespace:  "ngrok-operator",
+		Finalizers: []string{util.FinalizerName},
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: "test.ngrok.io",
 		},
@@ -479,11 +460,9 @@ func TestDrainer_DrainOperatorResource_DeleteError(t *testing.T) {
 	require.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	domain := &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-domain",
-			Namespace:  "ngrok-operator",
-			Finalizers: []string{util.FinalizerName},
-		},
+		Name:       "test-domain",
+		Namespace:  "ngrok-operator",
+		Finalizers: []string{util.FinalizerName},
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: "test.ngrok.io",
 		},
@@ -534,11 +513,9 @@ func TestDrainer_DrainOperatorResource_RetainUpdateError(t *testing.T) {
 	require.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	domain := &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-domain",
-			Namespace:  "ngrok-operator",
-			Finalizers: []string{util.FinalizerName},
-		},
+		Name:       "test-domain",
+		Namespace:  "ngrok-operator",
+		Finalizers: []string{util.FinalizerName},
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: "test.ngrok.io",
 		},

--- a/internal/drain/orchestrator_test.go
+++ b/internal/drain/orchestrator_test.go
@@ -89,10 +89,8 @@ func TestOrchestrator_HandleDrain_CompletesSuccessfully(t *testing.T) {
 	scheme := setupTestScheme(t)
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-release",
-			Namespace: "ngrok-operator",
-		},
+		Name:      "my-release",
+		Namespace: "ngrok-operator",
 		Spec: ngrokv1alpha1.KubernetesOperatorSpec{
 			Drain: &ngrokv1alpha1.DrainConfig{
 				Policy: ngrokv1alpha1.DrainPolicyRetain,
@@ -138,10 +136,8 @@ func TestOrchestrator_HandleDrain_SetsStatusToDraining(t *testing.T) {
 	scheme := setupTestScheme(t)
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-release",
-			Namespace: "ngrok-operator",
-		},
+		Name:      "my-release",
+		Namespace: "ngrok-operator",
 	}
 
 	client := fake.NewClientBuilder().
@@ -176,10 +172,8 @@ func TestOrchestrator_HandleDrain_AlreadyCompleted(t *testing.T) {
 	scheme := setupTestScheme(t)
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-release",
-			Namespace: "ngrok-operator",
-		},
+		Name:      "my-release",
+		Namespace: "ngrok-operator",
 		Status: ngrokv1alpha1.KubernetesOperatorStatus{
 			Conditions: []metav1.Condition{{
 				Type:               ngrokv1alpha1.KubernetesOperatorConditionDraining,
@@ -216,10 +210,8 @@ func TestOrchestrator_HandleDrain_TransientErrors_OutcomeRetry(t *testing.T) {
 	scheme := setupTestScheme(t)
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-release",
-			Namespace: "ngrok-operator",
-		},
+		Name:      "my-release",
+		Namespace: "ngrok-operator",
 		Spec: ngrokv1alpha1.KubernetesOperatorSpec{
 			Drain: &ngrokv1alpha1.DrainConfig{
 				Policy: ngrokv1alpha1.DrainPolicyRetain,
@@ -228,11 +220,9 @@ func TestOrchestrator_HandleDrain_TransientErrors_OutcomeRetry(t *testing.T) {
 	}
 
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-ingress",
-			Namespace:  "default",
-			Finalizers: []string{"k8s.ngrok.com/finalizer"},
-		},
+		Name:       "test-ingress",
+		Namespace:  "default",
+		Finalizers: []string{"k8s.ngrok.com/finalizer"},
 	}
 
 	fakeClient := fake.NewClientBuilder().
@@ -298,10 +288,8 @@ func TestOrchestrator_HandleDrain_ListError_OutcomeRetry(t *testing.T) {
 	scheme := setupTestScheme(t)
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-release",
-			Namespace: "ngrok-operator",
-		},
+		Name:      "my-release",
+		Namespace: "ngrok-operator",
 	}
 
 	fakeClient := fake.NewClientBuilder().

--- a/internal/drain/state_test.go
+++ b/internal/drain/state_test.go
@@ -52,11 +52,9 @@ func TestStateChecker_NoDraining(t *testing.T) {
 	require.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-release",
-			Namespace: "ngrok-operator",
-		},
-		Spec: ngrokv1alpha1.KubernetesOperatorSpec{},
+		Name:      "my-release",
+		Namespace: "ngrok-operator",
+		Spec:      ngrokv1alpha1.KubernetesOperatorSpec{},
 	}
 
 	client := fake.NewClientBuilder().
@@ -74,11 +72,9 @@ func TestStateChecker_DrainingConditionTrue(t *testing.T) {
 	require.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-release",
-			Namespace: "ngrok-operator",
-		},
-		Spec: ngrokv1alpha1.KubernetesOperatorSpec{},
+		Name:      "my-release",
+		Namespace: "ngrok-operator",
+		Spec:      ngrokv1alpha1.KubernetesOperatorSpec{},
 		Status: ngrokv1alpha1.KubernetesOperatorStatus{
 			Conditions: []metav1.Condition{{
 				Type:               ngrokv1alpha1.KubernetesOperatorConditionDraining,
@@ -107,13 +103,11 @@ func TestStateChecker_DeletionTimestampWithoutStatus(t *testing.T) {
 
 	now := metav1.NewTime(time.Now())
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "my-release",
-			Namespace:         "ngrok-operator",
-			DeletionTimestamp: &now,
-			Finalizers:        []string{"test-finalizer"},
-		},
-		Spec: ngrokv1alpha1.KubernetesOperatorSpec{},
+		Name:              "my-release",
+		Namespace:         "ngrok-operator",
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"test-finalizer"},
+		Spec:              ngrokv1alpha1.KubernetesOperatorSpec{},
 		// Status.Conditions has no Draining condition
 	}
 
@@ -149,11 +143,9 @@ func TestStateChecker_CachesDrainingState(t *testing.T) {
 	require.NoError(t, ngrokv1alpha1.AddToScheme(scheme))
 
 	ko := &ngrokv1alpha1.KubernetesOperator{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-release",
-			Namespace: "ngrok-operator",
-		},
-		Spec: ngrokv1alpha1.KubernetesOperatorSpec{},
+		Name:      "my-release",
+		Namespace: "ngrok-operator",
+		Spec:      ngrokv1alpha1.KubernetesOperatorSpec{},
 		Status: ngrokv1alpha1.KubernetesOperatorStatus{
 			Conditions: []metav1.Condition{{
 				Type:               ngrokv1alpha1.KubernetesOperatorConditionDraining,

--- a/internal/ngrokapi/bindingendpoint_aggregator.go
+++ b/internal/ngrokapi/bindingendpoint_aggregator.go
@@ -75,10 +75,8 @@ func AggregateBindingEndpoints(ctx context.Context, endpoints []ngrok.Endpoint) 
 
 		// add the found endpoint to the list of endpoints
 		bindingEndpoint.Status.Endpoints = append(bindingEndpoint.Status.Endpoints, bindingsv1alpha1.BindingEndpoint{
-			Ref: ngrok.Ref{
-				ID:  endpoint.ID,
-				URI: endpoint.URI,
-			},
+			ID:  endpoint.ID,
+			URI: endpoint.URI,
 		})
 
 		// update the aggregated map

--- a/internal/ngrokapi/bindingendpoint_aggregator_test.go
+++ b/internal/ngrokapi/bindingendpoint_aggregator_test.go
@@ -77,7 +77,7 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: ngrok.Ref{ID: "ep_123"}},
+							{ID: "ep_123"},
 						},
 					},
 				},
@@ -110,7 +110,7 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: ngrok.Ref{ID: "ep_good"}},
+							{ID: "ep_good"},
 						},
 					},
 				},
@@ -153,9 +153,9 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: ngrok.Ref{ID: "ep_100"}},
-							{Ref: ngrok.Ref{ID: "ep_101"}},
-							{Ref: ngrok.Ref{ID: "ep_102"}},
+							{ID: "ep_100"},
+							{ID: "ep_101"},
+							{ID: "ep_102"},
 						},
 					},
 				},
@@ -172,8 +172,8 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: ngrok.Ref{ID: "ep_200"}},
-							{Ref: ngrok.Ref{ID: "ep_201"}},
+							{ID: "ep_200"},
+							{ID: "ep_201"},
 						},
 					},
 				},
@@ -190,7 +190,7 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: ngrok.Ref{ID: "ep_300"}},
+							{ID: "ep_300"},
 						},
 					},
 				},
@@ -207,7 +207,7 @@ func Test_AggregateBindingEndpoints(t *testing.T) {
 					},
 					Status: bindingsv1alpha1.BoundEndpointStatus{
 						Endpoints: []bindingsv1alpha1.BindingEndpoint{
-							{Ref: ngrok.Ref{ID: "ep_400"}},
+							{ID: "ep_400"},
 						},
 					},
 				},

--- a/internal/resolvers/ip_policy_test.go
+++ b/internal/resolvers/ip_policy_test.go
@@ -5,7 +5,6 @@ import (
 
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -25,10 +24,8 @@ func TestDefaultIPPolicyResolver(t *testing.T) {
 	utilruntime.Must(ingressv1alpha1.AddToScheme(scheme))
 	objects := []runtime.Object{
 		&ingressv1alpha1.IPPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "namespace",
-				Name:      "my-ip-policy",
-			},
+			Namespace: "namespace",
+			Name:      "my-ip-policy",
 			Spec: ingressv1alpha1.IPPolicySpec{
 				Rules: []ingressv1alpha1.IPPolicyRule{},
 			},

--- a/internal/resolvers/secret_test.go
+++ b/internal/resolvers/secret_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -23,10 +22,8 @@ func TestDefaultSecretResolver(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "namespace",
-			Name:      "name",
-		},
+		Namespace: "namespace",
+		Name:      "name",
 		Data: map[string][]byte{
 			"key": []byte("secret-value"),
 		},

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -575,28 +575,26 @@ var _ = Describe("Store", func() {
 			multiRuleIngress.Spec.Rules = []netv1.IngressRule{
 				{
 					Host: "test1.com",
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path: "/",
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "test-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 80,
-											},
+					HTTP: &netv1.HTTPIngressRuleValue{
+						Paths: []netv1.HTTPIngressPath{
+							{
+								Path: "/",
+								Backend: netv1.IngressBackend{
+									Service: &netv1.IngressServiceBackend{
+										Name: "test-service",
+										Port: netv1.ServiceBackendPort{
+											Number: 80,
 										},
 									},
 								},
-								{
-									Path: "/api",
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "api-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 80,
-											},
+							},
+							{
+								Path: "/api",
+								Backend: netv1.IngressBackend{
+									Service: &netv1.IngressServiceBackend{
+										Name: "api-service",
+										Port: netv1.ServiceBackendPort{
+											Number: 80,
 										},
 									},
 								},
@@ -606,17 +604,15 @@ var _ = Describe("Store", func() {
 				},
 				{
 					Host: "test2.com",
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path: "/",
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "test-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 80,
-											},
+					HTTP: &netv1.HTTPIngressRuleValue{
+						Paths: []netv1.HTTPIngressPath{
+							{
+								Path: "/",
+								Backend: netv1.IngressBackend{
+									Service: &netv1.IngressServiceBackend{
+										Name: "test-service",
+										Port: netv1.ServiceBackendPort{
+											Number: 80,
 										},
 									},
 								},
@@ -704,16 +700,14 @@ var _ = Describe("Store", func() {
 				ing.Spec.Rules = []netv1.IngressRule{
 					{
 						Host: "a-hostname.com",
-						IngressRuleValue: netv1.IngressRuleValue{
-							HTTP: &netv1.HTTPIngressRuleValue{
-								Paths: []netv1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: netv1.IngressBackend{
-											Service: &netv1.IngressServiceBackend{
-												Name: "test-service",
-												Port: netv1.ServiceBackendPort{Number: 80},
-											},
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "test-service",
+											Port: netv1.ServiceBackendPort{Number: 80},
 										},
 									},
 								},
@@ -722,16 +716,14 @@ var _ = Describe("Store", func() {
 					},
 					{
 						Host: "", // Missing hostname
-						IngressRuleValue: netv1.IngressRuleValue{
-							HTTP: &netv1.HTTPIngressRuleValue{
-								Paths: []netv1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: netv1.IngressBackend{
-											Service: &netv1.IngressServiceBackend{
-												Name: "test-service",
-												Port: netv1.ServiceBackendPort{Number: 80},
-											},
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "test-service",
+											Port: netv1.ServiceBackendPort{Number: 80},
 										},
 									},
 								},

--- a/internal/testutils/k8s-resources.go
+++ b/internal/testutils/k8s-resources.go
@@ -20,11 +20,9 @@ import (
 
 func NewTestIngressClass(name string, isDefault bool, isNgrok bool) *netv1.IngressClass {
 	i := netv1.IngressClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"app.kubernetes.io/component": "controller",
-			},
+		Name: name,
+		Labels: map[string]string{
+			"app.kubernetes.io/component": "controller",
 		},
 	}
 
@@ -55,17 +53,15 @@ func NewTestIngressV1WithHosts(name string, namespace string, hosts ...string) *
 	for _, host := range hosts {
 		rules = append(rules, netv1.IngressRule{
 			Host: host,
-			IngressRuleValue: netv1.IngressRuleValue{
-				HTTP: &netv1.HTTPIngressRuleValue{
-					Paths: []netv1.HTTPIngressPath{
-						{
-							Path: "/",
-							Backend: netv1.IngressBackend{
-								Service: &netv1.IngressServiceBackend{
-									Name: "example",
-									Port: netv1.ServiceBackendPort{
-										Number: 80,
-									},
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
+					{
+						Path: "/",
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Name: "example",
+								Port: netv1.ServiceBackendPort{
+									Number: 80,
 								},
 							},
 						},
@@ -75,10 +71,8 @@ func NewTestIngressV1WithHosts(name string, namespace string, hosts ...string) *
 		})
 	}
 	return &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: netv1.IngressSpec{
 			Rules: rules,
 		},
@@ -91,10 +85,8 @@ func NewTestIngressV1(name string, namespace string) *netv1.Ingress {
 
 func NewTestServiceV1(name string, namespace string) *corev1.Service {
 	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
@@ -128,10 +120,8 @@ func WithDomainReadyCondition(status metav1.ConditionStatus, message string) Dom
 
 func NewDomainV1(name string, namespace string, opts ...DomainOpt) *ingressv1alpha1.Domain {
 	d := &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ingressv1alpha1.HyphenatedDomainNameFromURL(name),
-			Namespace: namespace,
-		},
+		Name:      ingressv1alpha1.HyphenatedDomainNameFromURL(name),
+		Namespace: namespace,
 		Spec: ingressv1alpha1.DomainSpec{
 			Domain: name,
 		},
@@ -162,9 +152,7 @@ func NewGatewayClass(isManaged bool) *gatewayv1.GatewayClass {
 		controllerName = "k8s.io/some-other-controller"
 	}
 	return &gatewayv1.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: RandomName("gateway-class"),
-		},
+		Name: RandomName("gateway-class"),
 		Spec: gatewayv1.GatewayClassSpec{
 			ControllerName: controllerName,
 		},
@@ -173,10 +161,8 @@ func NewGatewayClass(isManaged bool) *gatewayv1.GatewayClass {
 
 func NewGateway(name string, namespace string) gatewayv1.Gateway {
 	return gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: gatewayv1.GatewaySpec{
 			GatewayClassName: "test-gatewayclass",
 			Listeners: []gatewayv1.Listener{
@@ -205,10 +191,8 @@ func NewGatewayWithHostnames(name string, namespace string, hostnames ...string)
 	}
 
 	return &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: gatewayv1.GatewaySpec{
 			GatewayClassName: "ngrok",
 			Listeners:        listeners,
@@ -218,10 +202,8 @@ func NewGatewayWithHostnames(name string, namespace string, hostnames ...string)
 
 func NewHTTPRoute(name string, namespace string) gatewayv1.HTTPRoute {
 	return gatewayv1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: gatewayv1.HTTPRouteSpec{
 			Rules: []gatewayv1.HTTPRouteRule{
 				{
@@ -241,19 +223,15 @@ func NewHTTPRoute(name string, namespace string) gatewayv1.HTTPRoute {
 
 func NewTLSRoute(name string, namespace string) gatewayv1alpha2.TLSRoute {
 	return gatewayv1alpha2.TLSRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: gatewayv1alpha2.TLSRouteSpec{
 			Rules: []gatewayv1alpha2.TLSRouteRule{
 				{
 					BackendRefs: []gatewayv1alpha2.BackendRef{
 						{
-							BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-								Name: "test-service",
-								Port: ptr.To(gatewayv1.PortNumber(8000)),
-							},
+							Name: "test-service",
+							Port: ptr.To(gatewayv1.PortNumber(8000)),
 						},
 					},
 				},
@@ -264,19 +242,15 @@ func NewTLSRoute(name string, namespace string) gatewayv1alpha2.TLSRoute {
 
 func NewTCPRoute(name string, namespace string) gatewayv1alpha2.TCPRoute {
 	return gatewayv1alpha2.TCPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: gatewayv1alpha2.TCPRouteSpec{
 			Rules: []gatewayv1alpha2.TCPRouteRule{
 				{
 					BackendRefs: []gatewayv1alpha2.BackendRef{
 						{
-							BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-								Name: "tcp-service",
-								Port: ptr.To(gatewayv1.PortNumber(8000)),
-							},
+							Name: "tcp-service",
+							Port: ptr.To(gatewayv1.PortNumber(8000)),
 						},
 					},
 				},
@@ -287,10 +261,8 @@ func NewTCPRoute(name string, namespace string) gatewayv1alpha2.TCPRoute {
 
 func NewReferenceGrant(name string, namespace string) gatewayv1beta1.ReferenceGrant {
 	return gatewayv1beta1.ReferenceGrant{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: gatewayv1beta1.ReferenceGrantSpec{
 			From: []gatewayv1beta1.ReferenceGrantFrom{
 				{
@@ -311,10 +283,8 @@ func NewReferenceGrant(name string, namespace string) gatewayv1beta1.ReferenceGr
 
 func NewTestNgrokTrafficPolicy(name string, namespace string, policyStr string) ngrokv1alpha1.NgrokTrafficPolicy {
 	return ngrokv1alpha1.NgrokTrafficPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 			Policy: json.RawMessage(policyStr),
 		},
@@ -331,10 +301,8 @@ type CloudEndpointOpt func(*ngrokv1alpha1.CloudEndpoint)
 //	NewCloudEndpoint
 func NewCloudEndpoint(opts ...CloudEndpointOpt) *ngrokv1alpha1.CloudEndpoint {
 	clep := &ngrokv1alpha1.CloudEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      RandomName("cloud-endpoint"),
-			Namespace: RandomName("namespace"),
-		},
+		Name:      RandomName("cloud-endpoint"),
+		Namespace: RandomName("namespace"),
 		Spec: ngrokv1alpha1.CloudEndpointSpec{
 			URL: RandomName("url"),
 		},
@@ -349,10 +317,8 @@ type AgentEndpointOpt func(*ngrokv1alpha1.AgentEndpoint)
 
 func NewAgentEndpoint(opts ...AgentEndpointOpt) *ngrokv1alpha1.AgentEndpoint {
 	aep := &ngrokv1alpha1.AgentEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      RandomName("agent-endpoint"),
-			Namespace: RandomName("namespace"),
-		},
+		Name:      RandomName("agent-endpoint"),
+		Namespace: RandomName("namespace"),
 		Spec: ngrokv1alpha1.AgentEndpointSpec{
 			URL: RandomURL(),
 		},

--- a/internal/testutils/kginkgo.go
+++ b/internal/testutils/kginkgo.go
@@ -127,9 +127,7 @@ func (k *KGinkgo) ExpectCreateNamespace(ctx context.Context, name string) {
 	GinkgoHelper()
 
 	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
+		Name: name,
 	}
 	Expect(k.client.Create(ctx, ns)).To(Succeed())
 }
@@ -147,9 +145,7 @@ func (k *KGinkgo) ExpectDeleteNamespace(ctx context.Context, name string) {
 	GinkgoHelper()
 
 	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
+		Name: name,
 	}
 	err := k.client.Delete(ctx, ns)
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/internal/trafficpolicy/manager_test.go
+++ b/internal/trafficpolicy/manager_test.go
@@ -64,11 +64,9 @@ func (c errClient) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _
 
 func newAgentEndpoint(namespace string, cfg *ngrokv1alpha1.TrafficPolicyCfg) *ngrokv1alpha1.AgentEndpoint {
 	return &ngrokv1alpha1.AgentEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-aep",
-			Namespace:  namespace,
-			Generation: 7,
-		},
+		Name:       "test-aep",
+		Namespace:  namespace,
+		Generation: 7,
 		Spec: ngrokv1alpha1.AgentEndpointSpec{
 			URL:           "tcp://1.tcp.ngrok.io:1234",
 			TrafficPolicy: cfg,
@@ -78,10 +76,8 @@ func newAgentEndpoint(namespace string, cfg *ngrokv1alpha1.TrafficPolicyCfg) *ng
 
 func newPolicy(name, namespace, body string) *ngrokv1alpha1.NgrokTrafficPolicy {
 	return &ngrokv1alpha1.NgrokTrafficPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 		Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 			Policy: json.RawMessage(body),
 		},

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -11,7 +11,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,19 +23,15 @@ func TestToClientObjects(t *testing.T) {
 
 	s = []ingressv1alpha1.Domain{
 		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: "default",
-			},
+			Name:      "test",
+			Namespace: "default",
 			Spec: ingressv1alpha1.DomainSpec{
 				Domain: "test.ngrok.io",
 			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test2",
-				Namespace: "other",
-			},
+			Name:      "test2",
+			Namespace: "other",
 			Spec: ingressv1alpha1.DomainSpec{
 				Domain: "test.ngrok.io",
 			},
@@ -96,13 +91,9 @@ func Test_ObjNameFuncs(t *testing.T) {
 		{
 			name: "configmap",
 			obj: &v1.ConfigMap{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "ConfigMap",
-					APIVersion: "v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-cm",
-				},
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+				Name:       "my-cm",
 			},
 			wants: []fnTest{
 				{fn: ObjToName, want: "my-cm"},
@@ -115,13 +106,9 @@ func Test_ObjNameFuncs(t *testing.T) {
 		{
 			name: "job",
 			obj: &batchv1.Job{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Job",
-					APIVersion: "batch/v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-job",
-				},
+				Kind:       "Job",
+				APIVersion: "batch/v1",
+				Name:       "my-job",
 			},
 			wants: []fnTest{
 				{fn: ObjToName, want: "my-job"},
@@ -134,13 +121,9 @@ func Test_ObjNameFuncs(t *testing.T) {
 		{
 			name: "custom",
 			obj: &v1.ConfigMap{ // use a configmap, but change the type meta
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "CustomObject",
-					APIVersion: "k8s.ngrok.com/v1beta1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-obj",
-				},
+				Kind:       "CustomObject",
+				APIVersion: "k8s.ngrok.com/v1beta1",
+				Name:       "my-obj",
 			},
 			wants: []fnTest{
 				{fn: ObjToName, want: "my-obj"},
@@ -178,54 +161,42 @@ func TestHasFinalizer(t *testing.T) {
 		{
 			name: "different finalizer",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{"other.finalizer"},
-				},
+				Finalizers: []string{"other.finalizer"},
 			},
 			want: false,
 		},
 		{
 			name: "has new finalizer",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{FinalizerName},
-				},
+				Finalizers: []string{FinalizerName},
 			},
 			want: true,
 		},
 		{
 			name: "has legacy finalizer",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{LegacyFinalizerName},
-				},
+				Finalizers: []string{LegacyFinalizerName},
 			},
 			want: true,
 		},
 		{
 			name: "has both finalizers",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{FinalizerName, LegacyFinalizerName},
-				},
+				Finalizers: []string{FinalizerName, LegacyFinalizerName},
 			},
 			want: true,
 		},
 		{
 			name: "has new finalizer among others",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{"other.finalizer", FinalizerName, "another.finalizer"},
-				},
+				Finalizers: []string{"other.finalizer", FinalizerName, "another.finalizer"},
 			},
 			want: true,
 		},
 		{
 			name: "has legacy finalizer among others",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{"other.finalizer", LegacyFinalizerName, "another.finalizer"},
-				},
+				Finalizers: []string{"other.finalizer", LegacyFinalizerName, "another.finalizer"},
 			},
 			want: true,
 		},
@@ -259,9 +230,7 @@ func TestAddFinalizer(t *testing.T) {
 		{
 			name: "add to existing",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{"other.finalizer"},
-				},
+				Finalizers: []string{"other.finalizer"},
 			},
 			wantAdded:         true,
 			wantLegacyPresent: true,
@@ -270,9 +239,7 @@ func TestAddFinalizer(t *testing.T) {
 		{
 			name: "legacy already present",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{LegacyFinalizerName},
-				},
+				Finalizers: []string{LegacyFinalizerName},
 			},
 			wantAdded:         false,
 			wantLegacyPresent: true,
@@ -281,9 +248,7 @@ func TestAddFinalizer(t *testing.T) {
 		{
 			name: "new finalizer already present from prior R2 reconcile",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{FinalizerName},
-				},
+				Finalizers: []string{FinalizerName},
 			},
 			// R1 still wants the legacy key on the object, so the add
 			// returns true even though HasFinalizer was already true.
@@ -319,9 +284,7 @@ func TestRemoveFinalizer(t *testing.T) {
 		{
 			name: "remove when new present",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{FinalizerName},
-				},
+				Finalizers: []string{FinalizerName},
 			},
 			wantRemoved: true,
 			wantPresent: false,
@@ -329,9 +292,7 @@ func TestRemoveFinalizer(t *testing.T) {
 		{
 			name: "remove when legacy present",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{LegacyFinalizerName},
-				},
+				Finalizers: []string{LegacyFinalizerName},
 			},
 			wantRemoved: true,
 			wantPresent: false,
@@ -339,9 +300,7 @@ func TestRemoveFinalizer(t *testing.T) {
 		{
 			name: "remove when both present",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{FinalizerName, LegacyFinalizerName},
-				},
+				Finalizers: []string{FinalizerName, LegacyFinalizerName},
 			},
 			wantRemoved: true,
 			wantPresent: false,
@@ -349,9 +308,7 @@ func TestRemoveFinalizer(t *testing.T) {
 		{
 			name: "remove when not present",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{"other.finalizer"},
-				},
+				Finalizers: []string{"other.finalizer"},
 			},
 			wantRemoved: false,
 			wantPresent: false,
@@ -359,9 +316,7 @@ func TestRemoveFinalizer(t *testing.T) {
 		{
 			name: "remove from multiple with new",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{"other.finalizer", FinalizerName, "another.finalizer"},
-				},
+				Finalizers: []string{"other.finalizer", FinalizerName, "another.finalizer"},
 			},
 			wantRemoved: true,
 			wantPresent: false,
@@ -369,9 +324,7 @@ func TestRemoveFinalizer(t *testing.T) {
 		{
 			name: "remove from multiple with legacy",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{"other.finalizer", LegacyFinalizerName, "another.finalizer"},
-				},
+				Finalizers: []string{"other.finalizer", LegacyFinalizerName, "another.finalizer"},
 			},
 			wantRemoved: true,
 			wantPresent: false,
@@ -400,10 +353,8 @@ func TestRegisterAndSyncFinalizer(t *testing.T) {
 		{
 			name: "add finalizer to object without one",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-ingress",
-					Namespace: "default",
-				},
+				Name:      "test-ingress",
+				Namespace: "default",
 			},
 			wantErr:       false,
 			wantFinalizer: true,
@@ -412,11 +363,9 @@ func TestRegisterAndSyncFinalizer(t *testing.T) {
 		{
 			name: "object already has legacy finalizer",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-ingress",
-					Namespace:  "default",
-					Finalizers: []string{LegacyFinalizerName},
-				},
+				Name:       "test-ingress",
+				Namespace:  "default",
+				Finalizers: []string{LegacyFinalizerName},
 			},
 			wantErr:       false,
 			wantFinalizer: true,
@@ -463,11 +412,9 @@ func TestRemoveAndSyncFinalizer(t *testing.T) {
 		{
 			name: "remove new finalizer from object with one",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-ingress",
-					Namespace:  "default",
-					Finalizers: []string{FinalizerName},
-				},
+				Name:       "test-ingress",
+				Namespace:  "default",
+				Finalizers: []string{FinalizerName},
 			},
 			wantErr:       false,
 			wantFinalizer: false,
@@ -475,11 +422,9 @@ func TestRemoveAndSyncFinalizer(t *testing.T) {
 		{
 			name: "remove legacy finalizer from object with one",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-ingress",
-					Namespace:  "default",
-					Finalizers: []string{LegacyFinalizerName},
-				},
+				Name:       "test-ingress",
+				Namespace:  "default",
+				Finalizers: []string{LegacyFinalizerName},
 			},
 			wantErr:       false,
 			wantFinalizer: false,
@@ -487,10 +432,8 @@ func TestRemoveAndSyncFinalizer(t *testing.T) {
 		{
 			name: "remove finalizer from object without one",
 			obj: &netv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-ingress",
-					Namespace: "default",
-				},
+				Name:      "test-ingress",
+				Namespace: "default",
 			},
 			wantErr:       false,
 			wantFinalizer: false,

--- a/internal/util/traffic_policy_test.go
+++ b/internal/util/traffic_policy_test.go
@@ -213,7 +213,7 @@ func TestToCRDJson(t *testing.T) {
 					PhaseOnHttpRequest: {[]byte(`ngrok is built to deliver applications and APIs with  zero networking configuration and zero hardware`)},
 				},
 			},
-			expectedErr: errors.New(`json: error calling MarshalJSON for type json.RawMessage: invalid character 'g' in literal null (expecting 'u')`),
+			expectedErr: errors.New(`json: error calling MarshalJSON for type *jsontext.Value: invalid character 'g' in literal null (expecting 'u')`),
 		},
 	}
 
@@ -484,7 +484,7 @@ func TestMergeEndpointRule(t *testing.T) {
 			addedPhase: PhaseOnHttpRequest,
 			// original traffic policy should be unaffected
 			expectedMergedTrafficPolicy: *newBaseTrafficPolicy(t, nil),
-			expectedErr:                 errors.New("json: error calling MarshalJSON for type json.RawMessage: invalid character 'i' looking for beginning of value"),
+			expectedErr:                 errors.New("json: error calling MarshalJSON for type *jsontext.Value: invalid character 'i' looking for beginning of value"),
 		},
 	}
 

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -2034,6 +2034,7 @@ rules:
   - patch
   - update
   - watch
+
 ---
 # Source: ngrok-operator/templates/api-manager/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2934,6 +2935,7 @@ rules:
   - get
   - list
   - watch
+
 ---
 # Source: ngrok-operator/templates/api-manager/leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2973,6 +2975,7 @@ rules:
   verbs:
   - create
   - patch
+
 ---
 # Source: ngrok-operator/templates/api-manager/release-namespace-role.yaml
 # Operator-state RBAC: rules the api-manager needs that are tied to the
@@ -3035,6 +3038,7 @@ rules:
   - get
   - patch
   - update
+
 ---
 # Source: ngrok-operator/templates/agent/release-namespace-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3334,6 +3338,7 @@ metadata:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+
 ---
 # Source: ngrok-operator/templates/cleanup-hook/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3362,6 +3367,7 @@ rules:
       - list
       - watch
       - delete
+
 ---
 # Source: ngrok-operator/templates/cleanup-hook/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/managerdriver/domains.go
+++ b/pkg/managerdriver/domains.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ngrok/ngrok-operator/internal/util"
 	"golang.org/x/sync/errgroup"
 	netv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -34,10 +33,8 @@ func ingressToDomains(in *netv1.Ingress, newDomainMetadata string, existingDomai
 		}
 
 		domain := ingressv1alpha1.Domain{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      ingressv1alpha1.HyphenatedDomainNameFromURL(domainName),
-				Namespace: in.Namespace,
-			},
+			Name:      ingressv1alpha1.HyphenatedDomainNameFromURL(domainName),
+			Namespace: in.Namespace,
 			Spec: ingressv1alpha1.DomainSpec{
 				Domain: domainName,
 				// LEGACY-metadata-format: operator-generated objects keep writing
@@ -73,10 +70,8 @@ func gatewayToDomains(in *gatewayv1.Gateway, newDomainMetadata string, existingD
 		}
 
 		domain := ingressv1alpha1.Domain{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      ingressv1alpha1.HyphenatedDomainNameFromURL(domainName),
-				Namespace: in.Namespace,
-			},
+			Name:      ingressv1alpha1.HyphenatedDomainNameFromURL(domainName),
+			Namespace: in.Namespace,
 			Spec: ingressv1alpha1.DomainSpec{
 				Domain: domainName,
 				// LEGACY-metadata-format: operator-generated objects keep writing
@@ -98,10 +93,8 @@ func (d *Driver) applyDomains(ctx context.Context, c client.Client, desiredDomai
 	for _, desiredDomain := range desiredDomains {
 		g.Go(func() error {
 			domain := &ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      desiredDomain.Name,
-					Namespace: desiredDomain.Namespace,
-				},
+				Name:      desiredDomain.Name,
+				Namespace: desiredDomain.Namespace,
 			}
 
 			res, err := controllerutil.CreateOrPatch(ctx, c, domain, func() error {

--- a/pkg/managerdriver/domains_backfill_test.go
+++ b/pkg/managerdriver/domains_backfill_test.go
@@ -34,13 +34,11 @@ func TestApplyDomains_BackfillsLegacyOnlyDomain(t *testing.T) {
 	require.NoError(t, ingressv1alpha1.AddToScheme(scheme))
 
 	existing := &ingressv1alpha1.Domain{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      domainName,
-			Namespace: "default",
-			Labels: map[string]string{
-				labels.LegacyControllerName:      controllerName,
-				labels.LegacyControllerNamespace: controllerNamespace,
-			},
+		Name:      domainName,
+		Namespace: "default",
+		Labels: map[string]string{
+			labels.LegacyControllerName:      controllerName,
+			labels.LegacyControllerNamespace: controllerNamespace,
 		},
 		Spec: ingressv1alpha1.DomainSpec{Domain: "example.com"},
 	}

--- a/pkg/managerdriver/domains_test.go
+++ b/pkg/managerdriver/domains_test.go
@@ -155,10 +155,8 @@ func TestGatewayToDomains_SkipsExistingDomains(t *testing.T) {
 
 func TestIngressToDomains_SkipsEmptyHost(t *testing.T) {
 	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-ingress",
-			Namespace: "test-namespace",
-		},
+		Name:      "test-ingress",
+		Namespace: "test-namespace",
 		Spec: netv1.IngressSpec{
 			Rules: []netv1.IngressRule{
 				{Host: ""},
@@ -176,10 +174,8 @@ func TestIngressToDomains_SkipsEmptyHost(t *testing.T) {
 
 func TestGatewayToDomains_SkipsNilHostname(t *testing.T) {
 	gateway := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-gateway",
-			Namespace: "test-namespace",
-		},
+		Name:      "test-gateway",
+		Namespace: "test-namespace",
 		Spec: gatewayv1.GatewaySpec{
 			Listeners: []gatewayv1.Listener{
 				{Name: "no-hostname", Hostname: nil},

--- a/pkg/managerdriver/driver_test.go
+++ b/pkg/managerdriver/driver_test.go
@@ -254,18 +254,16 @@ var _ = Describe("Driver", func() {
 					i.Spec.Rules = []netv1.IngressRule{
 						{
 							Host: "foo.ngrok.io",
-							IngressRuleValue: netv1.IngressRuleValue{
-								HTTP: &netv1.HTTPIngressRuleValue{
-									Paths: []netv1.HTTPIngressPath{
-										{
-											Path:     "/",
-											PathType: ptr.To(netv1.PathTypePrefix),
-											Backend: netv1.IngressBackend{
-												Service: &netv1.IngressServiceBackend{
-													Name: s.Name,
-													Port: netv1.ServiceBackendPort{
-														Name: s.Spec.Ports[0].Name,
-													},
+							HTTP: &netv1.HTTPIngressRuleValue{
+								Paths: []netv1.HTTPIngressPath{
+									{
+										Path:     "/",
+										PathType: ptr.To(netv1.PathTypePrefix),
+										Backend: netv1.IngressBackend{
+											Service: &netv1.IngressServiceBackend{
+												Name: s.Name,
+												Port: netv1.ServiceBackendPort{
+													Name: s.Spec.Ports[0].Name,
 												},
 											},
 										},
@@ -279,10 +277,8 @@ var _ = Describe("Driver", func() {
 
 			BeforeEach(func() {
 				httpService = &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "http-service",
-						Namespace: namespace,
-					},
+					Name:      "http-service",
+					Namespace: namespace,
 					Spec: v1.ServiceSpec{
 						Ports: []v1.ServicePort{
 							{
@@ -294,12 +290,10 @@ var _ = Describe("Driver", func() {
 					},
 				}
 				httpsService = &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "https-service",
-						Namespace: namespace,
-						Annotations: map[string]string{
-							"k8s.ngrok.com/app-protocols": `{"https": "https"}`,
-						},
+					Name:      "https-service",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"k8s.ngrok.com/app-protocols": `{"https": "https"}`,
 					},
 					Spec: v1.ServiceSpec{
 						Ports: []v1.ServicePort{
@@ -312,11 +306,9 @@ var _ = Describe("Driver", func() {
 					},
 				}
 				ingress = &netv1.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "test-ingress",
-						Namespace:   namespace,
-						Annotations: map[string]string{"k8s.ngrok.com/mapping-strategy": "edges"},
-					},
+					Name:        "test-ingress",
+					Namespace:   namespace,
+					Annotations: map[string]string{"k8s.ngrok.com/mapping-strategy": "edges"},
 					Spec: netv1.IngressSpec{
 						IngressClassName: &ic.Name,
 						Rules:            []netv1.IngressRule{},
@@ -493,20 +485,16 @@ var _ = Describe("Driver", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				trafficPolicy = &ngrokv1alpha1.NgrokTrafficPolicy{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-policy",
-						Namespace: namespace,
-					},
+					Name:      "test-policy",
+					Namespace: namespace,
 					Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 
 						Policy: rawPolicy,
 					},
 				}
 				httpService = &v1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "http-service",
-						Namespace: namespace,
-					},
+					Name:      "http-service",
+					Namespace: namespace,
 					Spec: v1.ServiceSpec{
 						Ports: []v1.ServicePort{
 							{
@@ -518,27 +506,23 @@ var _ = Describe("Driver", func() {
 					},
 				}
 				ingress = &netv1.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-ingress",
-						Namespace: namespace,
-					},
+					Name:      "test-ingress",
+					Namespace: namespace,
 					Spec: netv1.IngressSpec{
 						IngressClassName: &ic.Name,
 						Rules: []netv1.IngressRule{
 							{
 								Host: "foo.ngrok.io",
-								IngressRuleValue: netv1.IngressRuleValue{
-									HTTP: &netv1.HTTPIngressRuleValue{
-										Paths: []netv1.HTTPIngressPath{
-											{
-												Path:     "/",
-												PathType: ptr.To(netv1.PathTypePrefix),
-												Backend: netv1.IngressBackend{
-													Service: &netv1.IngressServiceBackend{
-														Name: httpService.Name,
-														Port: netv1.ServiceBackendPort{
-															Name: httpService.Spec.Ports[0].Name,
-														},
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: ptr.To(netv1.PathTypePrefix),
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{
+													Name: httpService.Name,
+													Port: netv1.ServiceBackendPort{
+														Name: httpService.Spec.Ports[0].Name,
 													},
 												},
 											},
@@ -753,16 +737,14 @@ var _ = Describe("Driver", func() {
 				ingress.Spec.Rules = []netv1.IngressRule{
 					{
 						Host: "app.example.com",
-						IngressRuleValue: netv1.IngressRuleValue{
-							HTTP: &netv1.HTTPIngressRuleValue{
-								Paths: []netv1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: netv1.IngressBackend{
-											Service: &netv1.IngressServiceBackend{
-												Name: "example",
-												Port: netv1.ServiceBackendPort{Number: 80},
-											},
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "example",
+											Port: netv1.ServiceBackendPort{Number: 80},
 										},
 									},
 								},
@@ -771,16 +753,14 @@ var _ = Describe("Driver", func() {
 					},
 					{
 						Host: "service.namespace.internal",
-						IngressRuleValue: netv1.IngressRuleValue{
-							HTTP: &netv1.HTTPIngressRuleValue{
-								Paths: []netv1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: netv1.IngressBackend{
-											Service: &netv1.IngressServiceBackend{
-												Name: "example",
-												Port: netv1.ServiceBackendPort{Number: 80},
-											},
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "example",
+											Port: netv1.ServiceBackendPort{Number: 80},
 										},
 									},
 								},
@@ -819,16 +799,14 @@ var _ = Describe("Driver", func() {
 				ingress.Spec.Rules = []netv1.IngressRule{
 					{
 						Host: "foo.internal",
-						IngressRuleValue: netv1.IngressRuleValue{
-							HTTP: &netv1.HTTPIngressRuleValue{
-								Paths: []netv1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: netv1.IngressBackend{
-											Service: &netv1.IngressServiceBackend{
-												Name: "example",
-												Port: netv1.ServiceBackendPort{Number: 80},
-											},
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "example",
+											Port: netv1.ServiceBackendPort{Number: 80},
 										},
 									},
 								},
@@ -837,16 +815,14 @@ var _ = Describe("Driver", func() {
 					},
 					{
 						Host: "bar.internal",
-						IngressRuleValue: netv1.IngressRuleValue{
-							HTTP: &netv1.HTTPIngressRuleValue{
-								Paths: []netv1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: netv1.IngressBackend{
-											Service: &netv1.IngressServiceBackend{
-												Name: "example",
-												Port: netv1.ServiceBackendPort{Number: 80},
-											},
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "example",
+											Port: netv1.ServiceBackendPort{Number: 80},
 										},
 									},
 								},
@@ -912,9 +888,7 @@ var _ = Describe("Driver", func() {
 		}
 		newTestDomain := func(name, domain string, cnameTarget *string) ingressv1alpha1.Domain {
 			return ingressv1alpha1.Domain{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
+				Name: name,
 				Spec: ingressv1alpha1.DomainSpec{
 					Domain: domain,
 				},
@@ -968,9 +942,7 @@ var _ = Describe("Driver", func() {
 				ingress = testutils.NewTestIngressV1("test-ingress", "test-namespace")
 				domains = newTestDomainList(
 					ingressv1alpha1.Domain{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "example-com",
-						},
+						Name: "example-com",
 						Spec: ingressv1alpha1.DomainSpec{
 							Domain: "example.com",
 						},
@@ -1105,10 +1077,8 @@ var _ = Describe("Driver", func() {
 			namespace = "test"
 
 			policyCrd = &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-policy",
-					Namespace: namespace,
-				},
+				Name:      "test-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"on_http_request": [{"name":"t","actions":[{"type":"deny"}]}]}`),
 				},
@@ -1116,10 +1086,8 @@ var _ = Describe("Driver", func() {
 			Expect(driver.store.Add(policyCrd)).To(BeNil())
 
 			legacyPolicyCrd = &ngrokv1alpha1.NgrokTrafficPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "legacy-test-policy",
-					Namespace: namespace,
-				},
+				Name:      "legacy-test-policy",
+				Namespace: namespace,
 				Spec: ngrokv1alpha1.NgrokTrafficPolicySpec{
 					Policy: []byte(`{"inbound": [{"name":"t","actions":[{"type":"deny"}]}], "outbound": []}`),
 				},
@@ -1324,28 +1292,26 @@ var _ = Describe("Driver", func() {
 			i1.Spec.Rules = []netv1.IngressRule{
 				{
 					Host: "a.customdomain.com",
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path: "/",
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "test-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 80,
-											},
+					HTTP: &netv1.HTTPIngressRuleValue{
+						Paths: []netv1.HTTPIngressPath{
+							{
+								Path: "/",
+								Backend: netv1.IngressBackend{
+									Service: &netv1.IngressServiceBackend{
+										Name: "test-service",
+										Port: netv1.ServiceBackendPort{
+											Number: 80,
 										},
 									},
 								},
-								{
-									Path: "/api",
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "api-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 80,
-											},
+							},
+							{
+								Path: "/api",
+								Backend: netv1.IngressBackend{
+									Service: &netv1.IngressServiceBackend{
+										Name: "api-service",
+										Port: netv1.ServiceBackendPort{
+											Number: 80,
 										},
 									},
 								},
@@ -1355,17 +1321,15 @@ var _ = Describe("Driver", func() {
 				},
 				{
 					Host: "b.customdomain.com",
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path: "/b/",
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "b-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 80,
-											},
+					HTTP: &netv1.HTTPIngressRuleValue{
+						Paths: []netv1.HTTPIngressPath{
+							{
+								Path: "/b/",
+								Backend: netv1.IngressBackend{
+									Service: &netv1.IngressServiceBackend{
+										Name: "b-service",
+										Port: netv1.ServiceBackendPort{
+											Number: 80,
 										},
 									},
 								},
@@ -1382,17 +1346,15 @@ var _ = Describe("Driver", func() {
 			i2.Spec.Rules = []netv1.IngressRule{
 				{
 					Host: "c.customdomain.com",
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path: "/",
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "test-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 80,
-											},
+					HTTP: &netv1.HTTPIngressRuleValue{
+						Paths: []netv1.HTTPIngressPath{
+							{
+								Path: "/",
+								Backend: netv1.IngressBackend{
+									Service: &netv1.IngressServiceBackend{
+										Name: "test-service",
+										Port: netv1.ServiceBackendPort{
+											Number: 80,
 										},
 									},
 								},
@@ -1402,17 +1364,15 @@ var _ = Describe("Driver", func() {
 				},
 				{
 					Host: "d.customdomain.com",
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path: "/",
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "test-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 80,
-											},
+					HTTP: &netv1.HTTPIngressRuleValue{
+						Paths: []netv1.HTTPIngressPath{
+							{
+								Path: "/",
+								Backend: netv1.IngressBackend{
+									Service: &netv1.IngressServiceBackend{
+										Name: "test-service",
+										Port: netv1.ServiceBackendPort{
+											Number: 80,
 										},
 									},
 								},
@@ -1619,12 +1579,8 @@ var _ = Describe("Driver", func() {
 				{
 					BackendRefs: []gatewayv1.HTTPBackendRef{
 						{
-							BackendRef: gatewayv1.BackendRef{
-								BackendObjectReference: gatewayv1.BackendObjectReference{
-									Name: "example",
-									Port: ptr.To(gatewayv1.PortNumber(80)),
-								},
-							},
+							Name: "example",
+							Port: ptr.To(gatewayv1.PortNumber(80)),
 						},
 					},
 				},
@@ -1674,16 +1630,14 @@ var _ = Describe("Driver", func() {
 			albIngress.Spec.Rules = []netv1.IngressRule{
 				{
 					Host: "alb.example.com",
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path: "/",
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "alb-service",
-											Port: netv1.ServiceBackendPort{Number: 80},
-										},
+					HTTP: &netv1.HTTPIngressRuleValue{
+						Paths: []netv1.HTTPIngressPath{
+							{
+								Path: "/",
+								Backend: netv1.IngressBackend{
+									Service: &netv1.IngressServiceBackend{
+										Name: "alb-service",
+										Port: netv1.ServiceBackendPort{Number: 80},
 									},
 								},
 							},

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ngrok/ngrok-operator/internal/ir"
 	"github.com/ngrok/ngrok-operator/internal/store"
 	"github.com/ngrok/ngrok-operator/internal/trafficpolicy"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -288,7 +287,7 @@ func (t *translator) IRToEndpoints(irVHosts []*ir.IRVirtualHost) (cloudEndpoints
 			// Drop the `Policy` write in the cleanup release.
 			cloudEndpoint.Spec.TrafficPolicy = &ngrokv1alpha1.CloudEndpointTrafficPolicyCfg{
 				Inline: json.RawMessage(listenerPolicyJSON),
-				Policy: json.RawMessage(listenerPolicyJSON),
+				Policy: json.RawMessage(listenerPolicyJSON), //nolint:staticcheck // SA1019: deliberate legacy dual-write, see above
 			}
 			cloudEndpoints[types.NamespacedName{
 				Name:      cloudEndpoint.Name,
@@ -807,12 +806,10 @@ func buildCloudEndpoint(irVHost *ir.IRVirtualHost) (*ngrokv1alpha1.CloudEndpoint
 	}
 
 	return &ngrokv1alpha1.CloudEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        sanitizeStringForK8sName(name),
-			Namespace:   irVHost.Namespace,
-			Labels:      irVHost.LabelsToAdd,
-			Annotations: irVHost.AnnotationsToAdd,
-		},
+		Name:        sanitizeStringForK8sName(name),
+		Namespace:   irVHost.Namespace,
+		Labels:      irVHost.LabelsToAdd,
+		Annotations: irVHost.AnnotationsToAdd,
 		Spec: ngrokv1alpha1.CloudEndpointSpec{
 			URL:            publicURL,
 			PoolingEnabled: irVHost.EndpointPoolingEnabled,
@@ -858,12 +855,10 @@ func buildAgentEndpoint(
 	}
 
 	ret := &ngrokv1alpha1.AgentEndpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        internalAgentEndpointName(irService.UID, irService.Name, irService.Namespace, clusterDomain, irService.Port, irService.ClientCertRefs),
-			Namespace:   irService.Namespace,
-			Labels:      irVHost.LabelsToAdd,
-			Annotations: irVHost.AnnotationsToAdd,
-		},
+		Name:        internalAgentEndpointName(irService.UID, irService.Name, irService.Namespace, clusterDomain, irService.Port, irService.ClientCertRefs),
+		Namespace:   irService.Namespace,
+		Labels:      irVHost.LabelsToAdd,
+		Annotations: irVHost.AnnotationsToAdd,
 		Spec: ngrokv1alpha1.AgentEndpointSpec{
 			URL: url,
 			// LEGACY-metadata-format: operator-generated objects keep writing the

--- a/pkg/managerdriver/utils_test.go
+++ b/pkg/managerdriver/utils_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSanitizeStringForURL(t *testing.T) {
@@ -483,9 +482,8 @@ func TestGetProtoForServicePort(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-				Name: "svc", Namespace: "ns", Annotations: tc.annotations,
-			}}
+			svc := &corev1.Service{
+				Name: "svc", Namespace: "ns", Annotations: tc.annotations}
 			got, err := getProtoForServicePort(logr.Discard(), svc, "p", ir.IRProtocol_HTTP)
 			if tc.wantErr {
 				assert.Error(t, err)
@@ -512,7 +510,7 @@ func TestGetPortAppProtocol(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"}}
+			svc := &corev1.Service{Name: "svc", Namespace: "ns"}
 			port := &corev1.ServicePort{Name: "p", AppProtocol: tc.appProtocol}
 			assert.Equal(t, tc.want, getPortAppProtocol(logr.Discard(), svc, port))
 		})


### PR DESCRIPTION
## What

Golang 1.27 has been released.

## How
* Bump our nix flake
* Build tools with go1.27
* Add no-lint for places we have deprecated.

## Breaking Changes
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Developer Experience**
  - Updated the development environment and module support to Go 1.27.
  - Upgraded linting and supporting Go development tools for improved compatibility.

- **Bug Fixes**
  - Improved error classification and handling consistency.
  - Updated validation expectations for current JSON serialization behavior.

- **Maintenance**
  - Preserved compatibility coverage for legacy traffic-policy configurations.
  - Refined static-analysis annotations and formatting without changing runtime behavior.
  - Updated manifest formatting with no resource or configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->