### PR TITLE
Upgrade ngrok-api-go to v9 and filter reserved domains server-side

### DIFF
--- a/api/bindings/v1alpha1/boundendpoint_types.go
+++ b/api/bindings/v1alpha1/boundendpoint_types.go
@@ -25,7 +25,7 @@ SOFTWARE.
 package v1alpha1
 
 import (
-	v6 "github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -149,7 +149,7 @@ type TargetMetadata struct {
 // All endpoints in a BoundEndpoint share the same underlying Kubernetes services
 type BindingEndpoint struct {
 	// Ref is the ngrok API reference to the Endpoint object (id, uri)
-	v6.Ref `json:",inline"`
+	ngrok.Ref `json:",inline"`
 }
 
 // +kubebuilder:object:root=true

--- a/cmd/api-manager.go
+++ b/cmd/api-manager.go
@@ -52,8 +52,8 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/ngrok/ngrok-api-go/v7"
-	"github.com/ngrok/ngrok-api-go/v7/api_keys"
+	"github.com/ngrok/ngrok-api-go/v9"
+	"github.com/ngrok/ngrok-api-go/v9/api_keys"
 
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 	common "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
@@ -499,7 +499,7 @@ func loadNgrokClientset(ctx context.Context, opts apiManagerOpts) (ngrokapi.Clie
 	// by making a dummy request to list API keys
 	// and checking for errors
 	cApiKeys := api_keys.NewClient(ngrokClientConfig)
-	cIter := cApiKeys.List(&ngrok.Paging{Limit: new("1")})
+	cIter := cApiKeys.List(&ngrok.FilteredPaging{Limit: new("1")})
 	cIter.Next(ctx)
 	if cIter.Err() != nil {
 		return nil, fmt.Errorf("Unable to verify API Key: %w", cIter.Err())

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/gobwas/glob v0.2.3
 	github.com/google/uuid v1.6.0
-	github.com/ngrok/ngrok-api-go/v7 v7.8.0
+	github.com/ngrok/ngrok-api-go/v9 v9.0.0
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
 	github.com/segmentio/ksuid v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
-github.com/ngrok/ngrok-api-go/v7 v7.8.0 h1:Qw/mXpv4TyTku0EwjQtJQq3OUHutBH5X6xcGQcp1ddA=
-github.com/ngrok/ngrok-api-go/v7 v7.8.0/go.mod h1:Si/pYAJmbCuo4Fb3xz0MF6N5ubRvPdUixETBwhFvBf0=
+github.com/ngrok/ngrok-api-go/v9 v9.0.0 h1:dBTOl+PK8oUN/WAores6V/CTlyPEqD8yH70ToDSuAWg=
+github.com/ngrok/ngrok-api-go/v9 v9.0.0/go.mod h1:Y6SGu3WzfTRGJiHVSk2REXp3cmi0cEsAvJDsb30dBuU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=

--- a/helm/ngrok-crds/templates/bindings.k8s.ngrok.com_boundendpoints.yaml
+++ b/helm/ngrok-crds/templates/bindings.k8s.ngrok.com_boundendpoints.yaml
@@ -238,6 +238,9 @@ spec:
                     uri:
                       description: a uri for locating a resource
                       type: string
+                  required:
+                  - id
+                  - uri
                   type: object
                 type: array
               endpointsSummary:

--- a/internal/controller/base_controller.go
+++ b/internal/controller/base_controller.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"github.com/ngrok/ngrok-operator/internal/drain"
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
 	"github.com/ngrok/ngrok-operator/internal/util"

--- a/internal/controller/base_controller_test.go
+++ b/internal/controller/base_controller_test.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/drain"
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"

--- a/internal/controller/bindings/boundendpoint_integration_test.go
+++ b/internal/controller/bindings/boundendpoint_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/testutils"
 	. "github.com/onsi/ginkgo/v2"

--- a/internal/controller/bindings/boundendpoint_poller.go
+++ b/internal/controller/bindings/boundendpoint_poller.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/drain"

--- a/internal/controller/bindings/suite_test.go
+++ b/internal/controller/bindings/suite_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"

--- a/internal/controller/ingress/domain_conditions.go
+++ b/internal/controller/ingress/domain_conditions.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller/conditions"
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"

--- a/internal/controller/ingress/domain_conditions_test.go
+++ b/internal/controller/ingress/domain_conditions_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/ingress/domain_controller.go
+++ b/internal/controller/ingress/domain_controller.go
@@ -27,6 +27,7 @@ package ingress
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -231,7 +232,11 @@ func (r *DomainReconciler) delete(ctx context.Context, domain *v1alpha1.Domain) 
 
 // finds the reserved domain by the hostname. If it doesn't exist, returns nil
 func (r *DomainReconciler) findReservedDomainByHostname(ctx context.Context, domainName string) (*ngrok.ReservedDomain, error) {
-	iter := r.DomainsClient.List(&ngrok.FilteredPaging{})
+	// Filter server-side via ngrok's API filtering (https://ngrok.com/docs/api/api-filtering)
+	// instead of paging through every reserved domain on the account.
+	iter := r.DomainsClient.List(&ngrok.FilteredPaging{
+		Filter: new(fmt.Sprintf("obj.domain == %q", domainName)),
+	})
 	for iter.Next(ctx) {
 		domain := iter.Item()
 		if domain.Domain == domainName {

--- a/internal/controller/ingress/domain_controller.go
+++ b/internal/controller/ingress/domain_controller.go
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	commonv1alpha1 "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	"github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	basecontroller "github.com/ngrok/ngrok-operator/internal/controller"
@@ -231,7 +231,7 @@ func (r *DomainReconciler) delete(ctx context.Context, domain *v1alpha1.Domain) 
 
 // finds the reserved domain by the hostname. If it doesn't exist, returns nil
 func (r *DomainReconciler) findReservedDomainByHostname(ctx context.Context, domainName string) (*ngrok.ReservedDomain, error) {
-	iter := r.DomainsClient.List(&ngrok.Paging{})
+	iter := r.DomainsClient.List(&ngrok.FilteredPaging{})
 	for iter.Next(ctx) {
 		domain := iter.Item()
 		if domain.Domain == domainName {

--- a/internal/controller/ingress/domain_controller_test.go
+++ b/internal/controller/ingress/domain_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	commonv1alpha1 "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
@@ -647,7 +647,7 @@ var _ = Describe("DomainReconciler", func() {
 				})
 
 				It("The domain is still missing in ngrok", func() {
-					iter := domainClient.List(&ngrok.Paging{})
+					iter := domainClient.List(&ngrok.FilteredPaging{})
 					for iter.Next(ctx) {
 						d := iter.Item()
 						if d.Domain == domain.Spec.Domain {
@@ -821,7 +821,7 @@ var _ = Describe("DomainReconciler", func() {
 			}, timeout, interval).Should(Succeed())
 
 			// Verify the domain was never created in ngrok
-			iter := domainClient.List(&ngrok.Paging{})
+			iter := domainClient.List(&ngrok.FilteredPaging{})
 			for iter.Next(ctx) {
 				d := iter.Item()
 				Expect(d.Domain).ToNot(Equal("my-service.namespace.internal"),

--- a/internal/controller/ingress/ippolicy_controller.go
+++ b/internal/controller/ingress/ippolicy_controller.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	commonv1alpha1 "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
@@ -238,7 +238,7 @@ func (r *IPPolicyReconciler) createOrUpdateIPPolicyRules(ctx context.Context, po
 }
 
 func (r *IPPolicyReconciler) getRemotePolicyRules(ctx context.Context, policyID string) ([]*ngrok.IPPolicyRule, error) {
-	iter := r.IPPolicyRulesClient.List(&ngrok.Paging{})
+	iter := r.IPPolicyRulesClient.List(&ngrok.FilteredPaging{})
 	rules := make([]*ngrok.IPPolicyRule, 0)
 
 	for iter.Next(ctx) {

--- a/internal/controller/ingress/ippolicy_controllers_test.go
+++ b/internal/controller/ingress/ippolicy_controllers_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	ngrok "github.com/ngrok/ngrok-api-go/v7"
+	ngrok "github.com/ngrok/ngrok-api-go/v9"
 	commonv1alpha1 "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"

--- a/internal/controller/ngrok/cloudendpoint_controller.go
+++ b/internal/controller/ngrok/cloudendpoint_controller.go
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	commonv1alpha1 "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	ngrokv1 "github.com/ngrok/ngrok-operator/api/ngrok/v1"
@@ -51,6 +51,7 @@ import (
 	domainpkg "github.com/ngrok/ngrok-operator/internal/domain"
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
 	trafficpolicypkg "github.com/ngrok/ngrok-operator/internal/trafficpolicy"
+	"github.com/ngrok/ngrok-operator/internal/util"
 )
 
 // CloudEndpointReconciler reconciles a CloudEndpoint object
@@ -249,7 +250,7 @@ func (r *CloudEndpointReconciler) createWithPolicy(ctx context.Context, clep *ng
 		Description:    &clep.Spec.Description,
 		Metadata:       &metadata,
 		TrafficPolicy:  policy,
-		Bindings:       clep.Spec.Bindings,
+		Bindings:       util.NilIfEmpty(clep.Spec.Bindings),
 		PoolingEnabled: clep.Spec.PoolingEnabled,
 	}
 
@@ -310,7 +311,7 @@ func (r *CloudEndpointReconciler) update(ctx context.Context, clep *ngrokv1alpha
 		Description:    &clep.Spec.Description,
 		Metadata:       &metadata,
 		TrafficPolicy:  &policy,
-		Bindings:       clep.Spec.Bindings,
+		Bindings:       util.NilIfEmpty(clep.Spec.Bindings),
 		PoolingEnabled: clep.Spec.PoolingEnabled,
 	}
 

--- a/internal/controller/ngrok/cloudendpoint_controller_unit_test.go
+++ b/internal/controller/ngrok/cloudendpoint_controller_unit_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	commonv1alpha1 "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ngrokv1 "github.com/ngrok/ngrok-operator/api/ngrok/v1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"

--- a/internal/controller/ngrok/kubernetesoperator_controller.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller.go
@@ -49,12 +49,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	commonv1alpha1 "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
 	"github.com/ngrok/ngrok-operator/internal/drain"
 	"github.com/ngrok/ngrok-operator/internal/ngrokapi"
+	"github.com/ngrok/ngrok-operator/internal/util"
 )
 
 var featureMap = map[string]string{
@@ -215,7 +216,7 @@ func (r *KubernetesOperatorReconciler) create(ctx context.Context, ko *ngrokv1al
 		}
 
 		createParams.Binding = &ngrok.KubernetesOperatorBindingCreate{
-			EndpointSelectors: ko.Spec.Binding.EndpointSelectors,
+			EndpointSelectors: util.NilIfEmpty(ko.Spec.Binding.EndpointSelectors),
 			CSR:               string(tlsSecret.Data["tls.csr"]),
 		}
 	}
@@ -401,7 +402,7 @@ func (r *KubernetesOperatorReconciler) _update(ctx context.Context, ko *ngrokv1a
 		}
 
 		updateParams.Binding = &ngrok.KubernetesOperatorBindingUpdate{
-			EndpointSelectors: ko.Spec.Binding.EndpointSelectors,
+			EndpointSelectors: util.NilIfEmpty(ko.Spec.Binding.EndpointSelectors),
 			CSR:               new(string(tlsSecret.Data["tls.csr"])),
 		}
 	}
@@ -477,7 +478,7 @@ func (r *KubernetesOperatorReconciler) findExisting(ctx context.Context, ko *ngr
 }
 
 func calculateFeaturesEnabled(ko *ngrokv1alpha1.KubernetesOperator) []string {
-	features := []string{}
+	var features []string
 
 	for _, f := range ko.Spec.EnabledFeatures {
 		if v, ok := featureMap[f]; ok {

--- a/internal/controller/ngrok/kubernetesoperator_controller_test.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	commonv1alpha1 "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/mocks/nmockapi"

--- a/internal/controller/ngrok/kubernetesoperator_controller_unit_test.go
+++ b/internal/controller/ngrok/kubernetesoperator_controller_unit_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
 	"github.com/ngrok/ngrok-operator/internal/controller"
 	"github.com/ngrok/ngrok-operator/internal/mocks/nmockapi"
@@ -35,7 +35,7 @@ func TestCalculateFeaturesEnabled(t *testing.T) {
 			in: &ngrokv1alpha1.KubernetesOperator{
 				Spec: ngrokv1alpha1.KubernetesOperatorSpec{},
 			},
-			expected: []string{},
+			expected: nil,
 		},
 		{
 			name: "all features enabled",

--- a/internal/controller/service/controller.go
+++ b/internal/controller/service/controller.go
@@ -34,7 +34,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	common "github.com/ngrok/ngrok-operator/api/common/v1alpha1"
 	ingressv1alpha1 "github.com/ngrok/ngrok-operator/api/ingress/v1alpha1"
 	ngrokv1 "github.com/ngrok/ngrok-operator/api/ngrok/v1"
@@ -405,7 +405,7 @@ func (r *ServiceReconciler) setComputedURLAnnotation(ctx context.Context, svc *c
 }
 
 func (r *ServiceReconciler) tcpAddressIsReserved(ctx context.Context, hostport string) (bool, error) {
-	iter := r.TCPAddresses.List(&ngrok.Paging{})
+	iter := r.TCPAddresses.List(&ngrok.FilteredPaging{})
 	for iter.Next(ctx) {
 		addr := iter.Item()
 		if addr.Addr == hostport {

--- a/internal/mocks/nmockapi/base_client.go
+++ b/internal/mocks/nmockapi/base_client.go
@@ -8,11 +8,14 @@ import (
 	"slices"
 	"time"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"github.com/segmentio/ksuid"
 )
 
-type baseClient[T any] struct {
+// baseClient is shared by the mock resource clients. P is the paging type
+// used by that resource's real List method (ngrok.Paging or
+// ngrok.FilteredPaging), which varies by resource in ngrok-api-go v9.
+type baseClient[T any, P any] struct {
 	idPrefix string
 	items    map[string]T
 
@@ -26,14 +29,14 @@ type baseClient[T any] struct {
 	updateCallCount int
 }
 
-func newBase[T any](idPrefix string) baseClient[T] {
-	return baseClient[T]{
+func newBase[T any, P any](idPrefix string) baseClient[T, P] {
+	return baseClient[T, P]{
 		items:    make(map[string]T),
 		idPrefix: idPrefix,
 	}
 }
 
-func (m *baseClient[T]) Get(_ context.Context, id string) (T, error) {
+func (m *baseClient[T, P]) Get(_ context.Context, id string) (T, error) {
 	if m.getError != nil {
 		return *new(T), m.getError
 	}
@@ -44,12 +47,12 @@ func (m *baseClient[T]) Get(_ context.Context, id string) (T, error) {
 	return item, nil
 }
 
-func (m *baseClient[T]) List(_ *ngrok.Paging) ngrok.Iter[T] {
+func (m *baseClient[T, P]) List(_ *P) ngrok.Iter[T] {
 	items := slices.Collect(maps.Values(m.items))
 	return NewIter(items, m.listError)
 }
 
-func (m *baseClient[T]) Delete(ctx context.Context, id string) error {
+func (m *baseClient[T, P]) Delete(ctx context.Context, id string) error {
 	_, err := m.Get(ctx, id)
 	if err != nil {
 		return err
@@ -60,22 +63,22 @@ func (m *baseClient[T]) Delete(ctx context.Context, id string) error {
 
 // Reset clears the items in the client.
 // This is useful for resetting the state of the client between tests, without allocating a new client.
-func (m *baseClient[T]) Reset() {
+func (m *baseClient[T, P]) Reset() {
 	m.items = make(map[string]T)
 	m.updateCallCount = 0
 }
 
-func (m *baseClient[T]) newID() string {
+func (m *baseClient[T, P]) newID() string {
 	return fmt.Sprintf("%s_%s", m.idPrefix, ksuid.New().String())
 }
 
-func (m *baseClient[T]) notFoundErr() error {
+func (m *baseClient[T, P]) notFoundErr() error {
 	return &ngrok.Error{
 		StatusCode: http.StatusNotFound,
 	}
 }
 
-func (m *baseClient[T]) any(predicate func(T) bool) bool {
+func (m *baseClient[T, P]) any(predicate func(T) bool) bool {
 	for _, item := range m.items {
 		if predicate(item) {
 			return true
@@ -84,32 +87,32 @@ func (m *baseClient[T]) any(predicate func(T) bool) bool {
 	return false
 }
 
-func (m *baseClient[T]) createdAt() string {
+func (m *baseClient[T, P]) createdAt() string {
 	return time.Now().Format(time.RFC3339)
 }
 
 // SetCreateError configures the client to return an error on Create calls
-func (m *baseClient[T]) SetCreateError(err error) {
+func (m *baseClient[T, P]) SetCreateError(err error) {
 	m.createError = err
 }
 
 // SetGetError configures the client to return an error on Get calls
-func (m *baseClient[T]) SetGetError(err error) {
+func (m *baseClient[T, P]) SetGetError(err error) {
 	m.getError = err
 }
 
 // SetUpdateError configures the client to return an error on Update calls
-func (m *baseClient[T]) SetUpdateError(err error) {
+func (m *baseClient[T, P]) SetUpdateError(err error) {
 	m.updateError = err
 }
 
 // SetListError configures the client to return an error on List calls
-func (m *baseClient[T]) SetListError(err error) {
+func (m *baseClient[T, P]) SetListError(err error) {
 	m.listError = err
 }
 
 // ClearErrors clears all configured errors
-func (m *baseClient[T]) ClearErrors() {
+func (m *baseClient[T, P]) ClearErrors() {
 	m.createError = nil
 	m.getError = nil
 	m.updateError = nil
@@ -117,11 +120,11 @@ func (m *baseClient[T]) ClearErrors() {
 }
 
 // UpdateCallCount returns the number of times Update has been called
-func (m *baseClient[T]) UpdateCallCount() int {
+func (m *baseClient[T, P]) UpdateCallCount() int {
 	return m.updateCallCount
 }
 
 // ResetUpdateCallCount resets the update call counter to zero
-func (m *baseClient[T]) ResetUpdateCallCount() {
+func (m *baseClient[T, P]) ResetUpdateCallCount() {
 	m.updateCallCount = 0
 }

--- a/internal/mocks/nmockapi/domain_client.go
+++ b/internal/mocks/nmockapi/domain_client.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
@@ -16,12 +16,12 @@ import (
 // implementation. It is used for testing purposes only and should not be used in production
 // environments.
 type DomainClient struct {
-	baseClient[*ngrok.ReservedDomain]
+	baseClient[*ngrok.ReservedDomain, ngrok.FilteredPaging]
 }
 
 func NewDomainClient() *DomainClient {
 	return &DomainClient{
-		baseClient: newBase[*ngrok.ReservedDomain](
+		baseClient: newBase[*ngrok.ReservedDomain, ngrok.FilteredPaging](
 			"rd",
 		),
 	}

--- a/internal/mocks/nmockapi/domain_client_test.go
+++ b/internal/mocks/nmockapi/domain_client_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"github.com/ngrok/ngrok-operator/internal/mocks/nmockapi"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/internal/mocks/nmockapi/endpoints_client.go
+++ b/internal/mocks/nmockapi/endpoints_client.go
@@ -5,18 +5,18 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"k8s.io/utils/ptr"
 )
 
 // EndpointsClient is a mock implementation of the ngrok API client for managing endpoints.
 type EndpointsClient struct {
-	baseClient[*ngrok.Endpoint]
+	baseClient[*ngrok.Endpoint, ngrok.Paging]
 }
 
 func NewEndpointsClient() *EndpointsClient {
 	return &EndpointsClient{
-		baseClient: newBase[*ngrok.Endpoint]("ep"),
+		baseClient: newBase[*ngrok.Endpoint, ngrok.Paging]("ep"),
 	}
 }
 

--- a/internal/mocks/nmockapi/endpoints_client_test.go
+++ b/internal/mocks/nmockapi/endpoints_client_test.go
@@ -3,7 +3,7 @@ package nmockapi_test
 import (
 	context "context"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"github.com/ngrok/ngrok-operator/internal/mocks/nmockapi"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/internal/mocks/nmockapi/ippolicies_client.go
+++ b/internal/mocks/nmockapi/ippolicies_client.go
@@ -5,16 +5,16 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 )
 
 type IPPolicyClient struct {
-	baseClient[*ngrok.IPPolicy]
+	baseClient[*ngrok.IPPolicy, ngrok.FilteredPaging]
 }
 
 func NewIPPolicyClient() *IPPolicyClient {
 	return &IPPolicyClient{
-		baseClient: newBase[*ngrok.IPPolicy](
+		baseClient: newBase[*ngrok.IPPolicy, ngrok.FilteredPaging](
 			"ipp",
 		),
 	}

--- a/internal/mocks/nmockapi/ippolicies_client_test.go
+++ b/internal/mocks/nmockapi/ippolicies_client_test.go
@@ -2,7 +2,7 @@ package nmockapi_test
 
 import (
 	context "context"
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"github.com/ngrok/ngrok-operator/internal/mocks/nmockapi"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/internal/mocks/nmockapi/ippolicies_rules_client.go
+++ b/internal/mocks/nmockapi/ippolicies_rules_client.go
@@ -6,18 +6,18 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 )
 
 type IPPolicyRuleClient struct {
-	baseClient[*ngrok.IPPolicyRule]
+	baseClient[*ngrok.IPPolicyRule, ngrok.FilteredPaging]
 	ippClient *IPPolicyClient
 }
 
 // NewIPPolicyRuleClient constructs a mock IP policy rule client used by tests.
 func NewIPPolicyRuleClient(ippClient *IPPolicyClient) *IPPolicyRuleClient {
 	return &IPPolicyRuleClient{
-		baseClient: newBase[*ngrok.IPPolicyRule](
+		baseClient: newBase[*ngrok.IPPolicyRule, ngrok.FilteredPaging](
 			"ippr",
 		),
 		ippClient: ippClient,

--- a/internal/mocks/nmockapi/ippolicies_rules_client_test.go
+++ b/internal/mocks/nmockapi/ippolicies_rules_client_test.go
@@ -3,7 +3,7 @@ package nmockapi_test
 import (
 	"context"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"github.com/ngrok/ngrok-operator/internal/mocks/nmockapi"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/internal/mocks/nmockapi/iter_test.go
+++ b/internal/mocks/nmockapi/iter_test.go
@@ -4,7 +4,7 @@ import (
 	context "context"
 	"errors"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"github.com/ngrok/ngrok-operator/internal/mocks/nmockapi"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/internal/mocks/nmockapi/kubernetes_operators_client.go
+++ b/internal/mocks/nmockapi/kubernetes_operators_client.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 )
 
 // KubernetesOperatorsClient is a mock implementation of the ngrok API client for managing kubernetes operators.
 type KubernetesOperatorsClient struct {
-	baseClient[*ngrok.KubernetesOperator]
+	baseClient[*ngrok.KubernetesOperator, ngrok.Paging]
 
 	// mu protects boundEndpoints
 	mu sync.RWMutex
@@ -20,7 +20,7 @@ type KubernetesOperatorsClient struct {
 
 func NewKubernetesOperatorsClient() *KubernetesOperatorsClient {
 	return &KubernetesOperatorsClient{
-		baseClient:     newBase[*ngrok.KubernetesOperator]("ko"),
+		baseClient:     newBase[*ngrok.KubernetesOperator, ngrok.Paging]("ko"),
 		boundEndpoints: []ngrok.Endpoint{},
 	}
 }

--- a/internal/mocks/nmockapi/tcp_addresses_client.go
+++ b/internal/mocks/nmockapi/tcp_addresses_client.go
@@ -6,16 +6,16 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 )
 
 type TCPAddressesClient struct {
-	baseClient[*ngrok.ReservedAddr]
+	baseClient[*ngrok.ReservedAddr, ngrok.FilteredPaging]
 }
 
 func NewTCPAddressClient() *TCPAddressesClient {
 	return &TCPAddressesClient{
-		baseClient: newBase[*ngrok.ReservedAddr](
+		baseClient: newBase[*ngrok.ReservedAddr, ngrok.FilteredPaging](
 			"ra",
 		),
 	}

--- a/internal/mocks/nmockapi/tcp_addresses_client_test.go
+++ b/internal/mocks/nmockapi/tcp_addresses_client_test.go
@@ -3,7 +3,7 @@ package nmockapi
 import (
 	context "context"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/internal/ngrokapi/bindingendpoint_aggregator.go
+++ b/internal/ngrokapi/bindingendpoint_aggregator.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )

--- a/internal/ngrokapi/bindingendpoint_aggregator_test.go
+++ b/internal/ngrokapi/bindingendpoint_aggregator_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 )
 

--- a/internal/ngrokapi/clientset.go
+++ b/internal/ngrokapi/clientset.go
@@ -3,13 +3,13 @@ package ngrokapi
 import (
 	"context"
 
-	"github.com/ngrok/ngrok-api-go/v7"
-	"github.com/ngrok/ngrok-api-go/v7/endpoints"
-	"github.com/ngrok/ngrok-api-go/v7/ip_policies"
-	"github.com/ngrok/ngrok-api-go/v7/ip_policy_rules"
-	"github.com/ngrok/ngrok-api-go/v7/kubernetes_operators"
-	"github.com/ngrok/ngrok-api-go/v7/reserved_addrs"
-	"github.com/ngrok/ngrok-api-go/v7/reserved_domains"
+	"github.com/ngrok/ngrok-api-go/v9"
+	"github.com/ngrok/ngrok-api-go/v9/endpoints"
+	"github.com/ngrok/ngrok-api-go/v9/ip_policies"
+	"github.com/ngrok/ngrok-api-go/v9/ip_policy_rules"
+	"github.com/ngrok/ngrok-api-go/v9/kubernetes_operators"
+	"github.com/ngrok/ngrok-api-go/v9/reserved_addrs"
+	"github.com/ngrok/ngrok-api-go/v9/reserved_domains"
 )
 
 type Clientset interface {
@@ -62,12 +62,18 @@ type Lister[T any] interface {
 	List(*ngrok.Paging) ngrok.Iter[T]
 }
 
+// FilteredLister is for resources whose List method supports CEL filtering
+// via ngrok.FilteredPaging (see https://ngrok.com/docs/api/api-filtering).
+type FilteredLister[T any] interface {
+	List(*ngrok.FilteredPaging) ngrok.Iter[T]
+}
+
 type DomainClient interface {
 	Creator[*ngrok.ReservedDomainCreate, *ngrok.ReservedDomain]
 	Reader[*ngrok.ReservedDomain]
 	Updater[*ngrok.ReservedDomainUpdate, *ngrok.ReservedDomain]
 	Deletor
-	Lister[*ngrok.ReservedDomain]
+	FilteredLister[*ngrok.ReservedDomain]
 }
 
 func (c *DefaultClientset) Domains() DomainClient {
@@ -101,7 +107,7 @@ type IPPolicyRulesClient interface {
 	Creator[*ngrok.IPPolicyRuleCreate, *ngrok.IPPolicyRule]
 	Deletor
 	Updater[*ngrok.IPPolicyRuleUpdate, *ngrok.IPPolicyRule]
-	Lister[*ngrok.IPPolicyRule]
+	FilteredLister[*ngrok.IPPolicyRule]
 }
 
 func (c *DefaultClientset) IPPolicyRules() IPPolicyRulesClient {
@@ -124,7 +130,7 @@ func (c *DefaultClientset) KubernetesOperators() KubernetesOperatorsClient {
 type TCPAddressesClient interface {
 	Creator[*ngrok.ReservedAddrCreate, *ngrok.ReservedAddr]
 	Updater[*ngrok.ReservedAddrUpdate, *ngrok.ReservedAddr]
-	Lister[*ngrok.ReservedAddr]
+	FilteredLister[*ngrok.ReservedAddr]
 }
 
 func (c *DefaultClientset) TCPAddresses() TCPAddressesClient {

--- a/internal/ngrokapi/clientset_test.go
+++ b/internal/ngrokapi/clientset_test.go
@@ -3,7 +3,7 @@ package ngrokapi
 import (
 	"testing"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/ngrokapi/enriched_errors.go
+++ b/internal/ngrokapi/enriched_errors.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ngrok/ngrok-api-go/v7"
+	"github.com/ngrok/ngrok-api-go/v9"
 )
 
 // whitespaceRegex is compiled once to avoid repeated compilation

--- a/internal/util/slices.go
+++ b/internal/util/slices.go
@@ -1,0 +1,14 @@
+package util
+
+// NilIfEmpty returns nil when s has no elements, and s otherwise.
+//
+// This distinction matters for ngrok API request structs whose JSON tags use
+// omitzero: a nil slice is omitted from the request body, while a non-nil
+// empty slice is serialized as `[]`, which explicitly clears the field
+// server-side instead of leaving it untouched.
+func NilIfEmpty[T any](s []T) []T {
+	if len(s) == 0 {
+		return nil
+	}
+	return s
+}

--- a/manifest-bundle.yaml
+++ b/manifest-bundle.yaml
@@ -290,6 +290,9 @@ spec:
                     uri:
                       description: a uri for locating a resource
                       type: string
+                  required:
+                  - id
+                  - uri
                   type: object
                 type: array
               endpointsSummary:


### PR DESCRIPTION
## What
Upgrades `ngrok-api-go` from v7 to v9, and uses ngrok's [API filtering](https://ngrok.com/docs/api/api-filtering) to look up reserved domains by hostname.

## How
- Bump the dependency to v9. `List()` on resources that support CEL filtering now takes `*ngrok.FilteredPaging`, so `ngrokapi.Lister` is split into `Lister` and `FilteredLister`, and the shared mock base client is generic over the paging type.
- v9 switches JSON tags from `omitempty` to `omitzero`, so a non-nil empty slice is serialized instead of dropped. Guard the few call sites that could send one on a KubernetesOperator or CloudEndpoint create/update, so behavior is unchanged.
- Regenerate the BoundEndpoint CRD. `ngrok.Ref` is inlined into `status.endpoints[]`, and since its fields now use `omitzero`, controller-gen marks `id` and `uri` as required. The operator always populates both from the ngrok API, so what it writes is unchanged.
- `findReservedDomainByHostname` now filters on an exact hostname match server-side, instead of paging through every reserved domain on the account and filtering client-side.

## Breaking Changes
None for users. The only schema change is the required `id`/`uri` noted above, on operator-owned status fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated the ngrok API integration to the latest version for improved compatibility.
  * Added efficient server-side filtering for domain, IP policy, and TCP address lookups.
  * Improved request handling by omitting empty binding and selector values when appropriate.

* **Bug Fixes**
  * Corrected empty-result handling for API requests.
  * Updated the BoundEndpoint status schema to require endpoint IDs and URIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->