### PR TITLE
docs: replace retired community Slack links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@
   <a href="#gateway-api-status">
     <img src="https://img.shields.io/badge/Gateway_API-supported-rgba(159%2C122%2C234)" alt="Gateway API Supported"/>
   </a>
-  <a href="https://ngrok.com/slack">
-    <img src="https://img.shields.io/badge/Join%20Our%20Community-Slack-blue" alt="Slack"/>
-  </a>
   <a href="https://twitter.com/intent/follow?screen_name=ngrokHQ">
     <img src="https://img.shields.io/twitter/follow/ngrokHQ.svg?style=social&label=Follow" alt="Twitter"/>
   </a>
@@ -110,7 +107,7 @@ For guidance on safely uninstalling the operator, including cleanup of ngrok API
 
 ## Support
 
-The best place to get support using the ngrok Kubernetes Operator is through the [ngrok Slack Community](https://ngrok.com/slack). If you find bugs or would like to contribute code, please follow the instructions in the [contributing guide](./docs/CONTRIBUTING.md).
+The best place to get support using the ngrok Kubernetes Operator is by [opening an issue](https://github.com/ngrok/ngrok-operator/issues). For account or billing questions, contact [ngrok support](https://ngrok.com/support). If you find bugs or would like to contribute code, please follow the instructions in the [contributing guide](./docs/CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
`https://ngrok.com/slack` returns a 404, as reported in #879. The README linked it twice: the "Join Our Community — Slack" badge at the top, and the Support section.

The community Slack was retired in 2024 — `ngrok.com/slack` served a "no longer using Slack for community feedback and support" notice for about two years, and that page has since been removed, leaving a bare 404. The community Discord that briefly replaced it is also gone, and `ngrok.com/discord` 404s as well.

This removes the badge and repoints Support at destinations that are actually staffed:

- this repo's issues, for questions and bugs about the operator
- `ngrok.com/support`, for account and billing questions

Same approach taken in ngrok/.github#4 and ngrok/ngrok-docs#960.

Fixes #879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Slack community badge from the README.
  * Updated support guidance to recommend opening a GitHub issue or contacting ngrok support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->