### PR TITLE
chore: Collapse temp-var-then-address into new(expr) at select sites

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -128,8 +128,7 @@ func ExtractUseEndpointPooling(obj client.Object) (*bool, error) {
 		return nil, err
 	}
 
-	result := strings.EqualFold(val, "true")
-	return &result, nil
+	return new(strings.EqualFold(val, "true")), nil
 }
 
 // Determines which traffic is allowed to reach an endpoint

--- a/internal/util/traffic_policy.go
+++ b/internal/util/traffic_policy.go
@@ -207,15 +207,13 @@ func (t *trafficPolicyImpl) mergeEnabled(incomingEnabled *bool) {
 	// original traffic policy had no enabled set, take on new value
 	if t.enabled == nil {
 		// don't want to copy the pointer, as the value will still be linked to a different policy
-		temp := *incomingEnabled
-		t.enabled = &temp
+		t.enabled = new(*incomingEnabled)
 		return
 	}
 
 	// both being set likely won't happen. However, if we have a mismatch, we should keep it enabled. Otherwise,
 	// we might accidentally turn off something important like auth.
-	resolvedEnabled := *t.enabled || *incomingEnabled
-	t.enabled = &resolvedEnabled
+	t.enabled = new(*t.enabled || *incomingEnabled)
 }
 
 // filterEnabled looks for a top level "enabled" in the json, removes it, and returns the value. For the module and gateway

--- a/pkg/managerdriver/translate_gatewayapi.go
+++ b/pkg/managerdriver/translate_gatewayapi.go
@@ -1129,8 +1129,7 @@ func (t *translator) httpRouteBackendToIR(httpRoute *gatewayv1.HTTPRoute, backen
 	}
 
 	if backendRef.Weight != nil {
-		weight := int(*backendRef.Weight)
-		destination.Weight = &weight
+		destination.Weight = new(int(*backendRef.Weight))
 	}
 
 	for _, filter := range backendRef.Filters {
@@ -1249,8 +1248,7 @@ func (t *translator) tcpBackendToIR(routeName string, routeNamespace string, rou
 	}
 
 	if backendRef.Weight != nil {
-		weight := int(*backendRef.Weight)
-		destination.Weight = &weight
+		destination.Weight = new(int(*backendRef.Weight))
 	}
 
 	if backendRef.Kind != nil && !strings.EqualFold(string(*backendRef.Kind), "Service") {
@@ -1408,7 +1406,6 @@ func (t *translator) gatewayTLSTermConfigToIR(listenerTLS *gatewayv1.ListenerTLS
 				fmt.Sprintf("%s.%s", string(certRef.Name), refNamespace),
 			)
 		}
-		privateKey := string(privateKeyData)
 
 		// Pull out the certificate (tls.crt)
 		certData, ok := secret.Data[corev1.TLSCertKey]
@@ -1417,10 +1414,8 @@ func (t *translator) gatewayTLSTermConfigToIR(listenerTLS *gatewayv1.ListenerTLS
 				fmt.Sprintf("%s.%s", string(certRef.Name), refNamespace),
 			)
 		}
-		cert := string(certData)
-
-		tlsTermCfg.ServerCertificate = &cert
-		tlsTermCfg.ServerPrivateKey = &privateKey
+		tlsTermCfg.ServerCertificate = new(string(certData))
+		tlsTermCfg.ServerPrivateKey = new(string(privateKeyData))
 	}
 
 	// Next, check if there is mTLS config at the gateway level (moved from per-listener in gateway-api v1.5+)

--- a/pkg/managerdriver/translator.go
+++ b/pkg/managerdriver/translator.go
@@ -434,8 +434,7 @@ func (t *translator) buildRoutingPolicy(irVHost *ir.IRVirtualHost, agentEndpoint
 			routeTotalWeight := 0
 			for _, irDestination := range irRoute.Destinations {
 				if irDestination.Weight == nil {
-					defaultWeight := 1
-					irDestination.Weight = &defaultWeight
+					irDestination.Weight = new(1)
 				}
 				routeTotalWeight += *irDestination.Weight
 			}


### PR DESCRIPTION
## What

Use Go's new(expr) to eliminate single-use temp variables that existed only to take their address, at 8 of the 9 candidate sites (plus one adjacent site found during review):

## How

- internal/util/traffic_policy.go: mergeEnabled's two temp/pointer pairs
- internal/annotations/annotations.go: ExtractUseEndpointPooling result
- pkg/managerdriver/translator.go: default weight of 1
- pkg/managerdriver/translate_gatewayapi.go: backendRef weight (x2), TLS server certificate, and TLS server private key (the last found during review as the untouched twin of the certificate conversion; verified privateKey is read exactly once, purely to take its address, and string(...) is a pure conversion so inlining across the earlier early-return is safe)

Left unchanged (temp var kept) with reasons:
- translator.go:160 (svcKey/CollapseIntoServiceKey): svcKey is read twice (map lookup, then address-of), not "used exactly once for its address", so collapsing would require duplicating the Service.Key() call or provide no benefit.
- translator.go:476/479 (weightedRouteExpression, both branches of an if/else): the else-branch fmt.Sprintf is long enough that collapsing it into new(...) would blow past a sane line length; left both branches as temp vars for consistency between the if/else arms.

## Breaking Changes
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal handling of boolean, numeric, and configuration values.
  * Preserved existing traffic policy, gateway translation, TLS configuration, and destination-weight behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->